### PR TITLE
Fix `InvalidCastException` when union subtypes implement `IEnumerable`

### DIFF
--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -213,6 +213,9 @@ public record MessagePackSerializer
 	/// <returns>The deserialized value.</returns>
 	public T? Deserialize<T>(ref MessagePackReader reader, ITypeShape<T> shape) => this.GetOrAddConverter(shape).Deserialize(ref reader, this.StartingContext);
 
+	/// <inheritdoc cref="ConvertToJson(in ReadOnlySequence{byte})"/>
+	public static string ConvertToJson(ReadOnlyMemory<byte> msgpack) => ConvertToJson(new ReadOnlySequence<byte>(msgpack));
+
 	/// <summary>
 	/// Converts a msgpack sequence into equivalent JSON.
 	/// </summary>

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Frozen;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Nerdbank.MessagePack;
@@ -319,7 +318,7 @@ internal class StandardVisitor(MessagePackSerializer owner) : TypeShapeVisitor, 
 		Dictionary<Type, (int Alias, IMessagePackConverter Converter)> serializerData = new();
 		foreach (KnownSubTypeAttribute unionAttribute in unionAttributes)
 		{
-			IObjectTypeShape? subtypeShape = (IObjectTypeShape?)objectShape.Provider.GetShape(unionAttribute.SubType);
+			ITypeShape? subtypeShape = objectShape.Provider.GetShape(unionAttribute.SubType);
 			if (subtypeShape is null)
 			{
 				throw new InvalidOperationException($"The type {objectShape.Type.FullName} has a union attribute that references a type that is not known to the serializer: {unionAttribute.SubType.FullName}.");

--- a/test/Nerdbank.MessagePack.Tests/KnownSubTypeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/KnownSubTypeTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-public partial class UnionTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+public partial class KnownSubTypeTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
 {
 	[Fact]
 	public void BaseType()
@@ -40,10 +40,19 @@ public partial class UnionTests(ITestOutputHelper logger) : MessagePackSerialize
 	[Fact]
 	public void DerivedB_AsBaseType() => this.AssertRoundtrip<BaseClass>(new DerivedB(10) { BaseClassProperty = 5 });
 
+	[Fact]
+	public void EnumerableDerived_BaseType()
+	{
+		EnumerableDerived value = new(3) { BaseClassProperty = 5 };
+		byte[] msgpack = this.Serializer.Serialize(value);
+		this.Logger.WriteLine(MessagePackSerializer.ConvertToJson(msgpack));
+	}
+
 	[GenerateShape]
 	[KnownSubType(1, typeof(DerivedA))]
 	[KnownSubType(2, typeof(DerivedAA))]
 	[KnownSubType(3, typeof(DerivedB))]
+	[KnownSubType(4, typeof(EnumerableDerived))]
 	public partial record BaseClass
 	{
 		public int BaseClassProperty { get; set; }
@@ -63,5 +72,13 @@ public partial class UnionTests(ITestOutputHelper logger) : MessagePackSerialize
 	[GenerateShape]
 	public partial record DerivedB(int DerivedBProperty) : BaseClass
 	{
+	}
+
+	[GenerateShape]
+	public partial record EnumerableDerived(int Count) : BaseClass, IEnumerable<int>
+	{
+		public IEnumerator<int> GetEnumerator() => Enumerable.Range(0, this.Count).GetEnumerator();
+
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
 	}
 }


### PR DESCRIPTION
Fixes [the bug @eiriktsarpalis predicted](https://github.com/AArnott/Nerdbank.MessagePack/pull/5#discussion_r1825721992).