### PR TITLE
Add support for async (de)serialization

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+
+dotnet_diagnostic.VSTHRD111.severity = warning # Use ConfigureAwait(bool)

--- a/src/Nerdbank.MessagePack/BufferMemoryWriter.cs
+++ b/src/Nerdbank.MessagePack/BufferMemoryWriter.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// This file was originally derived from https://github.com/MessagePack-CSharp/MessagePack-CSharp/
+using System.Runtime.CompilerServices;
+using Microsoft;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// A fast access struct that wraps <see cref="IBufferWriter{T}"/>.
+/// This one is slower than <see cref="BufferWriter"/> but it is more flexible in that it is not a <see langword="ref" /> struct.
+/// </summary>
+internal struct BufferMemoryWriter
+{
+	/// <summary>
+	/// The underlying <see cref="IBufferWriter{T}"/>.
+	/// </summary>
+	private IBufferWriter<byte> output;
+
+	/// <summary>
+	/// The result of the last call to <see cref="IBufferWriter{T}.GetMemory(int)"/>, less any bytes already "consumed" with <see cref="Advance(int)"/>.
+	/// Backing field for the <see cref="Memory"/> property.
+	/// </summary>
+	private Memory<byte> memory;
+
+	/// <summary>
+	/// The number of uncommitted bytes (all the calls to <see cref="Advance(int)"/> since the last call to <see cref="Commit"/>).
+	/// </summary>
+	private int buffered;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BufferMemoryWriter"/> struct.
+	/// </summary>
+	/// <param name="output">The <see cref="IBufferWriter{T}"/> to be wrapped.</param>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal BufferMemoryWriter(IBufferWriter<byte> output)
+	{
+		this.buffered = 0;
+		this.output = output ?? throw new ArgumentNullException(nameof(output));
+		this.memory = this.output.GetMemoryCheckResult();
+	}
+
+	/// <summary>
+	/// Gets the result of the last call to <see cref="IBufferWriter{T}.GetMemory(int)"/>.
+	/// </summary>
+	internal Memory<byte> Memory => this.memory;
+
+	/// <inheritdoc cref="IBufferWriter{T}.GetSpan(int)"/>
+	internal Span<byte> GetSpan(int sizeHint = 0)
+	{
+		this.Ensure(sizeHint);
+		return this.Memory.Span;
+	}
+
+	/// <inheritdoc cref="IBufferWriter{T}.GetMemory(int)"/>
+	internal Memory<byte> GetMemory(int sizeHint = 0)
+	{
+		this.Ensure(sizeHint);
+		return this.Memory;
+	}
+
+	/// <summary>
+	/// Gets a reference to the next byte to write to.
+	/// </summary>
+	/// <param name="sizeHint">The minimum size to guarantee is available in the buffer.</param>
+	/// <returns>The first byte in the buffer.</returns>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal ref byte GetPointer(int sizeHint = 0)
+	{
+		this.Ensure(sizeHint);
+		return ref this.memory.Span[0];
+	}
+
+	/// <summary>
+	/// Calls <see cref="IBufferWriter{T}.Advance(int)"/> on the underlying writer
+	/// with the number of uncommitted bytes.
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal void Commit()
+	{
+		int buffered = this.buffered;
+		if (buffered > 0)
+		{
+			this.buffered = 0;
+			this.output.Advance(buffered);
+			this.memory = default;
+		}
+	}
+
+	/// <summary>
+	/// Used to indicate that part of the buffer has been written to.
+	/// </summary>
+	/// <param name="count">The number of bytes written to.</param>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal void Advance(int count)
+	{
+		this.buffered += count;
+		this.memory = this.memory[count..];
+	}
+
+	/// <summary>
+	/// Copies the caller's buffer into this writer and calls <see cref="Advance(int)"/> with the length of the source buffer.
+	/// </summary>
+	/// <param name="source">The buffer to copy in.</param>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal void Write(ReadOnlySpan<byte> source)
+	{
+		if (this.memory.Length >= source.Length)
+		{
+			source.CopyTo(this.memory.Span);
+			this.Advance(source.Length);
+		}
+		else
+		{
+			this.WriteMultiBuffer(source);
+		}
+	}
+
+	/// <summary>
+	/// Acquires a new buffer if necessary to ensure that some given number of bytes can be written to a single buffer.
+	/// </summary>
+	/// <param name="count">The number of bytes that must be allocated in a single buffer.</param>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal void Ensure(int count = 0)
+	{
+		if (this.memory.Length < count || this.memory.Length == 0)
+		{
+			this.EnsureMore(count);
+		}
+	}
+
+	/// <summary>
+	/// Gets a fresh span to write to, with an optional minimum size.
+	/// </summary>
+	/// <param name="count">The minimum size for the next requested buffer.</param>
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void EnsureMore(int count = 0)
+	{
+		if (this.buffered > 0)
+		{
+			this.Commit();
+		}
+
+		Assumes.NotNull(this.output);
+		this.memory = this.output.GetMemoryCheckResult(count);
+	}
+
+	/// <summary>
+	/// Copies the caller's buffer into this writer, potentially across multiple buffers from the underlying writer.
+	/// </summary>
+	/// <param name="source">The buffer to copy into this writer.</param>
+	private void WriteMultiBuffer(ReadOnlySpan<byte> source)
+	{
+		int copiedBytes = 0;
+		int bytesLeftToCopy = source.Length;
+		while (bytesLeftToCopy > 0)
+		{
+			if (this.memory.Length == 0)
+			{
+				this.EnsureMore();
+			}
+
+			int writable = Math.Min(bytesLeftToCopy, this.memory.Length);
+			source.Slice(copiedBytes, writable).CopyTo(this.memory.Span);
+			copiedBytes += writable;
+			bytesLeftToCopy -= writable;
+			this.Advance(writable);
+		}
+	}
+}

--- a/src/Nerdbank.MessagePack/Converters/ArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayConverter`1.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Nerdbank.MessagePack.Converters;
 
 /// <summary>
@@ -9,6 +11,9 @@ namespace Nerdbank.MessagePack.Converters;
 /// <typeparam name="TElement">The element type.</typeparam>
 internal class ArrayConverter<TElement>(MessagePackConverter<TElement> elementConverter) : MessagePackConverter<TElement[]>
 {
+	/// <inheritdoc/>
+	public override bool PreferAsyncSerialization => true;
+
 	/// <inheritdoc/>
 	public override TElement[]? Deserialize(ref MessagePackReader reader, SerializationContext context)
 	{
@@ -42,6 +47,105 @@ internal class ArrayConverter<TElement>(MessagePackConverter<TElement> elementCo
 		for (int i = 0; i < value.Length; i++)
 		{
 			elementConverter.Serialize(ref writer, ref value[i]!, context);
+		}
+	}
+
+	/// <inheritdoc/>
+	[Experimental("NBMsgPackAsync")]
+	public override async ValueTask SerializeAsync(MessagePackAsyncWriter writer, TElement[]? value, SerializationContext context, CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+
+		if (value is null)
+		{
+			writer.WriteNil();
+			return;
+		}
+
+		context.DepthStep();
+		if (elementConverter.PreferAsyncSerialization)
+		{
+			writer.WriteArrayHeader(value.Length);
+			for (int i = 0; i < value.Length; i++)
+			{
+				await elementConverter.SerializeAsync(writer, value[i], context, cancellationToken).ConfigureAwait(false);
+				await writer.FlushIfAppropriateAsync(context, cancellationToken).ConfigureAwait(false);
+			}
+		}
+		else
+		{
+			int progress = 0;
+			do
+			{
+				SerializeStep(value, ref progress, context, cancellationToken);
+				await writer.FlushIfAppropriateAsync(context, cancellationToken).ConfigureAwait(false);
+			}
+			while (progress < value.Length);
+
+			void SerializeStep(TElement[] value, ref int progress, SerializationContext context, CancellationToken cancellationToken)
+			{
+				MessagePackWriter syncWriter = writer.CreateWriter();
+				if (progress == 0)
+				{
+					syncWriter.WriteArrayHeader(value.Length);
+				}
+
+				for (; progress < value.Length; progress++)
+				{
+					if (writer.IsTimeToFlush(context))
+					{
+						break;
+					}
+
+					elementConverter.Serialize(ref syncWriter, ref value[progress]!, context);
+					cancellationToken.ThrowIfCancellationRequested();
+				}
+
+				syncWriter.Flush();
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	[Experimental("NBMsgPackAsync")]
+	public override async ValueTask<TElement[]?> DeserializeAsync(MessagePackAsyncReader reader, SerializationContext context, CancellationToken cancellationToken)
+	{
+		if (await reader.TryReadNilAsync(cancellationToken).ConfigureAwait(false))
+		{
+			return null;
+		}
+
+		context.DepthStep();
+
+		if (elementConverter.PreferAsyncSerialization)
+		{
+			int count = await reader.ReadArrayHeaderAsync(cancellationToken).ConfigureAwait(false);
+			TElement[] array = new TElement[count];
+			for (int i = 0; i < count; i++)
+			{
+				array[i] = (await elementConverter.DeserializeAsync(reader, context, cancellationToken).ConfigureAwait(false))!;
+			}
+
+			return array;
+		}
+		else
+		{
+			ReadOnlySequence<byte> map = await reader.ReadNextStructureAsync(context, cancellationToken).ConfigureAwait(false);
+			TElement[] array = Read(new MessagePackReader(map));
+			reader.AdvanceTo(map.End);
+			return array;
+
+			TElement[] Read(MessagePackReader syncReader)
+			{
+				int count = syncReader.ReadArrayHeader();
+				TElement[] array = new TElement[count];
+				for (int i = 0; i < count; i++)
+				{
+					array[i] = elementConverter.Deserialize(ref syncReader, context)!;
+				}
+
+				return array;
+			}
 		}
 	}
 }

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Nerdbank.MessagePack.Converters;
 
 /// <summary>
@@ -10,6 +12,9 @@ namespace Nerdbank.MessagePack.Converters;
 /// <typeparam name="T">The type of objects that can be serialized or deserialized with this converter.</typeparam>
 internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<T>? constructor) : MessagePackConverter<T>
 {
+	/// <inheritdoc/>
+	public override bool PreferAsyncSerialization => true;
+
 	/// <inheritdoc/>
 	public override T? Deserialize(ref MessagePackReader reader, SerializationContext context)
 	{
@@ -28,7 +33,7 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 		int count = reader.ReadArrayHeader();
 		for (int i = 0; i < count; i++)
 		{
-			if (properties.Length > i && properties[i]?.Deserialize is { } deserialize)
+			if (properties.Length > i && properties[i]?.MsgPackReaders is var (deserialize, _))
 			{
 				deserialize(ref value, ref reader, context);
 			}
@@ -55,7 +60,7 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 		writer.WriteArrayHeader(properties.Length);
 		for (int i = 0; i < properties.Length; i++)
 		{
-			if (properties[i]?.Serialize is { } serialize)
+			if (properties[i]?.MsgPackWriters is var (serialize, _))
 			{
 				serialize(ref value, ref writer, context);
 			}
@@ -64,5 +69,63 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 				writer.WriteNil();
 			}
 		}
+	}
+
+	/// <inheritdoc/>
+	[Experimental("NBMsgPackAsync")]
+	public override async ValueTask SerializeAsync(MessagePackAsyncWriter writer, T? value, SerializationContext context, CancellationToken cancellationToken)
+	{
+		if (value is null)
+		{
+			writer.WriteNil();
+			return;
+		}
+
+		context.DepthStep();
+
+		writer.WriteArrayHeader(properties.Length);
+		for (int i = 0; i < properties.Length; i++)
+		{
+			if (properties[i]?.MsgPackWriters is var (_, serializeAsync))
+			{
+				await serializeAsync(value, writer, context, cancellationToken).ConfigureAwait(false);
+			}
+			else
+			{
+				writer.WriteNil();
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	[Experimental("NBMsgPackAsync")]
+	public override async ValueTask<T?> DeserializeAsync(MessagePackAsyncReader reader, SerializationContext context, CancellationToken cancellationToken)
+	{
+		if (await reader.TryReadNilAsync(cancellationToken).ConfigureAwait(false))
+		{
+			return default;
+		}
+
+		if (constructor is null)
+		{
+			throw new NotSupportedException($"The {typeof(T).Name} type cannot be deserialized.");
+		}
+
+		context.DepthStep();
+		T value = constructor();
+		int count = await reader.ReadArrayHeaderAsync(cancellationToken).ConfigureAwait(false);
+		for (int i = 0; i < count; i++)
+		{
+			if (properties.Length > i && properties[i]?.MsgPackReaders is var (_, deserializeAsync))
+			{
+				value = await deserializeAsync(value, reader, context, cancellationToken).ConfigureAwait(false);
+			}
+			else
+			{
+				await reader.SkipAsync(context, cancellationToken).ConfigureAwait(false);
+			}
+		}
+
+		return value;
 	}
 }

--- a/src/Nerdbank.MessagePack/MessagePackAsyncReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackAsyncReader.cs
@@ -1,0 +1,267 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Pipelines;
+using Microsoft;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// A primitive types reader for the MessagePack format that reads from a <see cref="PipeReader"/>.
+/// </summary>
+/// <param name="pipeReader">The pipe reader to decode from.</param>
+/// <remarks>
+/// <para>
+/// This is an async capable and slower alternative to <see cref="MessagePackReader"/> with fewer methods,
+/// making the sync version more generally useful.
+/// It is useful when implementing the async virtual methods on <see cref="MessagePackConverter{T}"/>.
+/// </para>
+/// <see href="https://github.com/msgpack/msgpack/blob/master/spec.md">The MessagePack spec.</see>.
+/// </remarks>
+/// <exception cref="MessagePackSerializationException">Thrown when reading methods fail due to invalid data.</exception>
+/// <exception cref="EndOfStreamException">Thrown by reading methods when there are not enough bytes to read the required value.</exception>
+[Experimental("NBMsgPackAsync")]
+public class MessagePackAsyncReader(PipeReader pipeReader)
+{
+	private ReadResult? lastReadResult;
+	private bool timeForAdvanceTo;
+
+	/// <inheritdoc cref="MessagePackReader.TryReadNil"/>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	public async ValueTask<bool> TryReadNilAsync(CancellationToken cancellationToken)
+	{
+		ReadResult readResult = await this.ReadAsync(cancellationToken).ConfigureAwait(false);
+		if (readResult.IsCanceled)
+		{
+			throw new OperationCanceledException();
+		}
+
+		bool isNil = TryReadNil(readResult.Buffer, out SequencePosition readTo);
+		this.AdvanceTo(readTo);
+		return isNil;
+
+		bool TryReadNil(in ReadOnlySequence<byte> buffer, out SequencePosition readTo)
+		{
+			MessagePackReader reader = new(buffer);
+			bool result = reader.TryReadNil();
+			readTo = reader.Position;
+			return result;
+		}
+	}
+
+	/// <inheritdoc cref="MessagePackReader.ReadMapHeader"/>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	public async ValueTask<int> ReadMapHeaderAsync(CancellationToken cancellationToken)
+	{
+		ReadResult readResult = await this.ReadAsync(cancellationToken).ConfigureAwait(false);
+		if (readResult.IsCanceled)
+		{
+			throw new OperationCanceledException();
+		}
+
+retry:
+		MessagePackPrimitives.DecodeResult decodeResult = MessagePackPrimitives.TryReadMapHeader(readResult.Buffer, out uint count, out SequencePosition readTo);
+		switch (decodeResult)
+		{
+			case MessagePackPrimitives.DecodeResult.Success:
+				this.AdvanceTo(readTo);
+				return (int)count;
+			case MessagePackPrimitives.DecodeResult.TokenMismatch:
+				throw MessagePackReader.ThrowInvalidCode(readResult.Buffer.FirstSpan[0]);
+			case MessagePackPrimitives.DecodeResult.InsufficientBuffer when !readResult.IsCompleted:
+				// Fetch more data.
+				this.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
+				readResult = await this.ReadAsync(cancellationToken).ConfigureAwait(false);
+				goto retry;
+			case MessagePackPrimitives.DecodeResult.EmptyBuffer or MessagePackPrimitives.DecodeResult.InsufficientBuffer:
+				throw new EndOfStreamException();
+			default: throw new UnreachableException();
+		}
+	}
+
+	/// <inheritdoc cref="MessagePackReader.ReadArrayHeader"/>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	public async ValueTask<int> ReadArrayHeaderAsync(CancellationToken cancellationToken)
+	{
+		ReadResult readResult = await this.ReadAsync(cancellationToken).ConfigureAwait(false);
+		if (readResult.IsCanceled)
+		{
+			throw new OperationCanceledException();
+		}
+
+retry:
+		MessagePackPrimitives.DecodeResult decodeResult = MessagePackPrimitives.TryReadArrayHeader(readResult.Buffer, out uint count, out SequencePosition readTo);
+		switch (decodeResult)
+		{
+			case MessagePackPrimitives.DecodeResult.Success:
+				this.AdvanceTo(readTo);
+				return (int)count;
+			case MessagePackPrimitives.DecodeResult.TokenMismatch:
+				throw MessagePackReader.ThrowInvalidCode(readResult.Buffer.FirstSpan[0]);
+			case MessagePackPrimitives.DecodeResult.InsufficientBuffer when !readResult.IsCompleted:
+				// Fetch more data.
+				this.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
+				readResult = await this.ReadAsync(cancellationToken).ConfigureAwait(false);
+				goto retry;
+			case MessagePackPrimitives.DecodeResult.EmptyBuffer or MessagePackPrimitives.DecodeResult.InsufficientBuffer:
+				throw new EndOfStreamException();
+			default: throw new UnreachableException();
+		}
+	}
+
+	/// <summary>
+	/// Retrieves enough data from the pipe to read the next msgpack structure.
+	/// </summary>
+	/// <param name="context">The serialization context.</param>
+	/// <param name="cancellationToken">A cancellation tokne.</param>
+	/// <returns>A task that completes when enough bytes have been retrieved into local buffers.</returns>
+	/// <remarks>
+	/// After awaiting this method, the next msgpack structure can be retrieved by a call to <see cref="PipeReader.ReadAsync(CancellationToken)"/>.
+	/// </remarks>
+	public async ValueTask BufferNextStructureAsync(SerializationContext context, CancellationToken cancellationToken)
+	{
+		ReadOnlySequence<byte> buffer = await this.ReadNextStructureAsync(context, cancellationToken).ConfigureAwait(false);
+		this.AdvanceTo(buffer.Start);
+	}
+
+	/// <summary>
+	/// Retrieves enough data from the pipe to read the next msgpack structure.
+	/// </summary>
+	/// <param name="context">The serialization context.</param>
+	/// <param name="cancellationToken">A cancellation tokne.</param>
+	/// <returns>The buffer containing the next structure.</returns>
+	/// <remarks>
+	/// After a successful call to this method, the caller *must* call <see cref="AdvanceTo(SequencePosition, SequencePosition)"/>,
+	/// usually with <see cref="ReadOnlySequence{T}.End"/> to indicate that the next msgpack structure has been consumed.
+	/// After that call, the caller must *not* read the buffer again as it will have been recycled.
+	/// </remarks>
+	public async ValueTask<ReadOnlySequence<byte>> ReadNextStructureAsync(SerializationContext context, CancellationToken cancellationToken)
+	{
+		while (true)
+		{
+			ReadResult readBuffer = await this.ReadAsync(cancellationToken).ConfigureAwait(false);
+			if (readBuffer.IsCanceled)
+			{
+				throw new OperationCanceledException();
+			}
+
+			if (TryRead(readBuffer.Buffer, context, out SequencePosition position))
+			{
+				return readBuffer.Buffer.Slice(0, position);
+			}
+			else
+			{
+				// Indicate that we haven't got enough buffer so that the next ReadAsync will guarantee us more.
+				this.AdvanceTo(readBuffer.Buffer.Start, readBuffer.Buffer.End);
+				if (readBuffer.IsCompleted)
+				{
+					throw new EndOfStreamException();
+				}
+			}
+		}
+
+		bool TryRead(ReadOnlySequence<byte> buffer, SerializationContext context, out SequencePosition position)
+		{
+			MessagePackReader msgpackReader = new(buffer);
+			bool result = msgpackReader.TrySkip(context);
+			position = msgpackReader.Position;
+			return result;
+		}
+	}
+
+	/// <summary>
+	/// Skips the next msgpack structure in the pipe.
+	/// </summary>
+	/// <param name="context">The serialization context.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A task that completes when done reading past the next msgpack structure.</returns>
+	public async ValueTask SkipAsync(SerializationContext context, CancellationToken cancellationToken)
+	{
+		while (true)
+		{
+			ReadResult readBuffer = await this.ReadAsync(cancellationToken).ConfigureAwait(false);
+			if (readBuffer.IsCanceled)
+			{
+				throw new OperationCanceledException();
+			}
+
+			if (TrySkip(readBuffer.Buffer, context, out SequencePosition newPosition))
+			{
+				this.AdvanceTo(newPosition);
+				return;
+			}
+			else
+			{
+				// Indicate that we haven't got enough buffer so that the next ReadAsync will guarantee us more.
+				this.AdvanceTo(readBuffer.Buffer.Start, readBuffer.Buffer.End);
+				if (readBuffer.IsCompleted)
+				{
+					throw new EndOfStreamException();
+				}
+			}
+		}
+
+		bool TrySkip(ReadOnlySequence<byte> buffer, SerializationContext context, out SequencePosition newPosition)
+		{
+			MessagePackReader msgpackReader = new(buffer);
+			if (msgpackReader.TrySkip(context))
+			{
+				newPosition = msgpackReader.Position;
+				return true;
+			}
+			else
+			{
+				newPosition = buffer.Start;
+				return false;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Follows up on a prior call to <see cref="ReadNextStructureAsync"/> to report some subset of the sequence as consumed.
+	/// </summary>
+	/// <param name="consumed">The position that was consumed. Should be <see cref="ReadOnlySequence{T}.End"/> on the value returned from <see cref="ReadNextStructureAsync"/> if the whole sequence was deserialize.</param>
+	public void AdvanceTo(SequencePosition consumed) => this.AdvanceTo(consumed, consumed);
+
+	/// <summary>
+	/// Follows up on a prior call to <see cref="ReadNextStructureAsync"/> to report some subset of the sequence as consumed.
+	/// </summary>
+	/// <param name="consumed">The position that was consumed. Should be <see cref="ReadOnlySequence{T}.End"/> on the value returned from <see cref="ReadNextStructureAsync"/> if the whole sequence was deserialize.</param>
+	/// <param name="examined">The position that was examined up to. Should always be no earlier in the sequence than <paramref name="consumed" />.</param>
+	public void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+	{
+		Verify.Operation(this.timeForAdvanceTo && this.lastReadResult.HasValue, "Call ReadAsync first.");
+		ReadResult lastReadResult = this.lastReadResult.Value;
+
+		if (lastReadResult.Buffer.End.Equals(examined))
+		{
+			// The caller has examined everything we have.
+			pipeReader.AdvanceTo(consumed, examined);
+			this.lastReadResult = null;
+		}
+		else
+		{
+			// We still have data left to read in our local buffer.
+			this.lastReadResult = new(lastReadResult.Buffer.Slice(consumed), lastReadResult.IsCanceled, lastReadResult.IsCompleted);
+		}
+
+		this.timeForAdvanceTo = false;
+	}
+
+	private async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken)
+	{
+		Verify.Operation(!this.timeForAdvanceTo, "Calls out of order. Call AdvanceTo first.");
+
+		// PipeReader.ReadAsync is *slow*.
+		// Only pull on the pipeReader if we don't already have a buffer to read from.
+		if (this.lastReadResult is not { Buffer.IsEmpty: false })
+		{
+			this.lastReadResult = await pipeReader.ReadAsync(cancellationToken).ConfigureAwait(false);
+		}
+
+		this.timeForAdvanceTo = true;
+		return this.lastReadResult.Value;
+	}
+}

--- a/src/Nerdbank.MessagePack/MessagePackAsyncWriter.cs
+++ b/src/Nerdbank.MessagePack/MessagePackAsyncWriter.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Pipelines;
+using Microsoft;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// A primitive types writer for the MessagePack format that writes to a <see cref="PipeWriter"/>.
+/// </summary>
+/// <param name="pipeWriter">The pipe writer to encode to.</param>
+/// <remarks>
+/// <para>
+/// This is an async capable and slower alternative to <see cref="MessagePackWriter"/> with fewer methods,
+/// making the sync version more generally useful.
+/// It is useful when implementing the async virtual methods on <see cref="MessagePackConverter{T}"/>.
+/// </para>
+/// <see href="https://github.com/msgpack/msgpack/blob/master/spec.md">The MessagePack spec.</see>.
+/// </remarks>
+[Experimental("NBMsgPackAsync")]
+public class MessagePackAsyncWriter(PipeWriter pipeWriter)
+{
+	private BufferMemoryWriter bufferWriter = new(pipeWriter);
+
+	/// <summary>
+	/// The delegate type that may be provided to the <see cref="Write{TState}(SyncWriter{TState}, TState)"/> method.
+	/// </summary>
+	/// <typeparam name="T">The type of state that may be given to the writer.</typeparam>
+	/// <param name="writer">The delegate to invoke to do the synchronous writing.</param>
+	/// <param name="state">The state to pass to the <paramref name="writer"/>.</param>
+	public delegate void SyncWriter<T>(ref MessagePackWriter writer, T state);
+
+	/// <summary>
+	/// Gets the fully-capable, synchronous writer.
+	/// </summary>
+	/// <returns>The writer.</returns>
+	/// <remarks>
+	/// The caller must take care to call <see cref="MessagePackWriter.Flush"/> before discarding the writer.
+	/// </remarks>
+	public MessagePackWriter CreateWriter()
+	{
+		return new(new BufferWriter(ref this.bufferWriter));
+	}
+
+	/// <summary>
+	/// Ensures everything previously written has been flushed to the underlying <see cref="IBufferWriter{T}"/>.
+	/// </summary>
+	public void Flush() => this.bufferWriter.Commit();
+
+	/// <summary>
+	/// Creates a sync writer for purposes of serializing a message.
+	/// </summary>
+	/// <typeparam name="TState">The type of state that may be given to the writer.</typeparam>
+	/// <param name="writer">The delegate to invoke to do the synchronous writing.</param>
+	/// <param name="state">State to pass to the writer.</param>
+	public void Write<TState>(SyncWriter<TState> writer, TState state)
+	{
+		Requires.NotNull(writer);
+
+		MessagePackWriter syncWriter = this.CreateWriter();
+		writer(ref syncWriter, state);
+		syncWriter.Flush();
+	}
+
+	/// <inheritdoc cref="MessagePackWriter.WriteNil"/>
+	public void WriteNil()
+	{
+		MessagePackWriter writer = this.CreateWriter();
+		writer.WriteNil();
+		writer.Flush();
+	}
+
+	/// <inheritdoc cref="MessagePackWriter.WriteArrayHeader(int)"/>
+	public void WriteArrayHeader(int count) => this.WriteArrayHeader(checked((uint)count));
+
+	/// <inheritdoc cref="MessagePackWriter.WriteArrayHeader(uint)"/>
+	public void WriteArrayHeader(uint count)
+	{
+		Span<byte> span = this.bufferWriter.GetSpan(5);
+		Assumes.True(MessagePackPrimitives.TryWriteArrayHeader(span, count, out int written));
+		this.bufferWriter.Advance(written);
+	}
+
+	/// <inheritdoc cref="MessagePackWriter.WriteMapHeader(int)"/>
+	public void WriteMapHeader(int count) => this.WriteMapHeader(checked((uint)count));
+
+	/// <inheritdoc cref="MessagePackWriter.WriteMapHeader(uint)"/>
+	public void WriteMapHeader(uint count)
+	{
+		Span<byte> span = this.bufferWriter.GetSpan(5);
+		Assumes.True(MessagePackPrimitives.TryWriteMapHeader(span, count, out int written));
+		this.bufferWriter.Advance(written);
+	}
+
+	/// <inheritdoc cref="MessagePackWriter.WriteRaw(ReadOnlySpan{byte})"/>
+	public void WriteRaw(ReadOnlySpan<byte> bytes)
+	{
+		MessagePackWriter writer = this.CreateWriter();
+		writer.WriteRaw(bytes);
+		writer.Flush();
+	}
+
+	/// <summary>
+	/// Flushes the pipe if the buffer is getting full.
+	/// </summary>
+	/// <param name="context">The serialization context.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A task to await before writing further.</returns>
+	public ValueTask FlushIfAppropriateAsync(SerializationContext context, CancellationToken cancellationToken)
+	{
+		if (this.IsTimeToFlush(context))
+		{
+			// We need to commit our own writer first or the PipeWriter may discard the buffer we've written to.
+			this.Flush();
+			return FlushAsync(pipeWriter, cancellationToken);
+		}
+		else
+		{
+			return default;
+		}
+
+		static async ValueTask FlushAsync(PipeWriter pipeWriter, CancellationToken cancellationToken)
+		{
+			FlushResult flushResult = await pipeWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+			if (flushResult.IsCanceled)
+			{
+				throw new OperationCanceledException();
+			}
+
+			if (flushResult.IsCompleted)
+			{
+				throw new EndOfStreamException("The receiver has stopped listening.");
+			}
+		}
+	}
+
+	/// <summary>
+	/// Gets a value indicating whether it is time to flush the pipe.
+	/// </summary>
+	/// <param name="context">The serialization context.</param>
+	/// <returns><see langword="true" /> if the pipe buffers are reaching their preferred capacity; <see langword="false" /> otherwise.</returns>
+	public bool IsTimeToFlush(SerializationContext context)
+	{
+		return pipeWriter.CanGetUnflushedBytes && pipeWriter.UnflushedBytes > context.UnflushedBytesThreshold;
+	}
+}

--- a/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
+++ b/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+using Microsoft;
+
 namespace Nerdbank.MessagePack;
 
 /// <summary>
@@ -9,6 +12,16 @@ namespace Nerdbank.MessagePack;
 /// <typeparam name="T">The data type that can be converted by this object.</typeparam>
 public abstract class MessagePackConverter<T> : IMessagePackConverter
 {
+	/// <summary>
+	/// Gets a value indicating whether callers should prefer the async methods on this object.
+	/// </summary>
+	/// <value>Unless overridden in a derived converter, this value is always <see langword="false"/>.</value>
+	/// <remarks>
+	/// Derived types that override the <see cref="SerializeAsync"/> and/or <see cref="DeserializeAsync"/> methods
+	/// should also override this property and have it return <see langword="true" />.
+	/// </remarks>
+	public virtual bool PreferAsyncSerialization => false;
+
 	/// <summary>
 	/// Serializes an instance of <typeparamref name="T"/>.
 	/// </summary>
@@ -24,6 +37,73 @@ public abstract class MessagePackConverter<T> : IMessagePackConverter
 	/// <param name="context">Context for the deserialization.</param>
 	/// <returns>The deserialized value.</returns>
 	public abstract T? Deserialize(ref MessagePackReader reader, SerializationContext context);
+
+	/// <summary>
+	/// Serializes an instance of <typeparamref name="T"/>.
+	/// </summary>
+	/// <param name="writer">The writer to use.</param>
+	/// <param name="value">The value to serialize.</param>
+	/// <param name="context">Context for the serialization.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A task that tracks the async serialization.</returns>
+	/// <remarks>
+	/// <para>
+	/// The default implementation delegates to <see cref="Serialize"/> and then flushes the data to the pipe
+	/// if the buffers are getting relatively full.
+	/// </para>
+	/// <para>
+	/// Derived classes should only override this method if they may write a lot of data.
+	/// They should do so with the intent of writing fragments of data at a time and periodically call
+	/// <see cref="MessagePackAsyncWriter.FlushIfAppropriateAsync"/>
+	/// in order to keep the size of memory buffers from growing too much.
+	/// </para>
+	/// </remarks>
+	[Experimental("NBMsgPackAsync")]
+	public virtual ValueTask SerializeAsync(MessagePackAsyncWriter writer, T? value, SerializationContext context, CancellationToken cancellationToken)
+	{
+		Requires.NotNull(writer);
+		cancellationToken.ThrowIfCancellationRequested();
+
+		MessagePackWriter syncWriter = writer.CreateWriter();
+		this.Serialize(ref syncWriter, ref value, context);
+		syncWriter.Flush();
+
+		// On our way out, pause to flush the pipe if a lot of data has accumulated in the buffer.
+		return writer.FlushIfAppropriateAsync(context, cancellationToken);
+	}
+
+	/// <summary>
+	/// Deserializes an instance of <typeparamref name="T"/>.
+	/// </summary>
+	/// <param name="reader">The reader to use.</param>
+	/// <param name="context">Context for the deserialization.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>The deserialized value.</returns>
+	/// <remarks>
+	/// <para>The default implementation delegates to <see cref="Deserialize"/> after ensuring there is sufficient buffer to read the next structure.</para>
+	/// <para>
+	/// Derived classes should only override this method if they may read a lot of data.
+	/// They should do so with the intent to be able to read some data then asynchronously wait for data before reading more
+	/// in order to reduce the amount of memory required to buffer.
+	/// </para>
+	/// </remarks>
+	[Experimental("NBMsgPackAsync")]
+	public virtual async ValueTask<T?> DeserializeAsync(MessagePackAsyncReader reader, SerializationContext context, CancellationToken cancellationToken)
+	{
+		Requires.NotNull(reader);
+		cancellationToken.ThrowIfCancellationRequested();
+
+		ReadOnlySequence<byte> buffer = await reader.ReadNextStructureAsync(context, cancellationToken).ConfigureAwait(false);
+		T? result = Deserialize(buffer, context);
+		reader.AdvanceTo(buffer.End);
+		return result;
+
+		T? Deserialize(ReadOnlySequence<byte> buffer, SerializationContext context)
+		{
+			MessagePackReader msgpackReader = new(buffer);
+			return this.Deserialize(ref msgpackReader, context);
+		}
+	}
 
 	/// <inheritdoc/>
 	void IMessagePackConverter.Serialize(ref MessagePackWriter writer, ref object? value, SerializationContext context)

--- a/src/Nerdbank.MessagePack/Nerdbank.MessagePack.csproj
+++ b/src/Nerdbank.MessagePack/Nerdbank.MessagePack.csproj
@@ -16,6 +16,10 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>IntConverters.cs</LastGenOutput>
     </None>
+    <None Update="MessagePackPrimitives.Readers.Integers.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>MessagePackPrimitives.Readers.Integers.cs</LastGenOutput>
+    </None>
     <None Update="MessagePackReader.Integers.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>MessagePackReader.Integers.cs</LastGenOutput>
@@ -40,6 +44,11 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>IntConverters.tt</DependentUpon>
+    </Compile>
+    <Compile Update="MessagePackPrimitives.Readers.Integers.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>MessagePackPrimitives.Readers.Integers.tt</DependentUpon>
     </Compile>
     <Compile Update="MessagePackReader.Integers.cs">
       <DesignTime>True</DesignTime>

--- a/src/Nerdbank.MessagePack/SerializationContext.cs
+++ b/src/Nerdbank.MessagePack/SerializationContext.cs
@@ -29,6 +29,12 @@ public struct SerializationContext
 	public int MaxDepth { get; set; } = 64;
 
 	/// <summary>
+	/// Gets a hint as to the number of bytes to write into the buffer before serialization will flush the output.
+	/// </summary>
+	/// <value>The default value is 64KB.</value>
+	public int UnflushedBytesThreshold { get; init; } = 64 * 1024;
+
+	/// <summary>
 	/// Decrements the depth remaining.
 	/// </summary>
 	/// <remarks>

--- a/test/Benchmarks/SyncVsAsyncArrays.cs
+++ b/test/Benchmarks/SyncVsAsyncArrays.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Pipelines;
+using static Data;
+
+public class SyncVsAsyncArrays
+{
+	private readonly MessagePackSerializer serializer = new();
+	private readonly Sequence<byte> syncBuffer = new();
+	private Pipe pipe = new();
+
+	[Benchmark]
+	public void Sync_Serialize()
+	{
+		this.serializer.Serialize(this.syncBuffer, PocoArray);
+		this.syncBuffer.Reset();
+	}
+
+	[Benchmark]
+	public void Sync_Deserialize()
+	{
+		PocoClass? result = this.serializer.Deserialize<PocoClass>(PocoArrayMsgpack);
+	}
+
+	[Benchmark]
+	public async Task Async_Serialize()
+	{
+		await this.serializer.SerializeAsync(this.pipe.Writer, PocoArray, default);
+
+		this.pipe.Writer.Complete();
+		this.pipe.Reader.Complete();
+		this.pipe.Reset();
+	}
+
+	[Benchmark]
+	public async ValueTask Async_Deserialize()
+	{
+		// Setup.
+		this.pipe.Writer.Write(PocoArrayMsgpack);
+		await this.pipe.Writer.FlushAsync();
+
+		PocoClass? result = await this.serializer.DeserializeAsync<PocoClass>(this.pipe.Reader, default);
+	}
+}

--- a/test/Benchmarks/SyncVsAsyncPoco.cs
+++ b/test/Benchmarks/SyncVsAsyncPoco.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Pipelines;
+using static Data;
+
+public class SyncVsAsyncPoco
+{
+	private readonly MessagePackSerializer serializer = new();
+	private readonly Sequence<byte> syncBuffer = new();
+	private readonly PipeWriter nullPipeWriter = PipeWriter.Create(Stream.Null);
+	private Pipe pipe = new();
+
+	[Benchmark]
+	public void Sync_Serialize()
+	{
+		this.serializer.Serialize(this.syncBuffer, Poco);
+		this.syncBuffer.Reset();
+	}
+
+	[Benchmark]
+	public void Sync_Deserialize()
+	{
+		PocoClass? result = this.serializer.Deserialize<PocoClass>(PocoMsgpack);
+	}
+
+	[Benchmark]
+	public async Task Async_Serialize()
+	{
+		await this.serializer.SerializeAsync(this.nullPipeWriter, Poco, default);
+	}
+
+	[Benchmark]
+	public async ValueTask Async_Deserialize()
+	{
+		// Setup.
+		this.pipe.Writer.Write(PocoMsgpack);
+		await this.pipe.Writer.FlushAsync();
+
+		PocoClass? result = await this.serializer.DeserializeAsync<PocoClass>(this.pipe.Reader, default);
+	}
+}

--- a/test/Nerdbank.MessagePack.Tests/AsyncSerializationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/AsyncSerializationTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public partial class AsyncSerializationTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	[Fact]
+	public async Task RoundtripPoco() => await this.AssertRoundtripAsync(new Poco(1, 2));
+
+	[Fact]
+	public async Task RoundtripPocoWithDefaultCtor() => await this.AssertRoundtripAsync(new PocoWithDefaultCtor { X = 1, Y = 2 });
+
+	[Fact]
+	public async Task LargeArray() => await this.AssertRoundtripAsync(new ArrayOfPocos(Enumerable.Range(0, 1000).Select(i => new Poco(i, i)).ToArray()));
+
+	[Fact]
+	public async Task Null_Array() => await this.AssertRoundtripAsync(new ArrayOfPocos(null));
+
+	[Fact]
+	public async Task Null() => await this.AssertRoundtripAsync<Poco>(null);
+
+	[Fact]
+	public async Task ArrayOfInts() => await this.AssertRoundtripAsync(new ArrayOfPrimitives([1, 2, 3]));
+
+	[Fact]
+	public async Task ObjectAsArrayOfValues() => await this.AssertRoundtripAsync(new PocoAsArray(42));
+
+	[Fact]
+	public async Task ObjectAsArrayOfValues_Null() => await this.AssertRoundtripAsync<PocoAsArray>(null);
+
+	[Fact]
+	public async Task ObjectAsArrayOfValues_DefaultCtor() => await this.AssertRoundtripAsync(new PocoAsArrayWithDefaultCtor { Value = 42 });
+
+	[Fact]
+	public async Task ObjectAsArrayOfValues_DefaultCtor_Null() => await this.AssertRoundtripAsync<PocoAsArrayWithDefaultCtor>(null);
+
+	[GenerateShape]
+	public partial record Poco(int X, int Y);
+
+	[GenerateShape]
+	public partial record PocoWithDefaultCtor
+	{
+		public int X { get; set; }
+
+		public int Y { get; set; }
+	}
+
+	[GenerateShape]
+	public partial class ArrayOfPocos(Poco[]? pocos) : IEquatable<ArrayOfPocos>
+	{
+		public Poco[]? Pocos => pocos;
+
+		public bool Equals(ArrayOfPocos? other) => other is not null && ByValueEquality.Equal(this.Pocos, other.Pocos);
+	}
+
+	[GenerateShape]
+	public partial class ArrayOfPrimitives(int[]? values) : IEquatable<ArrayOfPrimitives>
+	{
+		public int[]? Values => values;
+
+		public bool Equals(ArrayOfPrimitives? other) => other is not null && ByValueEquality.Equal(this.Values, other.Values);
+	}
+
+	[GenerateShape]
+	public partial record PocoAsArray([property: Key(0)] int Value);
+
+	[GenerateShape]
+	public partial record PocoAsArrayWithDefaultCtor
+	{
+		[Key(0)]
+		public int Value { get; set; }
+	}
+}


### PR DESCRIPTION
The mechanics of how it works is protected by `[Experimental]` attributes since it may be up for massive changes as we learn how to do this in a performant and usable way for Converter authors.
 
Perf comparisons have some really disappointing surprises but also some encouraging numbers.

## Arrays

| Method            | Mean      | Error    | StdDev   |
|------------------ |----------:|---------:|---------:|
| Sync_Serialize    |  72.25 μs | 0.146 μs | 0.129 μs |
| Sync_Deserialize  |  43.20 μs | 0.201 μs | 0.178 μs |
| Async_Serialize   | 209.77 μs | 0.597 μs | 0.559 μs |
| Async_Deserialize |  45.01 μs | 0.223 μs | 0.208 μs |

## Poco

| Method            | Mean       | Error   | StdDev  |
|------------------ |-----------:|--------:|--------:|
| Sync_Serialize    |   168.6 ns | 0.79 ns | 0.74 ns |
| Sync_Deserialize  |   172.1 ns | 0.38 ns | 0.36 ns |
| Async_Serialize   |   283.2 ns | 1.26 ns | 1.12 ns |
| Async_Deserialize | 1,468.1 ns | 4.40 ns | 3.90 ns |
