### PR TITLE
Add `NBMsgPack031` analyzer for =1 structure being read/written in a custom converter

### DIFF
--- a/docfx/analyzers/NBMsgPack030.md
+++ b/docfx/analyzers/NBMsgPack030.md
@@ -6,6 +6,8 @@ Such calls risk resetting the stack guard, unnecessary cache misses, etc.
 A custom converter will often find itself in a situation where the type it is serializing is made up of sub-values that themselves can be serialized automatically, without a custom converter.
 In such cases, @Nerdbank.MessagePack.SerializationContext.GetConverter*?displayProperty=nameWithType is the appropriate tool to delegate conversion of these sub-values.
 
+[Learn more about custom converters](../docs/custom-converters.md).
+
 ## Example violations
 
 ```cs

--- a/docfx/analyzers/NBMsgPack031.md
+++ b/docfx/analyzers/NBMsgPack031.md
@@ -1,0 +1,94 @@
+# NBMsgPack031: Converters should read or write exactly one msgpack structure
+
+A value must be serialized with exactly one msgpack structure, whether that is a scalar value like an integer, or a vector like an array or a map.
+If there is nothing to write, you may write an empty array header.
+If there is more than one value to write, lead with an array header that exactly predicts the number of values that will follow.
+
+## Example violations
+
+The following converter reads and writes two distinct values, which is not allowed.
+
+```cs
+public class MyTypeConverter : MessagePackConverter<MyType>
+{
+    public override MyType Deserialize(ref MessagePackReader reader, SerializationContext context)
+    {
+        reader.ReadInt32();
+        reader.ReadInt16();  // NBMsgPack031
+        return new MyType();
+    }
+
+    public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+    {
+        writer.Write(1);
+        writer.Write(2);  // NBMsgPack031
+    }
+}
+```
+
+## Resolution
+
+When multiple values need to be serialized, always start with an array or map header.
+
+When deserializing, always deserialize exactly the prescribed number of elements even if they do not match the expected count.
+Or throw if the converter cannot successfully deserialize the value with the actual number of elements.
+
+In the following example, the deserializer throws if it does not encounter exactly two elements.
+
+```cs
+public class MyTypeConverter : MessagePackConverter<MyType>
+{
+    public override MyType Deserialize(ref MessagePackReader reader, SerializationContext context)
+    {
+        int count = reader.ReadArrayHeader();
+        if (count != 2)
+        {
+            throw new MessagePackSerializationException("Expected 2 elements.");
+        }
+
+        int property1 = reader.ReadInt32();
+        short property2 = reader.ReadInt16();
+        return new MyType(property1, property2);
+    }
+
+    public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+    {
+        writer.WriteArrayHeader(2);
+        writer.Write(value.Property1);
+        writer.Write(value.Property2);
+    }
+}
+```
+
+In this next example, the deserializer is flexible to forward/backward compatibility by reading any number of elements, and uses default values if fewer than 2 are encountered:
+
+```cs
+public override MyType Deserialize(ref MessagePackReader reader, SerializationContext context)
+{
+    int count = reader.ReadArrayHeader();
+
+    // Initialize default values in case the array has fewer than 2 elements.
+    int property1 = 0;
+    short property2 = 0;
+
+    for (int i = 0; i < count; i++)
+    {
+        switch (i)
+        {
+            case 0:
+                property1 = reader.ReadInt32();
+                break;
+            case 1:
+                property2 = reader.ReadInt16();
+                break;
+            default:
+                // Very important that we read elements in the array belonging to this object even if we don't know what to do with them.
+                // Calling Skip() is a way to read and drop the element without knowing what kind it is.
+                reader.Skip();
+                break;
+        }
+    }
+
+    return new MyType(property1, property2);
+}
+```

--- a/docfx/analyzers/index.md
+++ b/docfx/analyzers/index.md
@@ -17,3 +17,4 @@ Rule ID | Category | Severity | Notes
 [NBMsgPack020](NBMsgPack020.md) | Usage | Error | `[MessagePackConverter]` type must be compatible converter
 [NBMsgPack021](NBMsgPack021.md) | Usage | Error | `[MessagePackConverter]` type missing default constructor
 [NBMsgPack030](NBMsgPack030.md) | Usage | Warning | Converters should not call top-level `MessagePackSerializer` methods
+[NBMsgPack031](NBMsgPack031.md) | Usage | Warning | Converters should read or write exactly one msgpack structure

--- a/docfx/analyzers/toc.yml
+++ b/docfx/analyzers/toc.yml
@@ -20,3 +20,5 @@
   href: NBMsgPack021.md
 - name: NBMsgPack030
   href: NBMsgPack030.md
+- name: NBMsgPack031
+  href: NBMsgPack031.md

--- a/src/Nerdbank.MessagePack.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Nerdbank.MessagePack.Analyzers/AnalyzerReleases.Unshipped.md
@@ -15,3 +15,4 @@ NBMsgPack013 | Usage | Error | `[KnownSubType]` type must not be an open generic
 NBMsgPack020 | Usage | Error | `[MessagePackConverter]` type must be compatible converter
 NBMsgPack021 | Usage | Error | `[MessagePackConverter]` type missing default constructor
 NBMsgPack030 | Usage | Warning | Converters should not call top-level `MessagePackSerializer` methods
+NBMsgPack031 | Usage | Warning | Converters should read or write exactly one msgpack structure

--- a/src/Nerdbank.MessagePack.Analyzers/ConverterAnalyzers.cs
+++ b/src/Nerdbank.MessagePack.Analyzers/ConverterAnalyzers.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Nerdbank.MessagePack.Analyzers;
@@ -9,6 +12,7 @@ namespace Nerdbank.MessagePack.Analyzers;
 public class ConverterAnalyzers : DiagnosticAnalyzer
 {
 	public const string CallbackToTopLevelSerializerDiagnosticId = "NBMsgPack030";
+	public const string NotExactlyOneStructureDiagnosticId = "NBMsgPack031";
 
 	public static readonly DiagnosticDescriptor CallbackToTopLevelSerializerDescriptor = new(
 		CallbackToTopLevelSerializerDiagnosticId,
@@ -18,8 +22,17 @@ public class ConverterAnalyzers : DiagnosticAnalyzer
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true);
 
+	public static readonly DiagnosticDescriptor NotExactlyOneStructureDescriptor = new(
+		NotExactlyOneStructureDiagnosticId,
+		title: Strings.NBMsgPack031_Title,
+		messageFormat: Strings.NBMsgPack031_MessageFormat,
+		category: "Usage",
+		defaultSeverity: DiagnosticSeverity.Warning,
+		isEnabledByDefault: true);
+
 	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [
 		CallbackToTopLevelSerializerDescriptor,
+		NotExactlyOneStructureDescriptor,
 	];
 
 	public override void Initialize(AnalysisContext context)
@@ -67,10 +80,135 @@ public class ConverterAnalyzers : DiagnosticAnalyzer
 								},
 								OperationKind.ObjectCreation,
 								OperationKind.Invocation);
+
+							context.RegisterOperationBlockEndAction(context => this.AnalyzeStructureCounts(context, referenceSymbols));
 						});
 					}
 				},
 				SymbolKind.NamedType);
 		});
+	}
+
+	private void AnalyzeStructureCounts(OperationBlockAnalysisContext context, ReferenceSymbols referenceSymbols)
+	{
+		if (context.OwningSymbol is not IMethodSymbol { IsOverride: true } method)
+		{
+			return;
+		}
+
+		int? GetVariableImpact(IInvocationOperation invocation) => invocation.Arguments.Length > 0 && invocation.Arguments[0].Value is ILiteralOperation { ConstantValue.Value: int count } ? -count : null;
+
+		INamedTypeSymbol applicableStruct;
+		Func<IInvocationOperation, (int? Impact, bool Unconditional)> relevantMethodTest;
+		switch (method.Name)
+		{
+			case "Serialize":
+				applicableStruct = referenceSymbols.MessagePackWriter;
+				relevantMethodTest = i => i.TargetMethod.Name switch
+				{
+					"WriteArrayHeader" => (1 + GetVariableImpact(i), true),
+					"WriteMapHeader" => (1 + (GetVariableImpact(i) * 2), true),
+					string t when t.StartsWith("Write", StringComparison.Ordinal) => (1, true),
+					_ => (0, true),
+				};
+				break;
+			case "Deserialize":
+				applicableStruct = referenceSymbols.MessagePackReader;
+				relevantMethodTest = i => i.TargetMethod.Name switch
+				{
+					"ReadArrayHeader" or "ReadMapHeader" => (null, true), // Advanced case, which we'll just assume they're doing correctly.
+					"TryReadArrayHeader" or "TryReadMapHeader" => (null, false), // Advanced case, which we'll just assume they're doing correctly.
+					"TryReadNil" => (1, false),
+					string t when t.StartsWith("Read", StringComparison.Ordinal) => (1, true),
+					_ => (0, true),
+				};
+				break;
+			default:
+				return;
+		}
+
+		foreach (IOperation block in context.OperationBlocks)
+		{
+			Debug.Assert(context.OperationBlocks.Length == 1, $"{context.OperationBlocks.Length} == 1");
+			ControlFlowGraph flow = context.GetControlFlowGraph(block);
+			if (flow.Blocks[0].FallThroughSuccessor?.Destination is { } initialBlock)
+			{
+				VisitBlock(initialBlock, 0, ImmutableHashSet<BasicBlock>.Empty);
+			}
+
+			void VisitBlock(BasicBlock basicBlock, int ops, ImmutableHashSet<BasicBlock> recursionGuard)
+			{
+				if (recursionGuard.Contains(basicBlock))
+				{
+					return;
+				}
+
+				recursionGuard = recursionGuard.Add(basicBlock);
+
+				foreach (IOperation op in basicBlock.Operations.SelectMany(op => op.DescendantsAndSelf()))
+				{
+					if (op is IInvocationOperation invocation)
+					{
+						if (SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingSymbol, applicableStruct))
+						{
+							(int? impact, bool unconditional) = relevantMethodTest(invocation);
+							if (impact.HasValue)
+							{
+								if (!unconditional)
+								{
+									// The code doesn't care whether it is actually reading a token or not, which is a bug.
+									context.ReportDiagnostic(Diagnostic.Create(NotExactlyOneStructureDescriptor, op.Syntax.GetLocation()));
+									return;
+								}
+
+								ops += impact.Value;
+								if (ops > 1)
+								{
+									// Too many structures.
+									context.ReportDiagnostic(Diagnostic.Create(NotExactlyOneStructureDescriptor, op.Syntax.GetLocation()));
+									return;
+								}
+							}
+							else
+							{
+								// Non-deterministic situation. Skip testing.
+								return;
+							}
+						}
+					}
+				}
+
+				if (ops < 1 && basicBlock.Kind == BasicBlockKind.Exit)
+				{
+					// Insufficient structures.
+					// Ideally the location should be the path that led to this point.
+					Location location = ((MethodDeclarationSyntax)method.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken)).Identifier.GetLocation();
+					context.ReportDiagnostic(Diagnostic.Create(NotExactlyOneStructureDescriptor, location));
+					return;
+				}
+
+				int? branchValueImpact = 0;
+				bool branchValueUnconditional = true;
+				if (basicBlock.BranchValue is IInvocationOperation conditionInvocation)
+				{
+					(branchValueImpact, branchValueUnconditional) = relevantMethodTest(conditionInvocation);
+				}
+
+				if (branchValueImpact is null)
+				{
+					return;
+				}
+
+				if (basicBlock.FallThroughSuccessor?.Destination is BasicBlock nextBlock)
+				{
+					VisitBlock(nextBlock, basicBlock.ConditionKind == ControlFlowConditionKind.WhenFalse || branchValueUnconditional ? ops + branchValueImpact.Value : ops, recursionGuard);
+				}
+
+				if (basicBlock.ConditionalSuccessor?.Destination is BasicBlock conditionalBlock)
+				{
+					VisitBlock(conditionalBlock, basicBlock.ConditionKind == ControlFlowConditionKind.WhenTrue || branchValueUnconditional ? ops + branchValueImpact.Value : ops, recursionGuard);
+				}
+			}
+		}
 	}
 }

--- a/src/Nerdbank.MessagePack.Analyzers/ReferenceSymbols.cs
+++ b/src/Nerdbank.MessagePack.Analyzers/ReferenceSymbols.cs
@@ -9,6 +9,8 @@ internal record ReferenceSymbols(
 	INamedTypeSymbol MessagePackSerializer,
 	INamedTypeSymbol MessagePackConverter,
 	INamedTypeSymbol MessagePackConverterAttribute,
+	INamedTypeSymbol MessagePackReader,
+	INamedTypeSymbol MessagePackWriter,
 	INamedTypeSymbol KeyAttribute,
 	INamedTypeSymbol KnownSubTypeAttribute,
 	INamedTypeSymbol PropertyShapeAttribute)
@@ -42,6 +44,20 @@ internal record ReferenceSymbols(
 			return false;
 		}
 
+		INamedTypeSymbol? messagePackReader = compilation.GetTypeByMetadataName("Nerdbank.MessagePack.MessagePackReader");
+		if (messagePackReader is null)
+		{
+			referenceSymbols = null;
+			return false;
+		}
+
+		INamedTypeSymbol? messagePackWriter = compilation.GetTypeByMetadataName("Nerdbank.MessagePack.MessagePackWriter");
+		if (messagePackWriter is null)
+		{
+			referenceSymbols = null;
+			return false;
+		}
+
 		INamedTypeSymbol? keyAttribute = compilation.GetTypeByMetadataName("Nerdbank.MessagePack.KeyAttribute");
 		if (keyAttribute is null)
 		{
@@ -63,7 +79,15 @@ internal record ReferenceSymbols(
 			return false;
 		}
 
-		referenceSymbols = new ReferenceSymbols(messagePackSerializer, messagePackConverter, messagePackConverterAttribute, keyAttribute, knownSubTypeAttribute, propertyShapeAttribute);
+		referenceSymbols = new ReferenceSymbols(
+			messagePackSerializer,
+			messagePackConverter,
+			messagePackConverterAttribute,
+			messagePackReader,
+			messagePackWriter,
+			keyAttribute,
+			knownSubTypeAttribute,
+			propertyShapeAttribute);
 		return true;
 	}
 }

--- a/src/Nerdbank.MessagePack.Analyzers/ReferenceSymbols.cs
+++ b/src/Nerdbank.MessagePack.Analyzers/ReferenceSymbols.cs
@@ -15,6 +15,8 @@ internal record ReferenceSymbols(
 	INamedTypeSymbol KnownSubTypeAttribute,
 	INamedTypeSymbol PropertyShapeAttribute)
 {
+	public INamedTypeSymbol MessagePackConverterUnbound { get; } = MessagePackConverter.ConstructUnboundGenericType();
+
 	internal static bool TryCreate(Compilation compilation, [NotNullWhen(true)] out ReferenceSymbols? referenceSymbols)
 	{
 		if (!compilation.ReferencedAssemblyNames.Any(id => id.Name == "Nerdbank.MessagePack"))

--- a/src/Nerdbank.MessagePack.Analyzers/Strings.resx
+++ b/src/Nerdbank.MessagePack.Analyzers/Strings.resx
@@ -130,49 +130,49 @@
     <value>Avoid [Key] on non-serialized members</value>
   </data>
   <data name="NBMsgPack003_MessageFormat" xml:space="preserve">
-    <value>Each index specified in [Key(index)] must be unique, but this member's index collides with that of {0}</value>
+    <value>Each index specified in [Key(index)] must be unique, but this member's index collides with that of {0}.</value>
   </data>
   <data name="NBMsgPack003_Title" xml:space="preserve">
     <value>[Key] index must be unique</value>
   </data>
   <data name="NBMsgPack010_MessageFormat" xml:space="preserve">
-    <value>[KnownSubType] should specify a type that is derived from or implements the type the attribute is applied to</value>
+    <value>[KnownSubType] should specify a type that is derived from or implements the type the attribute is applied to.</value>
   </data>
   <data name="NBMsgPack010_Title" xml:space="preserve">
     <value>[KnownSubType] should specify an assignable type</value>
   </data>
   <data name="NBMsgPack011_MessageFormat" xml:space="preserve">
-    <value>[KnownSubType] alias must be unique, within the scope of the type that the attribute is applied to</value>
+    <value>[KnownSubType] alias must be unique, within the scope of the type that the attribute is applied to.</value>
   </data>
   <data name="NBMsgPack011_Title" xml:space="preserve">
     <value>[KnownSubType] alias must be unique</value>
   </data>
   <data name="NBMsgPack012_MessageFormat" xml:space="preserve">
-    <value>[KnownSubType] type should be assigned just one alias but was already assigned {0}</value>
+    <value>[KnownSubType] type should be assigned just one alias but was already assigned {0}.</value>
   </data>
   <data name="NBMsgPack012_Title" xml:space="preserve">
     <value>[KnownSubType] type must be unique</value>
   </data>
   <data name="NBMsgPack013_MessageFormat" xml:space="preserve">
-    <value>[KnownSubType] type must be a non-generic or closed generic type</value>
+    <value>[KnownSubType] type must be a non-generic or closed generic type.</value>
   </data>
   <data name="NBMsgPack013_Title" xml:space="preserve">
     <value>[KnownSubType] type must not be an open generic</value>
   </data>
   <data name="NBMsgPack014_MessageFormat" xml:space="preserve">
-    <value>[KnownSubType] type must be one with [GenerateShape] applied directly or indirectly</value>
+    <value>[KnownSubType] type must be one with [GenerateShape] applied directly or indirectly.</value>
   </data>
   <data name="NBMsgPack014_Title" xml:space="preserve">
     <value>[KnownSubType] type must have a shape</value>
   </data>
   <data name="NBMsgPack020_MessageFormat" xml:space="preserve">
-    <value>[MessagePackConverter] type must derive from MessagePackConverter&lt;T&gt; where T is the type the attribute is applied to</value>
+    <value>[MessagePackConverter] type must derive from MessagePackConverter&lt;T&gt; where T is the type the attribute is applied to.</value>
   </data>
   <data name="NBMsgPack020_Title" xml:space="preserve">
     <value>[MessagePackConverter] type must be compatible converter</value>
   </data>
   <data name="NBMsgPack021_MessageFormat" xml:space="preserve">
-    <value>[MessagePackConverter] type must declare a public constructor with no parameters</value>
+    <value>[MessagePackConverter] type must declare a public constructor with no parameters.</value>
   </data>
   <data name="NBMsgPack021_Title" xml:space="preserve">
     <value>[MessagePackConverter] type missing default constructor</value>
@@ -182,5 +182,11 @@
   </data>
   <data name="NBMsgPack030_Title" xml:space="preserve">
     <value>Converters should not call top-level `MessagePackSerializer` methods</value>
+  </data>
+  <data name="NBMsgPack031_MessageFormat" xml:space="preserve">
+    <value>A value must be serialized with exactly one msgpack structure, whether that is a scalar value like an integer, or a vector like an array or a map. If there is nothing to write, you may write an empty array header. If there is more than one value to write, lead with an array header that exactly predicts the number of values that will follow.</value>
+  </data>
+  <data name="NBMsgPack031_Title" xml:space="preserve">
+    <value>Converters should read or write exactly one msgpack structure</value>
   </data>
 </root>

--- a/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
+++ b/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
@@ -8,6 +8,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Nerdbank.MessagePack\Nerdbank.MessagePack.csproj" />
+    <ProjectReference Include="..\..\src\Nerdbank.MessagePack.Analyzers.CodeFixes\Nerdbank.MessagePack.Analyzers.CodeFixes.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Analyzer</OutputItemType>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Nerdbank.MessagePack.Analyzers\Nerdbank.MessagePack.Analyzers.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Analyzer</OutputItemType>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
A custom converter should always write or read exactly one msgpack structure. When multiple values need to be read or written, an array or map header must be used first to introduce the number of elements that belong to one super-structure.

Conditional branching, loops and `TryRead` methods can complicate static analysis in counting how many structures are actually read/written. I'm using roslyn's control flow analysis to help out. This API doesn't have any real samples from what I can tell, so I figured this out myself and I probably didn't get it quite right yet. I have several tests that show that at least certain cases work.

There are complex cases that the analyzer doesn't handle, which the design is to just bail out without reporting a diagnostic. So this analyzer does not guarantee correct code. But it will catch most novice mistakes.