### PR TITLE
Add support for polymorphic serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 * Primitive msgpack reader and writer APIs for low-level scenarios.
 * Author custom converters for advanced scenarios.
 * Security mitigations for stack overflows.
-* Optionally serialize your custom types as arrays of bvalues instead of maps of names and value for more compact representation and even higher performance.
+* Optionally serialize your custom types as arrays of values instead of maps of names and value for more compact representation and even higher performance.
+* Support for serializing instances of certain types derived from the declared type and deserializing them back to their original runtime types using [unions](doc/unions.md).
 
 ## Usage
 

--- a/doc/unions.md
+++ b/doc/unions.md
@@ -1,0 +1,93 @@
+# Unions
+
+## Polymorphic serialization
+
+You can serialize instances of certain types derived from the declared type and deserialize them back to their original runtime types using the `KnownSubTypeAttribute`.
+
+For instance, suppose you have this type to serialize:
+
+```cs
+public class Farm
+{
+    public List<Animal> Animals { get; set; }
+}
+```
+
+But there are many kinds of animals.
+You can get them to serialize and deserialize correctly like this:
+
+```cs
+[KnownSubType(1, typeof(Cow))]
+[KnownSubType(2, typeof(Horse))]
+[KnownSubType(3, typeof(Dog))]
+public class Animal
+{
+    public string Name { get; set; }
+}
+
+public class Cow : Animal { }
+public class Horse : Animal { }
+public class Dog : Animal { }
+```
+
+This changes the schema of the serialized data to include a tag that indicates the type of the object.
+
+*Without* any `KnownSubTypeAttribute`, an `Animal` object would serialize like this (as represented in JSON):
+
+```json
+{ "Name": "Bessie" }
+```
+
+But with the `KnownSubTypeAttribute`, it serializes like this:
+```json
+[null, { "Name": "Bessie" }]
+```
+
+See how the natural form of `Animal` is still there, but nested as the second element in a 2-element array.
+The `null` first element indicates that the object was literally `Animal` (rather than a derived type).
+If the serialized object were an instance of `Cow`, the first element would be `1` instead of `null`:
+
+```json
+[1, { "Name": "Bessie" }]
+```
+
+This special union schema is only used when the statically *declared* type is a class that has `KnownSubTypeAttribute` on it.
+It is *not* used when the derived type is statically known. For example, consider this collection of horses:
+
+```cs
+public class HorsePen
+{
+    public List<Horse> Horses { get; set; }
+}
+```
+
+This would serialize like this:
+
+```json
+{ "Horses": [{ "Name": "Bessie" }] }
+```
+
+Note the lack of the union schema that would add `[2, ... ]` around every horse.
+This is because the `Horse` type is statically known as the generic type argument of the collection, and there's no need to add serialized data to indicate the runtime type.
+
+Now suppose you have different breeds of horses that each had their own subtype:
+
+```cs
+[KnownSubType(1, typeof(QuarterHorse))]
+[KnownSubType(2, typeof(Thoroughbred))]
+public class Horse : Animal { }
+
+public class QuarterHorse : Horse { }
+public class Thoroughbred : Horse { }
+```
+
+At this point your `HorsePen` *would* serialize with the union schema around each horse:
+```json
+{ "Horses": [[1, { "Name": "Bessie" }], [2, { "Name", "Lightfoot" }]] }
+```
+
+But now let's consider your `Farm` class, which has a collection of `Animal` objects.
+The `Animal` class only knows about `Horse` as a subtype and designates `2` as the alias for that subtype.
+`Animal` has no designation for `QuarterHorse` or `Thoroughbred`.
+As such, serializing your `Farm` would drop any details about horse breeds and deserializing would produce `Horse` objects, not `QuarterHorse` or `Thoroughbred`.
+To fix this, you would need to add `KnownSubTypeAttribute` to the `Animal` class for `QuarterHorse` and `Thoroughbred` that assigns type aliases for each of them.

--- a/src/Nerdbank.MessagePack/Converters/ArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayConverter`1.cs
@@ -7,10 +7,10 @@ namespace Nerdbank.MessagePack.Converters;
 /// Serializes and deserializes a 1-rank array.
 /// </summary>
 /// <typeparam name="TElement">The element type.</typeparam>
-internal class ArrayConverter<TElement>(IMessagePackConverter<TElement> elementConverter) : IMessagePackConverter<TElement[]>
+internal class ArrayConverter<TElement>(MessagePackConverter<TElement> elementConverter) : MessagePackConverter<TElement[]>
 {
 	/// <inheritdoc/>
-	public TElement[]? Deserialize(ref MessagePackReader reader, SerializationContext context)
+	public override TElement[]? Deserialize(ref MessagePackReader reader, SerializationContext context)
 	{
 		if (reader.TryReadNil())
 		{
@@ -29,7 +29,7 @@ internal class ArrayConverter<TElement>(IMessagePackConverter<TElement> elementC
 	}
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref TElement[]? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, ref TElement[]? value, SerializationContext context)
 	{
 		if (value is null)
 		{

--- a/src/Nerdbank.MessagePack/Converters/ArrayWithFlattenedDimensionsConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayWithFlattenedDimensionsConverter`2.cs
@@ -17,14 +17,14 @@ namespace Nerdbank.MessagePack.Converters;
 /// The format for this is:
 /// <c>[[dimension0, dimension1, ...], [element0, element1, ...]]</c>.
 /// </remarks>
-internal class ArrayWithFlattenedDimensionsConverter<TArray, TElement>(IMessagePackConverter<TElement> elementConverter) : IMessagePackConverter<TArray>
+internal class ArrayWithFlattenedDimensionsConverter<TArray, TElement>(MessagePackConverter<TElement> elementConverter) : MessagePackConverter<TArray>
 {
 	[ThreadStatic]
 	private static int[]? dimensionsReusable;
 
 	/// <inheritdoc/>
 	[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The Array.CreateInstance method generates TArray instances.")]
-	public TArray? Deserialize(ref MessagePackReader reader, SerializationContext context)
+	public override TArray? Deserialize(ref MessagePackReader reader, SerializationContext context)
 	{
 		if (reader.TryReadNil())
 		{
@@ -62,7 +62,7 @@ internal class ArrayWithFlattenedDimensionsConverter<TArray, TElement>(IMessageP
 	}
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref TArray? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, ref TArray? value, SerializationContext context)
 	{
 		if (value is null)
 		{

--- a/src/Nerdbank.MessagePack/Converters/ArrayWithNestedDimensionsConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayWithNestedDimensionsConverter`2.cs
@@ -19,14 +19,14 @@ namespace Nerdbank.MessagePack.Converters;
 /// This may change if <see href="https://github.com/msgpack/msgpack/pull/267">this pull request</see> is ever merged
 /// into the msgpack spec.
 /// </remarks>
-internal class ArrayWithNestedDimensionsConverter<TArray, TElement>(IMessagePackConverter<TElement> elementConverter, int rank) : IMessagePackConverter<TArray>
+internal class ArrayWithNestedDimensionsConverter<TArray, TElement>(MessagePackConverter<TElement> elementConverter, int rank) : MessagePackConverter<TArray>
 {
 	[ThreadStatic]
 	private static int[]? dimensionsReusable;
 
 	/// <inheritdoc/>
 	[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The Array.CreateInstance method generates TArray instances.")]
-	public TArray? Deserialize(ref MessagePackReader reader, SerializationContext context)
+	public override TArray? Deserialize(ref MessagePackReader reader, SerializationContext context)
 	{
 		if (reader.TryReadNil())
 		{
@@ -43,7 +43,7 @@ internal class ArrayWithNestedDimensionsConverter<TArray, TElement>(IMessagePack
 	}
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref TArray? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, ref TArray? value, SerializationContext context)
 	{
 		Array? array = (Array?)(object?)value;
 		if (array is null)
@@ -77,7 +77,7 @@ internal class ArrayWithNestedDimensionsConverter<TArray, TElement>(IMessagePack
 	/// <param name="writer">The msgpack writer.</param>
 	/// <param name="dimensions">The remaining dimensions to be written.</param>
 	/// <param name="elements">A flat list of elements to write.</param>
-	/// <param name="context"><inheritdoc cref="IMessagePackConverter{T}.Serialize" path="/param[@name='context']"/></param>
+	/// <param name="context"><inheritdoc cref="MessagePackConverter{T}.Serialize" path="/param[@name='context']"/></param>
 	private void WriteSubArray(ref MessagePackWriter writer, Span<int> dimensions, Span<TElement> elements, SerializationContext context)
 	{
 		context.DepthStep();
@@ -107,7 +107,7 @@ internal class ArrayWithNestedDimensionsConverter<TArray, TElement>(IMessagePack
 	/// <param name="reader">The msgpack reader.</param>
 	/// <param name="dimensions">The remaining dimensions to be read.</param>
 	/// <param name="elements">A flat list of elements to populate.</param>
-	/// <param name="context"><inheritdoc cref="IMessagePackConverter{T}.Deserialize" path="/param[@name='context']"/></param>
+	/// <param name="context"><inheritdoc cref="MessagePackConverter{T}.Deserialize" path="/param[@name='context']"/></param>
 	private void ReadSubArray(ref MessagePackReader reader, Span<int> dimensions, Span<TElement> elements, SerializationContext context)
 	{
 		context.DepthStep();

--- a/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
+++ b/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
@@ -4,6 +4,8 @@
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
 
+using System.Collections.Frozen;
+
 namespace Nerdbank.MessagePack.Converters;
 
 /// <summary>
@@ -12,7 +14,7 @@ namespace Nerdbank.MessagePack.Converters;
 /// <typeparam name="TDeclaringType">The data type whose property is to be read.</typeparam>
 /// <param name="container">The instance of the data type to be serialized.</param>
 /// <param name="writer">The means by which msgpack should be written.</param>
-/// <param name="context"><inheritdoc cref="IMessagePackConverter{T}.Serialize" path="/param[@name='context']"/></param>
+/// <param name="context"><inheritdoc cref="MessagePackConverter{T}.Serialize" path="/param[@name='context']"/></param>
 internal delegate void SerializeProperty<TDeclaringType>(ref TDeclaringType container, ref MessagePackWriter writer, SerializationContext context);
 
 /// <summary>
@@ -21,7 +23,7 @@ internal delegate void SerializeProperty<TDeclaringType>(ref TDeclaringType cont
 /// <typeparam name="TDeclaringType">The data type whose property is to be initialized.</typeparam>
 /// <param name="container">The instance of the data type to be serialized.</param>
 /// <param name="reader">The means by which msgpack should be read.</param>
-/// <param name="context"><inheritdoc cref="IMessagePackConverter{T}.Deserialize" path="/param[@name='context']"/></param>
+/// <param name="context"><inheritdoc cref="MessagePackConverter{T}.Deserialize" path="/param[@name='context']"/></param>
 internal delegate void DeserializeProperty<TDeclaringType>(ref TDeclaringType container, ref MessagePackReader reader, SerializationContext context);
 
 /// <summary>
@@ -68,4 +70,21 @@ internal record ArrayConstructorVisitorInputs<TDeclaringType>(List<(string Name,
 	/// </summary>
 	/// <returns>An array of accessors.</returns>
 	internal PropertyAccessors<TDeclaringType>?[] GetJustAccessors() => this.Properties.Select(p => p?.Accessors).ToArray();
+}
+
+/// <summary>
+/// Describes the derived types of some class that are allowed to appear as the runtime type in an object graph
+/// for serialization, or may be referenced by an alias in the serialized data for deserialization.
+/// </summary>
+internal record SubTypes
+{
+	/// <summary>
+	/// Gets the converters to use to deserialize a subtype, keyed by their alias.
+	/// </summary>
+	internal required FrozenDictionary<int, IMessagePackConverter> Deserializers { get; init; }
+
+	/// <summary>
+	/// Gets the converter and alias to use for a subtype, keyed by their <see cref="Type"/>.
+	/// </summary>
+	internal required FrozenDictionary<Type, (int Alias, IMessagePackConverter Converter)> Serializers { get; init; }
 }

--- a/src/Nerdbank.MessagePack/Converters/DelayedConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/DelayedConverter`1.cs
@@ -8,11 +8,11 @@ namespace Nerdbank.MessagePack.Converters;
 /// </summary>
 /// <typeparam name="T">The convertible data type.</typeparam>
 /// <param name="box">A box containing the not-yet-done converter.</param>
-internal class DelayedConverter<T>(ResultBox<IMessagePackConverter<T>> box) : IMessagePackConverter<T>
+internal class DelayedConverter<T>(ResultBox<MessagePackConverter<T>> box) : MessagePackConverter<T>
 {
 	/// <inheritdoc/>
-	public T? Deserialize(ref MessagePackReader reader, SerializationContext context) => box.Result.Deserialize(ref reader, context);
+	public override T? Deserialize(ref MessagePackReader reader, SerializationContext context) => box.Result.Deserialize(ref reader, context);
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context) => box.Result.Serialize(ref writer, ref value, context);
+	public override void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context) => box.Result.Serialize(ref writer, ref value, context);
 }

--- a/src/Nerdbank.MessagePack/Converters/DictionaryConverter`3.cs
+++ b/src/Nerdbank.MessagePack/Converters/DictionaryConverter`3.cs
@@ -15,10 +15,10 @@ namespace Nerdbank.MessagePack.Converters;
 /// <param name="getReadable">A delegate which converts the opaque dictionary type to a readable form.</param>
 /// <param name="keyConverter">A converter for keys.</param>
 /// <param name="valueConverter">A converter for values.</param>
-internal class DictionaryConverter<TDictionary, TKey, TValue>(Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getReadable, IMessagePackConverter<TKey> keyConverter, IMessagePackConverter<TValue> valueConverter) : IMessagePackConverter<TDictionary>
+internal class DictionaryConverter<TDictionary, TKey, TValue>(Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getReadable, MessagePackConverter<TKey> keyConverter, MessagePackConverter<TValue> valueConverter) : MessagePackConverter<TDictionary>
 {
 	/// <inheritdoc/>
-	public virtual TDictionary? Deserialize(ref MessagePackReader reader, SerializationContext context)
+	public override TDictionary? Deserialize(ref MessagePackReader reader, SerializationContext context)
 	{
 		if (reader.TryReadNil())
 		{
@@ -29,7 +29,7 @@ internal class DictionaryConverter<TDictionary, TKey, TValue>(Func<TDictionary, 
 	}
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref TDictionary? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, ref TDictionary? value, SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -54,7 +54,7 @@ internal class DictionaryConverter<TDictionary, TKey, TValue>(Func<TDictionary, 
 	/// Reads a key and value pair.
 	/// </summary>
 	/// <param name="reader">The reader.</param>
-	/// <param name="context"><inheritdoc cref="IMessagePackConverter{T}.Deserialize" path="/param[@name='context']"/></param>
+	/// <param name="context"><inheritdoc cref="MessagePackConverter{T}.Deserialize" path="/param[@name='context']"/></param>
 	/// <param name="key">Receives the key.</param>
 	/// <param name="value">Receives the value.</param>
 	protected void ReadEntry(ref MessagePackReader reader, SerializationContext context, out TKey? key, out TValue? value)
@@ -75,8 +75,8 @@ internal class DictionaryConverter<TDictionary, TKey, TValue>(Func<TDictionary, 
 /// <param name="ctor">The default constructor for the dictionary type.</param>
 internal class MutableDictionaryConverter<TDictionary, TKey, TValue>(
 	Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getReadable,
-	IMessagePackConverter<TKey> keyConverter,
-	IMessagePackConverter<TValue> valueConverter,
+	MessagePackConverter<TKey> keyConverter,
+	MessagePackConverter<TValue> valueConverter,
 	Setter<TDictionary, KeyValuePair<TKey, TValue>> addEntry,
 	Func<TDictionary> ctor) : DictionaryConverter<TDictionary, TKey, TValue>(getReadable, keyConverter, valueConverter)
 {
@@ -111,8 +111,8 @@ internal class MutableDictionaryConverter<TDictionary, TKey, TValue>(
 /// <param name="ctor">A dictionary initializer that constructs from a span of entries.</param>
 internal class ImmutableDictionaryConverter<TDictionary, TKey, TValue>(
 	Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getReadable,
-	IMessagePackConverter<TKey> keyConverter,
-	IMessagePackConverter<TValue> valueConverter,
+	MessagePackConverter<TKey> keyConverter,
+	MessagePackConverter<TValue> valueConverter,
 	SpanConstructor<KeyValuePair<TKey, TValue>, TDictionary> ctor) : DictionaryConverter<TDictionary, TKey, TValue>(getReadable, keyConverter, valueConverter)
 {
 	/// <inheritdoc/>
@@ -153,8 +153,8 @@ internal class ImmutableDictionaryConverter<TDictionary, TKey, TValue>(
 /// <param name="ctor">A dictionary initializer that constructs from an enumerable of entries.</param>
 internal class EnumerableDictionaryConverter<TDictionary, TKey, TValue>(
 	Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getReadable,
-	IMessagePackConverter<TKey> keyConverter,
-	IMessagePackConverter<TValue> valueConverter,
+	MessagePackConverter<TKey> keyConverter,
+	MessagePackConverter<TValue> valueConverter,
 	Func<IEnumerable<KeyValuePair<TKey, TValue>>, TDictionary> ctor) : DictionaryConverter<TDictionary, TKey, TValue>(getReadable, keyConverter, valueConverter)
 {
 	/// <inheritdoc/>

--- a/src/Nerdbank.MessagePack/Converters/EnumAsOrdinalConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/EnumAsOrdinalConverter`2.cs
@@ -8,13 +8,13 @@ namespace Nerdbank.MessagePack.Converters;
 /// </summary>
 /// <typeparam name="TEnum">The enum type.</typeparam>
 /// <typeparam name="TUnderlyingType">The underlying integer type.</typeparam>
-internal class EnumAsOrdinalConverter<TEnum, TUnderlyingType>(IMessagePackConverter<TUnderlyingType> primitiveConverter) : IMessagePackConverter<TEnum>
+internal class EnumAsOrdinalConverter<TEnum, TUnderlyingType>(MessagePackConverter<TUnderlyingType> primitiveConverter) : MessagePackConverter<TEnum>
 {
 	/// <inheritdoc/>
-	public TEnum? Deserialize(ref MessagePackReader reader, SerializationContext context) => (TEnum?)(object?)primitiveConverter.Deserialize(ref reader, context);
+	public override TEnum? Deserialize(ref MessagePackReader reader, SerializationContext context) => (TEnum?)(object?)primitiveConverter.Deserialize(ref reader, context);
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref TEnum? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, ref TEnum? value, SerializationContext context)
 	{
 		TUnderlyingType? intValue = (TUnderlyingType?)(object?)value;
 		primitiveConverter.Serialize(ref writer, ref intValue, context);

--- a/src/Nerdbank.MessagePack/Converters/EnumerableConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/EnumerableConverter`2.cs
@@ -11,10 +11,10 @@ namespace Nerdbank.MessagePack.Converters;
 /// </summary>
 /// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
 /// <typeparam name="TElement">The type of element in the enumerable.</typeparam>
-internal class EnumerableConverter<TEnumerable, TElement>(Func<TEnumerable, IEnumerable<TElement>> getEnumerable, IMessagePackConverter<TElement> elementConverter) : IMessagePackConverter<TEnumerable>
+internal class EnumerableConverter<TEnumerable, TElement>(Func<TEnumerable, IEnumerable<TElement>> getEnumerable, MessagePackConverter<TElement> elementConverter) : MessagePackConverter<TEnumerable>
 {
 	/// <inheritdoc/>
-	public virtual TEnumerable? Deserialize(ref MessagePackReader reader, SerializationContext context)
+	public override TEnumerable? Deserialize(ref MessagePackReader reader, SerializationContext context)
 	{
 		if (reader.TryReadNil())
 		{
@@ -25,7 +25,7 @@ internal class EnumerableConverter<TEnumerable, TElement>(Func<TEnumerable, IEnu
 	}
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref TEnumerable? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, ref TEnumerable? value, SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -59,7 +59,7 @@ internal class EnumerableConverter<TEnumerable, TElement>(Func<TEnumerable, IEnu
 	/// Reads one element from the reader.
 	/// </summary>
 	/// <param name="reader">The reader.</param>
-	/// <param name="context"><inheritdoc cref="IMessagePackConverter{T}.Deserialize" path="/param[@name='context']"/></param>
+	/// <param name="context"><inheritdoc cref="MessagePackConverter{T}.Deserialize" path="/param[@name='context']"/></param>
 	/// <returns>The element.</returns>
 	protected TElement ReadElement(ref MessagePackReader reader, SerializationContext context) => elementConverter.Deserialize(ref reader, context)!;
 }
@@ -74,7 +74,7 @@ internal class EnumerableConverter<TEnumerable, TElement>(Func<TEnumerable, IEnu
 /// <param name="ctor">The default constructor for the enumerable type.</param>
 internal class MutableEnumerableConverter<TEnumerable, TElement>(
 	Func<TEnumerable, IEnumerable<TElement>> getEnumerable,
-	IMessagePackConverter<TElement> elementConverter,
+	MessagePackConverter<TElement> elementConverter,
 	Setter<TEnumerable, TElement> addElement,
 	Func<TEnumerable> ctor) : EnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter)
 {
@@ -107,7 +107,7 @@ internal class MutableEnumerableConverter<TEnumerable, TElement>(
 /// <param name="ctor">A enumerable initializer that constructs from a span of elements.</param>
 internal class SpanEnumerableConverter<TEnumerable, TElement>(
 	Func<TEnumerable, IEnumerable<TElement>> getEnumerable,
-	IMessagePackConverter<TElement> elementConverter,
+	MessagePackConverter<TElement> elementConverter,
 	SpanConstructor<TElement, TEnumerable> ctor) : EnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter)
 {
 	/// <inheritdoc/>
@@ -146,7 +146,7 @@ internal class SpanEnumerableConverter<TEnumerable, TElement>(
 /// <param name="ctor">A enumerable initializer that constructs from an enumerable of elements.</param>
 internal class EnumerableEnumerableConverter<TEnumerable, TElement>(
 	Func<TEnumerable, IEnumerable<TElement>> getEnumerable,
-	IMessagePackConverter<TElement> elementConverter,
+	MessagePackConverter<TElement> elementConverter,
 	Func<IEnumerable<TElement>, TEnumerable> ctor) : EnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter)
 {
 	/// <inheritdoc/>

--- a/src/Nerdbank.MessagePack/Converters/IntConverters.cs
+++ b/src/Nerdbank.MessagePack/Converters/IntConverters.cs
@@ -11,81 +11,81 @@
 namespace Nerdbank.MessagePack;
 
 /// <summary>Serializes the primitive integer type <see cref="SByte"/> as a MessagePack integer.</summary>
-internal class SByteConverter : IMessagePackConverter<SByte>
+internal class SByteConverter : MessagePackConverter<SByte>
 {
 	/// <inheritdoc/>
-	public SByte Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadSByte();
+	public override SByte Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadSByte();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref SByte value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref SByte value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="Int16"/> as a MessagePack integer.</summary>
-internal class Int16Converter : IMessagePackConverter<Int16>
+internal class Int16Converter : MessagePackConverter<Int16>
 {
 	/// <inheritdoc/>
-	public Int16 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt16();
+	public override Int16 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt16();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref Int16 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref Int16 value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="Int32"/> as a MessagePack integer.</summary>
-internal class Int32Converter : IMessagePackConverter<Int32>
+internal class Int32Converter : MessagePackConverter<Int32>
 {
 	/// <inheritdoc/>
-	public Int32 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt32();
+	public override Int32 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt32();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref Int32 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref Int32 value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="Int64"/> as a MessagePack integer.</summary>
-internal class Int64Converter : IMessagePackConverter<Int64>
+internal class Int64Converter : MessagePackConverter<Int64>
 {
 	/// <inheritdoc/>
-	public Int64 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt64();
+	public override Int64 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt64();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref Int64 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref Int64 value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="Byte"/> as a MessagePack integer.</summary>
-internal class ByteConverter : IMessagePackConverter<Byte>
+internal class ByteConverter : MessagePackConverter<Byte>
 {
 	/// <inheritdoc/>
-	public Byte Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadByte();
+	public override Byte Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadByte();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref Byte value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref Byte value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="UInt16"/> as a MessagePack integer.</summary>
-internal class UInt16Converter : IMessagePackConverter<UInt16>
+internal class UInt16Converter : MessagePackConverter<UInt16>
 {
 	/// <inheritdoc/>
-	public UInt16 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadUInt16();
+	public override UInt16 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadUInt16();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref UInt16 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref UInt16 value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="UInt32"/> as a MessagePack integer.</summary>
-internal class UInt32Converter : IMessagePackConverter<UInt32>
+internal class UInt32Converter : MessagePackConverter<UInt32>
 {
 	/// <inheritdoc/>
-	public UInt32 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadUInt32();
+	public override UInt32 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadUInt32();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref UInt32 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref UInt32 value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="UInt64"/> as a MessagePack integer.</summary>
-internal class UInt64Converter : IMessagePackConverter<UInt64>
+internal class UInt64Converter : MessagePackConverter<UInt64>
 {
 	/// <inheritdoc/>
-	public UInt64 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadUInt64();
+	public override UInt64 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadUInt64();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref UInt64 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref UInt64 value, SerializationContext context) => writer.Write(value);
 }

--- a/src/Nerdbank.MessagePack/Converters/IntConverters.tt
+++ b/src/Nerdbank.MessagePack/Converters/IntConverters.tt
@@ -15,12 +15,12 @@ namespace Nerdbank.MessagePack;
 foreach (string type in types) { #>
 
 /// <summary>Serializes the primitive integer type <see cref="<#=type#>"/> as a MessagePack integer.</summary>
-internal class <#=type#>Converter : IMessagePackConverter<<#=type#>>
+internal class <#=type#>Converter : MessagePackConverter<<#=type#>>
 {
 	/// <inheritdoc/>
-	public <#=type#> Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.Read<#=type#>();
+	public override <#=type#> Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.Read<#=type#>();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref <#=type#> value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref <#=type#> value, SerializationContext context) => writer.Write(value);
 }
 <# } #>

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
@@ -4,14 +4,14 @@
 namespace Nerdbank.MessagePack.Converters;
 
 /// <summary>
-/// A <see cref="IMessagePackConverter{T}"/> that writes objects as arrays of property values.
+/// A <see cref="MessagePackConverter{T}"/> that writes objects as arrays of property values.
 /// Only data types with default constructors may be deserialized.
 /// </summary>
 /// <typeparam name="T">The type of objects that can be serialized or deserialized with this converter.</typeparam>
-internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<T>? constructor) : IMessagePackConverter<T>
+internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<T>? constructor) : MessagePackConverter<T>
 {
 	/// <inheritdoc/>
-	public virtual T? Deserialize(ref MessagePackReader reader, SerializationContext context)
+	public override T? Deserialize(ref MessagePackReader reader, SerializationContext context)
 	{
 		if (reader.TryReadNil())
 		{
@@ -42,7 +42,7 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 	}
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context)
 	{
 		if (value is null)
 		{

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayWithNonDefaultCtorConverter`2.cs
@@ -4,7 +4,7 @@
 namespace Nerdbank.MessagePack.Converters;
 
 /// <summary>
-/// A <see cref="IMessagePackConverter{T}"/> that writes objects as maps of property names to values.
+/// A <see cref="MessagePackConverter{T}"/> that writes objects as maps of property names to values.
 /// Data types with constructors and/or <see langword="init" /> properties may be deserialized.
 /// </summary>
 /// <typeparam name="TDeclaringType">The type of objects that can be serialized or deserialized with this converter.</typeparam>

--- a/src/Nerdbank.MessagePack/Converters/ObjectMapConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapConverter`1.cs
@@ -4,17 +4,17 @@
 namespace Nerdbank.MessagePack.Converters;
 
 /// <summary>
-/// A <see cref="IMessagePackConverter{T}"/> that writes objects as maps of property names to values.
+/// A <see cref="MessagePackConverter{T}"/> that writes objects as maps of property names to values.
 /// Only data types with default constructors may be deserialized.
 /// </summary>
 /// <typeparam name="T">The type of objects that can be serialized or deserialized with this converter.</typeparam>
 /// <param name="serializable">Tools for serializing individual property values.</param>
 /// <param name="deserializable">Tools for deserializing individual property values. May be omitted if the type will never be deserialized (i.e. there is no deserializing constructor).</param>
 /// <param name="constructor">The default constructor, if present.</param>
-internal class ObjectMapConverter<T>(MapSerializableProperties<T> serializable, MapDeserializableProperties<T>? deserializable, Func<T>? constructor) : IMessagePackConverter<T>
+internal class ObjectMapConverter<T>(MapSerializableProperties<T> serializable, MapDeserializableProperties<T>? deserializable, Func<T>? constructor) : MessagePackConverter<T>
 {
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -32,7 +32,7 @@ internal class ObjectMapConverter<T>(MapSerializableProperties<T> serializable, 
 	}
 
 	/// <inheritdoc/>
-	public virtual T? Deserialize(ref MessagePackReader reader, SerializationContext context)
+	public override T? Deserialize(ref MessagePackReader reader, SerializationContext context)
 	{
 		if (reader.TryReadNil())
 		{

--- a/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
@@ -4,7 +4,7 @@
 namespace Nerdbank.MessagePack.Converters;
 
 /// <summary>
-/// A <see cref="IMessagePackConverter{T}"/> that writes objects as maps of property names to values.
+/// A <see cref="MessagePackConverter{T}"/> that writes objects as maps of property names to values.
 /// Data types with constructors and/or <see langword="init" /> properties may be deserialized.
 /// </summary>
 /// <typeparam name="TDeclaringType">The type of objects that can be serialized or deserialized with this converter.</typeparam>

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
@@ -9,85 +9,85 @@ namespace Nerdbank.MessagePack.Converters;
 /// <summary>
 /// Serializes a <see cref="string"/>.
 /// </summary>
-internal class StringConverter : IMessagePackConverter<string>
+internal class StringConverter : MessagePackConverter<string>
 {
 	/// <inheritdoc/>
-	public string? Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadString();
+	public override string? Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadString();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref string? value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref string? value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
 /// Serializes a <see cref="bool"/>.
 /// </summary>
-internal class BooleanConverter : IMessagePackConverter<bool>
+internal class BooleanConverter : MessagePackConverter<bool>
 {
 	/// <inheritdoc/>
-	public bool Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadBoolean();
+	public override bool Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadBoolean();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref bool value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref bool value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
 /// Serializes a <see cref="float"/>.
 /// </summary>
-internal class SingleConverter : IMessagePackConverter<float>
+internal class SingleConverter : MessagePackConverter<float>
 {
 	/// <inheritdoc/>
-	public float Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadSingle();
+	public override float Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadSingle();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref float value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref float value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
 /// Serializes a <see cref="double"/>.
 /// </summary>
-internal class DoubleConverter : IMessagePackConverter<double>
+internal class DoubleConverter : MessagePackConverter<double>
 {
 	/// <inheritdoc/>
-	public double Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadDouble();
+	public override double Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadDouble();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref double value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref double value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
 /// Serializes <see cref="DateTime"/> values.
 /// </summary>
-internal class DateTimeConverter : IMessagePackConverter<DateTime>
+internal class DateTimeConverter : MessagePackConverter<DateTime>
 {
 	/// <inheritdoc/>
-	public DateTime Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadDateTime();
+	public override DateTime Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadDateTime();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref DateTime value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref DateTime value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
 /// Serializes <see cref="char"/> values.
 /// </summary>
-internal class CharConverter : IMessagePackConverter<char>
+internal class CharConverter : MessagePackConverter<char>
 {
 	/// <inheritdoc/>
-	public char Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadChar();
+	public override char Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadChar();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref char value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref char value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
 /// Serializes <see cref="byte"/> array values.
 /// </summary>
-internal class ByteArrayConverter : IMessagePackConverter<byte[]?>
+internal class ByteArrayConverter : MessagePackConverter<byte[]?>
 {
 	/// <inheritdoc/>
-	public byte[]? Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadBytes()?.ToArray();
+	public override byte[]? Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadBytes()?.ToArray();
 
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref byte[]? value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, ref byte[]? value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
@@ -95,11 +95,11 @@ internal class ByteArrayConverter : IMessagePackConverter<byte[]?>
 /// </summary>
 /// <typeparam name="T">The value type.</typeparam>
 /// <param name="elementConverter">The converter to use when the value is not null.</param>
-internal class NullableConverter<T>(IMessagePackConverter<T> elementConverter) : IMessagePackConverter<T?>
+internal class NullableConverter<T>(MessagePackConverter<T> elementConverter) : MessagePackConverter<T?>
 	where T : struct
 {
 	/// <inheritdoc/>
-	public void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context)
 	{
 		if (value.HasValue)
 		{
@@ -113,7 +113,7 @@ internal class NullableConverter<T>(IMessagePackConverter<T> elementConverter) :
 	}
 
 	/// <inheritdoc/>
-	public T? Deserialize(ref MessagePackReader reader, SerializationContext context)
+	public override T? Deserialize(ref MessagePackReader reader, SerializationContext context)
 	{
 		if (reader.TryReadNil())
 		{

--- a/src/Nerdbank.MessagePack/Converters/SubTypeUnionConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/SubTypeUnionConverter`1.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.MessagePack.Converters;
+
+/// <summary>
+/// A formatter for a type that may serve as an ancestor class for the actual runtime type of a value to be (de)serialized.
+/// </summary>
+/// <typeparam name="TBase">The type that serves as the runtime type or the ancestor type for any runtime value.</typeparam>
+/// <param name="subTypes">Contains maps to assist with converting subtypes.</param>
+/// <param name="baseConverter">The converter to use for values that are actual instances of the base type itself.</param>
+internal class SubTypeUnionConverter<TBase>(SubTypes subTypes, MessagePackConverter<TBase> baseConverter) : MessagePackConverter<TBase>
+{
+	/// <inheritdoc/>
+	public override TBase? Deserialize(ref MessagePackReader reader, SerializationContext context)
+	{
+		if (reader.TryReadNil())
+		{
+			return default;
+		}
+
+		int count = reader.ReadArrayHeader();
+		if (count != 2)
+		{
+			throw new MessagePackSerializationException($"Expected an array of 2 elements, but found {count}.");
+		}
+
+		// The alias for the base type itself is simply nil.
+		if (reader.TryReadNil())
+		{
+			return baseConverter.Deserialize(ref reader, context);
+		}
+
+		int alias = reader.ReadInt32();
+		if (!subTypes.Deserializers.TryGetValue(alias, out IMessagePackConverter? converter))
+		{
+			throw new MessagePackSerializationException($"Unknown alias {alias}.");
+		}
+
+		return (TBase?)converter.Deserialize(ref reader, context);
+	}
+
+	/// <inheritdoc/>
+	public override void Serialize(ref MessagePackWriter writer, ref TBase? value, SerializationContext context)
+	{
+		if (value is null)
+		{
+			writer.WriteNil();
+			return;
+		}
+
+		writer.WriteArrayHeader(2);
+
+		Type valueType = value.GetType();
+		if (valueType.IsEquivalentTo(typeof(TBase)))
+		{
+			// The runtime type of the value matches the base exactly. Use nil as the alias.
+			writer.WriteNil();
+			baseConverter.Serialize(ref writer, ref value, context);
+		}
+		else if (subTypes.Serializers.TryGetValue(valueType, out (int Alias, IMessagePackConverter Converter) result))
+		{
+			writer.Write(result.Alias);
+			object? untypedValue = value;
+			result.Converter.Serialize(ref writer, ref untypedValue, context);
+		}
+		else
+		{
+			throw new ArgumentException($"value is of type {valueType.FullName} which is not one of those listed via {nameof(KnownSubTypeAttribute)} on the declared base type {typeof(TBase).FullName}.");
+		}
+	}
+}

--- a/src/Nerdbank.MessagePack/IMessagePackConverter.cs
+++ b/src/Nerdbank.MessagePack/IMessagePackConverter.cs
@@ -4,24 +4,23 @@
 namespace Nerdbank.MessagePack;
 
 /// <summary>
-/// An interface for all message pack converters.
+/// A non-generic, <see cref="object"/>-based interface for all message pack converters.
 /// </summary>
-/// <typeparam name="T">The data type that can be converted by this object.</typeparam>
-public interface IMessagePackConverter<T>
+internal interface IMessagePackConverter
 {
 	/// <summary>
-	/// Serializes an instance of <typeparamref name="T"/>.
+	/// Serializes an instance of an object.
 	/// </summary>
 	/// <param name="writer">The writer to use.</param>
 	/// <param name="value">The value to serialize.</param>
 	/// <param name="context">Context for the serialization.</param>
-	void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context);
+	void Serialize(ref MessagePackWriter writer, ref object? value, SerializationContext context);
 
 	/// <summary>
-	/// Deserializes an instance of <typeparamref name="T"/>.
+	/// Deserializes an instance of an object.
 	/// </summary>
 	/// <param name="reader">The reader to use.</param>
 	/// <param name="context">Context for the deserialization.</param>
 	/// <returns>The deserialized value.</returns>
-	T? Deserialize(ref MessagePackReader reader, SerializationContext context);
+	object? Deserialize(ref MessagePackReader reader, SerializationContext context);
 }

--- a/src/Nerdbank.MessagePack/KnownSubTypeAttribute.cs
+++ b/src/Nerdbank.MessagePack/KnownSubTypeAttribute.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// Specifies that where the class to which this attribute is applied is the declared type in an object graph
+/// that certain derived types are recorded in the serialized data as well and allowed to be deserialized back
+/// as their derived types.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A type with one or more of these attributes applied serializes to a different schema than the same type
+/// without any attributes applied. The serialized data will include a special header that indicates the runtime type.
+/// Consider version compatibility issues when adding the first or removing the last attribute from a type.
+/// </para>
+/// <para>
+/// Each type referenced by this attribute must have <see cref="GenerateShapeAttribute"/> applied to it
+/// when using that attribute on the root of the serialization tree.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+[DebuggerDisplay($"Union: {{{nameof(Alias)}}}, {{{nameof(SubType.Name)},nq}}")]
+public class KnownSubTypeAttribute : Attribute
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="KnownSubTypeAttribute"/> class.
+	/// </summary>
+	/// <param name="alias">A value that identifies the subtype in the serialized data. Must be unique among all the attributes applied to the same class.</param>
+	/// <param name="subType">The class derived from the one to which this attribute is affixed.</param>
+	public KnownSubTypeAttribute(int alias, Type subType)
+	{
+		this.Alias = alias;
+		this.SubType = subType;
+	}
+
+	/// <summary>
+	/// Gets a value that identifies the subtype in the serialized data. Must be unique among all the attributes applied to the same class.
+	/// </summary>
+	public int Alias { get; }
+
+	/// <summary>
+	/// Gets the class derived from the one to which this attribute is affixed.
+	/// </summary>
+	public Type SubType { get; }
+}

--- a/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
+++ b/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// An interface for all message pack converters.
+/// </summary>
+/// <typeparam name="T">The data type that can be converted by this object.</typeparam>
+public abstract class MessagePackConverter<T> : IMessagePackConverter
+{
+	/// <summary>
+	/// Serializes an instance of <typeparamref name="T"/>.
+	/// </summary>
+	/// <param name="writer">The writer to use.</param>
+	/// <param name="value">The value to serialize.</param>
+	/// <param name="context">Context for the serialization.</param>
+	public abstract void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context);
+
+	/// <summary>
+	/// Deserializes an instance of <typeparamref name="T"/>.
+	/// </summary>
+	/// <param name="reader">The reader to use.</param>
+	/// <param name="context">Context for the deserialization.</param>
+	/// <returns>The deserialized value.</returns>
+	public abstract T? Deserialize(ref MessagePackReader reader, SerializationContext context);
+
+	/// <inheritdoc/>
+	void IMessagePackConverter.Serialize(ref MessagePackWriter writer, ref object? value, SerializationContext context)
+	{
+		T? typedValue = (T?)value;
+		this.Serialize(ref writer, ref typedValue, context);
+	}
+
+	/// <inheritdoc/>
+	object? IMessagePackConverter.Deserialize(ref MessagePackReader reader, SerializationContext context)
+	{
+		return this.Deserialize(ref reader, context);
+	}
+}

--- a/src/Nerdbank.MessagePack/README.md
+++ b/src/Nerdbank.MessagePack/README.md
@@ -16,6 +16,7 @@
 * Author custom converters for advanced scenarios.
 * Security mitigations for stack overflows.
 * Optionally serialize your custom types as arrays of bvalues instead of maps of names and value for more compact representation and even higher performance.
+* Support for serializing instances of certain types derived from the declared type and deserializing them back to their original runtime types using [unions](https://github.com/aarnott/nerdbank.messagepack/tree/main/doc/unions.md).
 
 ## Usage
 

--- a/test/Nerdbank.MessagePack.Tests/KnownSubTypeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/KnownSubTypeTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public partial class UnionTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	[Fact]
+	public void BaseType()
+	{
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip(new BaseClass { BaseClassProperty = 5 });
+
+		// Assert that it's serialized in its special syntax that allows for derived types.
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(2, reader.ReadArrayHeader());
+		reader.ReadNil();
+		Assert.Equal(1, reader.ReadMapHeader());
+		Assert.Equal(nameof(BaseClass.BaseClassProperty), reader.ReadString());
+	}
+
+	[Fact]
+	public void DerivedAType()
+	{
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip(new DerivedA { BaseClassProperty = 5, DerivedAProperty = 6 });
+
+		// Assert that this has no special header because it has no Union attribute of its own.
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(2, reader.ReadMapHeader());
+		Assert.Equal(nameof(DerivedA.DerivedAProperty), reader.ReadString());
+		Assert.Equal(6, reader.ReadInt32());
+		Assert.Equal(nameof(BaseClass.BaseClassProperty), reader.ReadString());
+		Assert.Equal(5, reader.ReadInt32());
+		Assert.True(reader.End);
+	}
+
+	[Fact]
+	public void DerivedA_AsBaseType() => this.AssertRoundtrip<BaseClass>(new DerivedA { BaseClassProperty = 5, DerivedAProperty = 6 });
+
+	[Fact]
+	public void DerivedAA_AsBaseType() => this.AssertRoundtrip<BaseClass>(new DerivedAA { BaseClassProperty = 5, DerivedAProperty = 6 });
+
+	[Fact]
+	public void DerivedB_AsBaseType() => this.AssertRoundtrip<BaseClass>(new DerivedB(10) { BaseClassProperty = 5 });
+
+	[GenerateShape]
+	[KnownSubType(1, typeof(DerivedA))]
+	[KnownSubType(2, typeof(DerivedAA))]
+	[KnownSubType(3, typeof(DerivedB))]
+	public partial record BaseClass
+	{
+		public int BaseClassProperty { get; set; }
+	}
+
+	[GenerateShape]
+	public partial record DerivedA() : BaseClass
+	{
+		public int DerivedAProperty { get; set; }
+	}
+
+	[GenerateShape]
+	public partial record DerivedAA : DerivedA
+	{
+	}
+
+	[GenerateShape]
+	public partial record DerivedB(int DerivedBProperty) : BaseClass
+	{
+	}
+}

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
@@ -3,18 +3,21 @@
 
 public abstract class MessagePackSerializerTestBase(ITestOutputHelper logger)
 {
+	private ReadOnlySequence<byte> lastRoundtrippedMsgpack;
+
 	protected MessagePackSerializer Serializer { get; set; } = new();
 
 	protected ITestOutputHelper Logger => logger;
 
-	protected void AssertRoundtrip<T>(T? value)
+	protected ReadOnlySequence<byte> AssertRoundtrip<T>(T? value)
 		where T : IShapeable<T> => this.AssertRoundtrip<T, T>(value);
 
-	protected void AssertRoundtrip<T, TProvider>(T? value)
+	protected ReadOnlySequence<byte> AssertRoundtrip<T, TProvider>(T? value)
 		where TProvider : IShapeable<T>
 	{
 		T? roundtripped = this.Roundtrip<T, TProvider>(value);
 		Assert.Equal(value, roundtripped);
+		return this.lastRoundtrippedMsgpack;
 	}
 
 	protected T? Roundtrip<T>(T? value)
@@ -26,6 +29,7 @@ public abstract class MessagePackSerializerTestBase(ITestOutputHelper logger)
 		Sequence<byte> sequence = new();
 		this.Serializer.Serialize<T, TProvider>(sequence, value);
 		this.LogMsgPack(sequence);
+		this.lastRoundtrippedMsgpack = sequence;
 		return this.Serializer.Deserialize<T, TProvider>(sequence);
 	}
 


### PR DESCRIPTION
This adds `UnionAttribute`, which can be applied to a type declaration to allow derivative types to appear at runtime where the base type is the declared type. In such a case, the data provided by the attribute dictates how the derived type will be identified in the serialized stream.