### PR TITLE
Use TypeShape.Roslyn in analyzer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.79" />
     <PackageVersion Include="PolySharp" Version="1.14.1" />
     <PackageVersion Include="typeshape-csharp" Version="0.14.1" />
+    <PackageVersion Include="TypeShape.Roslyn" Version="0.14.1" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/src/Nerdbank.MessagePack.Analyzers/KeyAttributeUseAnalyzer.cs
+++ b/src/Nerdbank.MessagePack.Analyzers/KeyAttributeUseAnalyzer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using TypeShape.Roslyn;
+
 namespace Nerdbank.MessagePack.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -50,6 +52,13 @@ public class KeyAttributeUseAnalyzer : DiagnosticAnalyzer
 
 		context.RegisterCompilationStartAction(context =>
 		{
+			TypeShape.Roslyn.KnownSymbols typeShapeSymbols = new(context.Compilation);
+			TypeDataModelGenerator typeDataModelGenerator = new(context.Compilation.Assembly, typeShapeSymbols, context.CancellationToken);
+			foreach (var model in typeDataModelGenerator.GeneratedModels)
+			{
+
+			}
+
 			if (!ReferenceSymbols.TryCreate(context.Compilation, out ReferenceSymbols? referenceSymbols))
 			{
 				return;

--- a/src/Nerdbank.MessagePack.Analyzers/Nerdbank.MessagePack.Analyzers.csproj
+++ b/src/Nerdbank.MessagePack.Analyzers/Nerdbank.MessagePack.Analyzers.csproj
@@ -4,6 +4,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="PolySharp" PrivateAssets="all" />
+    <PackageReference Include="TypeShape.Roslyn" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nerdbank.MessagePack/Nerdbank.MessagePack.csproj
+++ b/src/Nerdbank.MessagePack/Nerdbank.MessagePack.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <Target Name="PackAnalyzers" DependsOnTargets="ResolveProjectReferences;DebugSymbolsProjectOutputGroup">
     <ItemGroup>
+      <!-- Add TypeShape.Roslyn.dll -->
       <TfmSpecificPackageFile Include="%(AnalyzerAssembly.Identity)" PackagePath="analyzers\cs\" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
The TypeShape.Roslyn.dll provides some analysis that we should avoid repeating and trying to keep in sync with TypeShape policies.