### PR TITLE
Add support for inflating pre-created collections in the deserializer

### DIFF
--- a/docfx/docs/custom-converters.md
+++ b/docfx/docs/custom-converters.md
@@ -119,6 +119,17 @@ The built-in converters take special considerations to avoid allocating, encodin
 This reduces GC pressure and removes redundant CPU time spent repeatedly converting UTF-8 encoded property names as strings.
 Your custom converters *may* follow similar patterns if tuning performance for your particular type's serialization is important.
 
+### Async converters
+
+@Nerdbank.MessagePack.MessagePackConverter`1 is an abstract class that requires a derived converter to implement synchronous @Nerdbank.MessagePack.MessagePackConverter`1.Serialize* and @Nerdbank.MessagePack.MessagePackConverter`1.Deserialize* methods.
+The base class also declares `virtual` async alternatives to these methods (@Nerdbank.MessagePack.MessagePackConverter`1.SerializeAsync* and @Nerdbank.MessagePack.MessagePackConverter`1.DeserializeAsync*, respectively) which a derived class may *optionally* override.
+These default async implementations are correct, and essentially buffer the whole msgpack representation while deferring the actual serialization work to the synchronous methods.
+
+For types that may represent a great deal of data (e.g. arrays and maps), overriding the async methods in order to read or flush msgpack in smaller portions may reduce memory pressure and/or improve performance.
+When a derived type overrides the async methods, it should also override @Nerdbank.MessagePack.MessagePackConverter`1.PreferAsyncSerialization to return `true` so that callers know that you have optimized async paths.
+
+The built-in converters, including those that serialize your custom data types by default, already override the async methods with optimal implementations.
+
 ## Register your custom converter
 
 Register an instance of your custom converter with an instance of @Nerdbank.MessagePack.MessagePackSerializer using the @Nerdbank.MessagePack.MessagePackSerializer.RegisterConverter*.

--- a/docfx/docs/security.md
+++ b/docfx/docs/security.md
@@ -42,3 +42,27 @@ Doing so dramatically increases the cost to the attacker to carry out this attac
 > They must come from your own code or a library with cryptographic hash functions.
 
 This library does not (yet) have the capability to create collections during deserialization that have collision resistant hash functions, due to [a limitation in TypeShape](https://github.com/eiriktsarpalis/typeshape-csharp/issues/33), which it depends on.
+
+Instead, you can provide your own defense by initializing your collections with a collision resistant implementation of @System.Collections.Generic.IEqualityComparer`1 in your data type's constructor.
+
+> [!NOTE]
+> Hash collision resistance has no impact on the serialized data itself.
+> A program may defend itself against hash collision attacks without breaking interoperability with other parties that they exchange data with.
+
+Here is an example of a defense against hash collisions:
+
+```cs
+[GenerateShape]
+public partial class HashCollisionResistance : IEquatable<HashCollisionResistance>
+{
+    public HashCollisionResistance()
+    {
+        this.Dictionary = new(SipHashEqualityComparer<CustomType>.Default);
+        this.HashSet = new(SipHashEqualityComparer<CustomType>.Default);
+    }
+
+    public Dictionary<CustomType, string> Dictionary { get; }
+
+    public HashSet<CustomType> HashSet { get; }
+}
+```

--- a/src/Nerdbank.MessagePack/IDeserializeInto`1.cs
+++ b/src/Nerdbank.MessagePack/IDeserializeInto`1.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// An interface that may be optionally implemented by a <see cref="MessagePackConverter{T}"/> to support deserializing into an existing collection instance.
+/// </summary>
+/// <typeparam name="TCollectionType">The concrete collection type supported by the converter.</typeparam>
+/// <remarks>
+/// This enables the scenario of a user type that declares a read-only property of a mutable collection type,
+/// such that the deserializer can only add elements to the existing collection rather than creating a new collection.
+/// </remarks>
+internal interface IDeserializeInto<TCollectionType>
+{
+	/// <summary>
+	/// Deserializes a collection into an existing collection instance.
+	/// </summary>
+	/// <param name="reader">The reader to deserialize from.</param>
+	/// <param name="collection">The collection instance to inflate with elements.</param>
+	/// <param name="context">The deserialization context.</param>
+	/// <remarks>
+	/// Implementations may assume that the messagepack token is not <see cref="MessagePackCode.Nil"/>.
+	/// </remarks>
+	void DeserializeInto(ref MessagePackReader reader, ref TCollectionType collection, SerializationContext context);
+
+	/// <summary>
+	/// Deserializes a collection into an existing collection instance.
+	/// </summary>
+	/// <param name="reader">The reader to deserialize from.</param>
+	/// <param name="collection">The collection instance to inflate with elements.</param>
+	/// <param name="context">The deserialization context.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A task that tracks the async operation.</returns>
+	/// <remarks>
+	/// Implementations may assume that the messagepack token is not <see cref="MessagePackCode.Nil"/>.
+	/// </remarks>
+	[Experimental("NBMsgPackAsync")]
+	ValueTask DeserializeIntoAsync(MessagePackAsyncReader reader, TCollectionType collection, SerializationContext context, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
This provides an opportunity for the user to apply a collision resistant hash function for keyed collections, even while TypeShape does not yet support creating such collections automatically.