### PR TITLE
Offer automatic secure hash functions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />

--- a/docfx/docs/security.md
+++ b/docfx/docs/security.md
@@ -57,8 +57,8 @@ public partial class HashCollisionResistance : IEquatable<HashCollisionResistanc
 {
     public HashCollisionResistance()
     {
-        this.Dictionary = new(SipHashEqualityComparer<CustomType>.Default);
-        this.HashSet = new(SipHashEqualityComparer<CustomType>.Default);
+        this.Dictionary = new(ByValueEqualityComparer<CustomType>.HashResistant);
+        this.HashSet = new(ByValueEqualityComparer<CustomType>.HashResistant);
     }
 
     public Dictionary<CustomType, string> Dictionary { get; }
@@ -69,3 +69,8 @@ public partial class HashCollisionResistance : IEquatable<HashCollisionResistanc
 
 Note how the collection properties do *not* define a property setter.
 This is crucial to the threat mitigation, since it activates the deserializer behavior of not recreating the collection using the default (insecure) equality comparer.
+
+In this example, we use @Nerdbank.MessagePack.ByValueEqualityComparer`1.HashResistant?displayProperty=nameWithType, which provides a collision resistant implementation of @System.Collections.Generic.IEqualityComparer`1.
+This implementation uses the SIP hash algorithm, which is known for its high performance and collision resistance.
+While it will function for virtually any data type, its behavior is not correct in all cases and you may need to implement your own secure hash function.
+Please review the documentation for @Nerdbank.MessagePack.ByValueEqualityComparer`1.HashResistant for more information.

--- a/src/Nerdbank.MessagePack/ByValueEqualityComparer`1.cs
+++ b/src/Nerdbank.MessagePack/ByValueEqualityComparer`1.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.MessagePack;
+
+/// <inheritdoc cref="ByValueEqualityComparer{T, TProvider}"/>
+public static class ByValueEqualityComparer<T>
+	where T : IShapeable<T>
+{
+	/// <inheritdoc cref="ByValueEqualityComparer{T, TProvider}.Default"/>
+	public static IEqualityComparer<T> Default => ByValueEqualityComparer<T, T>.Default;
+
+	/// <inheritdoc cref="ByValueEqualityComparer{T, TProvider}.HashResistant"/>
+	public static IEqualityComparer<T> HashResistant => ByValueEqualityComparer<T, T>.HashResistant;
+}

--- a/src/Nerdbank.MessagePack/ByValueEqualityComparer`2.cs
+++ b/src/Nerdbank.MessagePack/ByValueEqualityComparer`2.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Nerdbank.MessagePack.SecureHash;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// Provides deep by-value implementations of <see cref="IEqualityComparer{T}"/> for arbitrary data types.
+/// </summary>
+/// <typeparam name="T">The data type to be hashed or compared by value.</typeparam>
+/// <typeparam name="TProvider">The provider of the type shape.</typeparam>
+/// <remarks>
+/// <para>
+/// The deep walking of the object graph for deep by-value equality and hashing is based on the same
+/// <see cref="GenerateShapeAttribute"/> that is used to generate MessagePack serializers.
+/// The implementation therefore considers all the same properties for equality and hashing that would
+/// be included in a serialized copy.
+/// </para>
+/// <para>
+/// This implementation is not suitable for all types. Specifically, it is not suitable for types that
+/// have multiple memory representations that are considered equal.
+/// An invariant for <see cref="IEqualityComparer{T}" /> behavior must be that if
+/// <c>x.Equals(y)</c> then <c>x.GetHashCode() == y.GetHashCode()</c>.
+/// For an auto-generated implementation of these methods for arbitrary types such as this,
+/// no specialization for multiple values that are considered equal is possible.
+/// </para>
+/// <para>
+/// For example, a <see cref="double"/> value has distinct memory representations for <c>0.0</c> and <c>-0.0</c>,
+/// yet these two values are considered equal and must have the same hash code.
+/// In this case and for several other common data types included with .NET, special consideration is built-in
+/// for correct operation.
+/// But this cannot be done automatically for any user-defined types.
+/// </para>
+/// <para>
+/// When using user-defined types for which this implementation is inappropriate,
+/// a custom implementation of <see cref="IEqualityComparer{T}"/> may be used if the type is used directly.
+/// But if the type is referenced in a type reference graph such that is used for by-value comparison,
+/// implementing <see cref="IDeepSecureEqualityComparer{T}"/> on that type will allow the type to take control
+/// of just its contribution to the hash code and equality comparison.
+/// </para>
+/// <para>
+/// Types that define no (public or opted in) properties and do not implement <see cref="IDeepSecureEqualityComparer{T}"/> will throw a <see cref="NotSupportedException"/> when attempting to create an equality comparer.
+/// </para>
+/// <para>
+/// This implementation should only be used for acyclic graphs, since cyclic graphs will cause a
+/// <see cref="StackOverflowException"/> while performing the comparison.
+/// </para>
+/// <para>
+/// Another consideration is that types used as keys in collections should generally not have a changing hash code
+/// or the collections internal data structures may become corrupted by a key that is stored in the wrong hash bucket.
+/// Keys should generally be immutable to prevent this, or at least immutable in the elements that contribute to the hash code.
+/// In an automated equality comparer such as the one produced by this class, all public properties contribute to the hash code,
+/// even if they are mutable.
+/// Care should therefore be taken to not mutate properties on objects used as keys in collections.
+/// </para>
+/// <para>
+/// The values are compared by their declared types rather than polymorphism.
+/// If some type has a property of type Foo, and the actual value at runtime derives from Foo, only the properties on Foo will be considered.
+/// If between two object graphs being equality checked, their runtime types do not match, the equality check will return <see langword="false" />.
+/// </para>
+/// </remarks>
+public static class ByValueEqualityComparer<T, TProvider>
+	where TProvider : IShapeable<T>
+{
+	private static IEqualityComparer<T>? defaultEqualityComparer;
+
+	private static IEqualityComparer<T>? hashResistantEqualityComparer;
+
+	/// <summary>
+	/// Gets a deep by-value equality comparer for the type <typeparamref name="T"/>, without hash collision resistance.
+	/// </summary>
+	/// <remarks>
+	/// See the remarks on the class for important notes about correctness of this implementation.
+	/// </remarks>
+	public static IEqualityComparer<T> Default => defaultEqualityComparer ??= (IEqualityComparer<T>)TProvider.GetShape().Accept(new ByValueVisitor())!;
+
+	/// <summary>
+	/// Gets a deep by-value equality comparer for the type <typeparamref name="T"/>, with hash collision resistance.
+	/// </summary>
+	/// <remarks>
+	/// See the remarks on the class for important notes about correctness of this implementation.
+	/// </remarks>
+	public static IEqualityComparer<T> HashResistant => hashResistantEqualityComparer ??= (IEqualityComparer<T>)TProvider.GetShape().Accept(new SecureVisitor())!;
+}

--- a/src/Nerdbank.MessagePack/IDeepSecureEqualityComparer`1.cs
+++ b/src/Nerdbank.MessagePack/IDeepSecureEqualityComparer`1.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// An interface that may be implemented by user-defined types in order to provide their own
+/// deep (i.e. giving all values a chance to contribute) hash code.
+/// </summary>
+/// <typeparam name="T">The same type that is implementing this interface.</typeparam>
+/// <remarks>
+/// <para>
+/// When a type implements this interface, <see cref="GetHashCode"/> and <see cref="DeepEquals(T?)"/>
+/// is used to determine equality and hash codes for the type by the
+/// <see cref="ByValueEqualityComparer{T, TProvider}"/> equality comparer
+/// instead of the deep by-value automatic implementation.
+/// </para>
+/// </remarks>
+public interface IDeepSecureEqualityComparer<T>
+{
+	/// <summary>
+	/// Tests deep equality of this object with another object.
+	/// </summary>
+	/// <param name="other">The other object.</param>
+	/// <returns><see langword="true" /> if the two objects are deeply equal.</returns>
+	/// <remarks>
+	/// An implementation may use <see cref="ByValueEqualityComparer{T}.Default"/> to obtain equality comparers for any sub-values that must be tested.
+	/// </remarks>
+	bool DeepEquals(T? other);
+
+	/// <summary>
+	/// Gets a collision resistant hash code for this object.
+	/// </summary>
+	/// <returns>A 64-bit integer.</returns>
+	/// <exception cref="NotSupportedException">May be thrown if not supported.</exception>
+	long GetSecureHashCode();
+
+	/// <summary>
+	/// Gets a hash code for this object, which may not be collision resistant.
+	/// </summary>
+	/// <returns>A 32-bit integer.</returns>
+	/// <remarks>
+	/// The default implementation of this method is to truncate the result of <see cref="GetSecureHashCode"/>.
+	/// </remarks>
+	int GetHashCode() => unchecked((int)this.GetSecureHashCode());
+}

--- a/src/Nerdbank.MessagePack/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/PublicAPI.Unshipped.txt
@@ -43,6 +43,8 @@ const Nerdbank.MessagePack.MessagePackCode.UInt16 = 205 -> byte
 const Nerdbank.MessagePack.MessagePackCode.UInt32 = 206 -> byte
 const Nerdbank.MessagePack.MessagePackCode.UInt64 = 207 -> byte
 const Nerdbank.MessagePack.MessagePackCode.UInt8 = 204 -> byte
+Nerdbank.MessagePack.ByValueEqualityComparer<T, TProvider>
+Nerdbank.MessagePack.ByValueEqualityComparer<T>
 Nerdbank.MessagePack.Extension
 Nerdbank.MessagePack.Extension.Data.get -> System.Buffers.ReadOnlySequence<byte>
 Nerdbank.MessagePack.Extension.Data.set -> void
@@ -59,6 +61,10 @@ Nerdbank.MessagePack.ExtensionHeader.Length.get -> uint
 Nerdbank.MessagePack.ExtensionHeader.Length.set -> void
 Nerdbank.MessagePack.ExtensionHeader.TypeCode.get -> sbyte
 Nerdbank.MessagePack.ExtensionHeader.TypeCode.set -> void
+Nerdbank.MessagePack.IDeepSecureEqualityComparer<T>
+Nerdbank.MessagePack.IDeepSecureEqualityComparer<T>.DeepEquals(T? other) -> bool
+Nerdbank.MessagePack.IDeepSecureEqualityComparer<T>.GetHashCode() -> int
+Nerdbank.MessagePack.IDeepSecureEqualityComparer<T>.GetSecureHashCode() -> long
 Nerdbank.MessagePack.KeyAttribute
 Nerdbank.MessagePack.KeyAttribute.Index.get -> int
 Nerdbank.MessagePack.KeyAttribute.KeyAttribute(int index) -> void
@@ -255,6 +261,10 @@ Nerdbank.MessagePack.SerializationContext.MaxDepth.set -> void
 Nerdbank.MessagePack.SerializationContext.SerializationContext() -> void
 Nerdbank.MessagePack.SerializationContext.UnflushedBytesThreshold.get -> int
 Nerdbank.MessagePack.SerializationContext.UnflushedBytesThreshold.init -> void
+static Nerdbank.MessagePack.ByValueEqualityComparer<T, TProvider>.Default.get -> System.Collections.Generic.IEqualityComparer<T>!
+static Nerdbank.MessagePack.ByValueEqualityComparer<T, TProvider>.HashResistant.get -> System.Collections.Generic.IEqualityComparer<T>!
+static Nerdbank.MessagePack.ByValueEqualityComparer<T>.Default.get -> System.Collections.Generic.IEqualityComparer<T>!
+static Nerdbank.MessagePack.ByValueEqualityComparer<T>.HashResistant.get -> System.Collections.Generic.IEqualityComparer<T>!
 static Nerdbank.MessagePack.MessagePackCode.ToFormatName(byte code) -> string!
 static Nerdbank.MessagePack.MessagePackCode.ToMessagePackType(byte code) -> Nerdbank.MessagePack.MessagePackType
 static Nerdbank.MessagePack.MessagePackNamingPolicy.CamelCase.get -> Nerdbank.MessagePack.MessagePackNamingPolicy!

--- a/src/Nerdbank.MessagePack/SecureHash/ByValueAggregatingEqualityComparer`1.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/ByValueAggregatingEqualityComparer`1.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A secure equality comparer that aggregates the results of multiple other secure equality comparers.
+/// </summary>
+/// <typeparam name="T">The type that the component equality comparers consider.</typeparam>
+/// <param name="components">
+/// This is expected to be a reasonably small number (e.g. properties on a type).
+/// While hashing, 8 bytes of stack space will be allocated for each of these.
+/// If this is an empty array, equality checking will always return <see langword="false" />.
+/// </param>
+internal class ByValueAggregatingEqualityComparer<T>(ImmutableArray<IEqualityComparer<T>> components) : IEqualityComparer<T>
+{
+	/// <summary>
+	/// Gets a value indicating whether no components were given.
+	/// </summary>
+	internal bool IsEmpty => components.IsEmpty;
+
+	/// <inheritdoc/>
+	public bool Equals(T? x, T? y) => components.All(c => c.Equals(x, y));
+
+	/// <inheritdoc/>
+	public int GetHashCode([DisallowNull] T obj)
+	{
+		HashCode hashCode = default;
+		for (int i = 0; i < components.Length; i++)
+		{
+			hashCode.Add(components[i].GetHashCode(obj));
+		}
+
+		return hashCode.ToHashCode();
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/ByValueByteArrayEqualityComparer.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/ByValueByteArrayEqualityComparer.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Security.AccessControl;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A full content comparison and hash of a byte buffer.
+/// </summary>
+internal class ByValueByteArrayEqualityComparer : IEqualityComparer<byte[]>
+{
+	/// <summary>
+	/// The singleton to use.
+	/// </summary>
+	internal static readonly ByValueByteArrayEqualityComparer Default = new();
+
+	private ByValueByteArrayEqualityComparer()
+	{
+	}
+
+	/// <inheritdoc/>
+	public bool Equals(byte[]? x, byte[]? y) => ReferenceEquals(x, y) || (x is null || y is null) ? false : x.SequenceEqual(y);
+
+	/// <inheritdoc/>
+	public int GetHashCode([DisallowNull] byte[] obj)
+	{
+		HashCode hashCode = default;
+		hashCode.AddBytes(obj);
+		return hashCode.ToHashCode();
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/ByValueCustomEqualityComparer`1.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/ByValueCustomEqualityComparer`1.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// An implementation of <see cref="IEqualityComparer{T}"/> that delegates to <see cref="IDeepSecureEqualityComparer{T}"/> on an object.
+/// </summary>
+/// <typeparam name="T">The self-implementing type to be compared.</typeparam>
+internal class ByValueCustomEqualityComparer<T> : IEqualityComparer<T>
+{
+	/// <summary>
+	/// The singleton that may be used for any type that implements <see cref="IDeepSecureEqualityComparer{T}"/>.
+	/// </summary>
+	internal static readonly ByValueCustomEqualityComparer<T> Default = new();
+
+	/// <inheritdoc/>
+	public bool Equals(T? x, T? y)
+	{
+		if (x is null || y is null)
+		{
+			return ReferenceEquals(x, y);
+		}
+
+		return ((IDeepSecureEqualityComparer<T>)x).DeepEquals(y);
+	}
+
+	/// <inheritdoc/>
+	public int GetHashCode([DisallowNull] T obj) => ((IDeepSecureEqualityComparer<T>)obj).GetHashCode();
+}

--- a/src/Nerdbank.MessagePack/SecureHash/ByValueDictionaryEqualityComparer`3.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/ByValueDictionaryEqualityComparer`3.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A by-value equality comparer for dictionary types.
+/// </summary>
+/// <typeparam name="TDictionary">The type of dictionary.</typeparam>
+/// <typeparam name="TKey">The type of key.</typeparam>
+/// <typeparam name="TValue">The type of value.</typeparam>
+/// <param name="getDictionary">A function that can get a meaningful dictionary out of a <typeparamref name="TDictionary"/>.</param>
+/// <param name="keyEqualityComparer">The equality comparer to use for the key.</param>
+/// <param name="valueEqualityComparer">The equality comparer to use for the value.</param>
+internal class ByValueDictionaryEqualityComparer<TDictionary, TKey, TValue>(
+	Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getDictionary,
+	IEqualityComparer<TKey> keyEqualityComparer,
+	IEqualityComparer<TValue> valueEqualityComparer) : IEqualityComparer<TDictionary>
+{
+	/// <inheritdoc/>
+	public bool Equals(TDictionary? x, TDictionary? y)
+	{
+		if (x is null || y is null)
+		{
+			return x is null && y is null;
+		}
+
+		if (ReferenceEquals(x, y))
+		{
+			return true;
+		}
+
+		IReadOnlyDictionary<TKey, TValue> xDict = getDictionary(x);
+		IReadOnlyDictionary<TKey, TValue> yDict = getDictionary(y);
+
+		if (xDict.Count != yDict.Count)
+		{
+			return false;
+		}
+
+		foreach (KeyValuePair<TKey, TValue> pair in xDict)
+		{
+			if (!yDict.TryGetValue(pair.Key, out TValue? yValue) || !valueEqualityComparer.Equals(pair.Value, yValue))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/// <inheritdoc/>
+	public int GetHashCode([DisallowNull] TDictionary obj)
+	{
+		HashCode hashCode = default;
+		IReadOnlyDictionary<TKey, TValue> dict = getDictionary(obj);
+		foreach (KeyValuePair<TKey, TValue> pair in dict)
+		{
+			hashCode.Add(pair.Key is null ? 0 : keyEqualityComparer.GetHashCode(pair.Key));
+			hashCode.Add(pair.Value is null ? 0 : valueEqualityComparer.GetHashCode(pair.Value));
+		}
+
+		return hashCode.ToHashCode();
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/ByValueEnumerableEqualityComparer`2.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/ByValueEnumerableEqualityComparer`2.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// An equality comparer that performs deep by-value comparisons.
+/// </summary>
+/// <typeparam name="TEnumerable">The type of the enumerable.</typeparam>
+/// <typeparam name="TElement">The type of element in the enumerable.</typeparam>
+/// <param name="equalityComparer">The equality comparer for individual elements.</param>
+/// <param name="getEnumerable">The function that gets the enumerable of the collection.</param>
+internal class ByValueEnumerableEqualityComparer<TEnumerable, TElement>(
+	IEqualityComparer<TElement> equalityComparer,
+	Func<TEnumerable, IEnumerable<TElement>> getEnumerable) : IEqualityComparer<TEnumerable>
+{
+	/// <inheritdoc/>
+	public bool Equals(TEnumerable? x, TEnumerable? y)
+	{
+		if (x is null || y is null)
+		{
+			return ReferenceEquals(x, y);
+		}
+
+		IEnumerable<TElement> enumerableX = getEnumerable(x);
+		IEnumerable<TElement> enumerableY = getEnumerable(y);
+
+		if (Enumerable.TryGetNonEnumeratedCount(enumerableX, out int countX) &&
+			Enumerable.TryGetNonEnumeratedCount(enumerableY, out int countY) &&
+			countX != countY)
+		{
+			return false;
+		}
+
+		using IEnumerator<TElement> enumeratorX = enumerableX.GetEnumerator();
+		using IEnumerator<TElement> enumeratorY = enumerableY.GetEnumerator();
+		while (enumeratorX.MoveNext())
+		{
+			if (!enumeratorY.MoveNext() || !equalityComparer.Equals(enumeratorX.Current, enumeratorY.Current))
+			{
+				return false;
+			}
+		}
+
+		return !enumeratorY.MoveNext();
+	}
+
+	/// <inheritdoc/>
+	public int GetHashCode([DisallowNull] TEnumerable obj)
+	{
+		IEnumerable<TElement> enumerable = getEnumerable(obj);
+
+		// Ideally we could switch this to a SIP hash implementation that can process additional data in chunks with a constant amount of memory.
+		List<int> hashes = new();
+		foreach (TElement element in enumerable)
+		{
+			hashes.Add(element is null ? 0 : equalityComparer.GetHashCode(element));
+		}
+
+		return unchecked((int)SipHash.Default.Compute(MemoryMarshal.Cast<int, byte>(CollectionsMarshal.AsSpan(hashes))));
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/ByValueNullableEqualityComparer`1.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/ByValueNullableEqualityComparer`1.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// Implements a hash collision resistant <see cref="IEqualityComparer{T}"/> for nullable value types.
+/// </summary>
+/// <typeparam name="T">The value type.</typeparam>
+/// <param name="inner">The inner equality comparer for the non-nullable value type.</param>
+internal class ByValueNullableEqualityComparer<T>(IEqualityComparer<T> inner) : IEqualityComparer<T?>
+	where T : struct
+{
+	/// <inheritdoc/>
+	public bool Equals(T? x, T? y)
+	{
+		if (x is null || y is null)
+		{
+			return x is null && y is null;
+		}
+
+		return inner.Equals(x.Value, y.Value);
+	}
+
+	/// <inheritdoc/>
+	public int GetHashCode([DisallowNull] T? obj)
+	{
+		if (obj is null)
+		{
+			return 0;
+		}
+
+		return inner.GetHashCode(obj.Value);
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/ByValuePropertyEqualityComparer`2.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/ByValuePropertyEqualityComparer`2.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// An equality comparer that focuses on just one property for a given type.
+/// </summary>
+/// <typeparam name="TDeclaringType">The type that declares the property.</typeparam>
+/// <typeparam name="TPropertyType">The type of the property itself.</typeparam>
+/// <param name="getter">The function that can retrieve the value of the property from an instance of <typeparamref name="TDeclaringType"/>.</param>
+/// <param name="equalityComparer">The equality comparer to use for the value of the property.</param>
+internal class ByValuePropertyEqualityComparer<TDeclaringType, TPropertyType>(
+	Getter<TDeclaringType, TPropertyType> getter,
+	IEqualityComparer<TPropertyType> equalityComparer) : IEqualityComparer<TDeclaringType>
+{
+	/// <inheritdoc/>
+	public bool Equals(TDeclaringType? x, TDeclaringType? y)
+		=> x is null || y is null ? ReferenceEquals(x, y) : x.GetType() == y.GetType() && equalityComparer.Equals(getter(ref x), getter(ref y));
+
+	/// <inheritdoc/>
+	public int GetHashCode([DisallowNull] TDeclaringType obj)
+		=> getter(ref obj) is TPropertyType value ? equalityComparer.GetHashCode(value) : 0;
+}

--- a/src/Nerdbank.MessagePack/SecureHash/ByValueVisitor.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/ByValueVisitor.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A visitor that creates an <see cref="IEqualityComparer{T}"/> for a given type shape that compares values by value (deeply).
+/// </summary>
+internal class ByValueVisitor : TypeShapeVisitor
+{
+	private readonly TypeDictionary equalityComparers = new();
+
+	/// <inheritdoc/>
+	public override object? VisitObject<T>(IObjectTypeShape<T> objectShape, object? state = null)
+	{
+		if (SecureVisitor.HashResistantPrimitiveEqualityComparers.ContainsKey(objectShape.Type))
+		{
+			// The type is a primitive, so we can rely on by-value equality being implemented by the default equality comparer.
+			return EqualityComparer<T>.Default;
+		}
+
+		if (typeof(T) == typeof(byte[]))
+		{
+			return ByValueByteArrayEqualityComparer.Default;
+		}
+
+		if (typeof(IDeepSecureEqualityComparer<T>).IsAssignableFrom(objectShape.Type))
+		{
+			return ByValueCustomEqualityComparer<T>.Default;
+		}
+
+		ByValueAggregatingEqualityComparer<T> aggregatingEqualityComparer = new([
+			.. from property in objectShape.GetProperties()
+			   where property.HasGetter
+			   select (IEqualityComparer<T>)property.Accept(this, null)!]);
+
+		if (aggregatingEqualityComparer.IsEmpty)
+		{
+			throw new NotSupportedException($"The type {objectShape.Type} has no properties to compare by value.");
+		}
+
+		return aggregatingEqualityComparer;
+	}
+
+	/// <inheritdoc/>
+	public override object? VisitProperty<TDeclaringType, TPropertyType>(IPropertyShape<TDeclaringType, TPropertyType> propertyShape, object? state = null)
+		=> new ByValuePropertyEqualityComparer<TDeclaringType, TPropertyType>(propertyShape.GetGetter(), this.GetEqualityComparer(propertyShape.PropertyType));
+
+	/// <inheritdoc/>
+	public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state = null)
+		=> new ByValueEnumerableEqualityComparer<TEnumerable, TElement>(this.GetEqualityComparer(enumerableShape.ElementType), enumerableShape.GetGetEnumerable());
+
+	/// <inheritdoc/>
+	public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
+		=> new ByValueDictionaryEqualityComparer<TDictionary, TKey, TValue>(dictionaryShape.GetGetDictionary(), this.GetEqualityComparer(dictionaryShape.KeyType), this.GetEqualityComparer(dictionaryShape.ValueType));
+
+	/// <inheritdoc/>
+	public override object? VisitEnum<TEnum, TUnderlying>(IEnumTypeShape<TEnum, TUnderlying> enumShape, object? state = null)
+		=> EqualityComparer<TEnum>.Default;
+
+	/// <inheritdoc/>
+	public override object? VisitNullable<T>(INullableTypeShape<T> nullableShape, object? state = null)
+		=> new ByValueNullableEqualityComparer<T>(this.GetEqualityComparer(nullableShape.ElementType));
+
+	/// <summary>
+	/// Gets or creates an equality comparer for the given type shape.
+	/// </summary>
+	/// <typeparam name="T">The data type to make convertible.</typeparam>
+	/// <param name="shape">The type shape.</param>
+	/// <param name="state">An optional state object to pass to the equality comparer.</param>
+	/// <returns>The equality comparer.</returns>
+	protected IEqualityComparer<T> GetEqualityComparer<T>(ITypeShape<T> shape, object? state = null)
+		=> this.equalityComparers.GetOrAdd<IEqualityComparer<T>>(shape, this, box => new DelayedEqualityComparer<T>(box));
+
+	private class DelayedEqualityComparer<T>(ResultBox<IEqualityComparer<T>> inner) : IEqualityComparer<T>
+	{
+		public bool Equals(T? x, T? y) => inner.Result.Equals(x, y);
+
+		public int GetHashCode([DisallowNull] T obj) => inner.Result.GetHashCode(obj);
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/CollisionResistantHasherUnmanaged`1.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/CollisionResistantHasherUnmanaged`1.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// Provides a default implementation of <see cref="IEqualityComparer{T}"/> for blittable structs.
+/// </summary>
+/// <typeparam name="T">The type that may be compared.</typeparam>
+/// <remarks>
+/// This implementation takes the raw byte representation of a blittable struct as the hash input.
+/// This will typically be correct behavior, but in cases where multiple unique binary data
+/// represent values that are considered equivalent (specifically where <see cref="object.Equals(object?)"/>
+/// would return <see lanword="true"/>), this method will not return the same hash code for those values
+/// and would violate the invariant that hash codes must be equal between two values that are themselves considered equal.
+/// An example of two equivalent values that have different binary representations are <see cref="double.NegativeZero"/>
+/// and 0.
+/// For such structs, it is important to normalize the data to be hashed first.
+/// </remarks>
+internal class CollisionResistantHasherUnmanaged<T> : SecureEqualityComparer<T>
+	where T : unmanaged
+{
+	/// <inheritdoc/>
+	public override bool Equals(T x, T y)
+		=> MemoryMarshal.Cast<T, byte>(new Span<T>(ref x)).SequenceEqual(MemoryMarshal.Cast<T, byte>(new Span<T>(ref y)));
+
+	/// <inheritdoc/>
+	public override long GetSecureHashCode(T value) => SipHash.Default.Compute(MemoryMarshal.Cast<T, byte>(new Span<T>(ref value)));
+}

--- a/src/Nerdbank.MessagePack/SecureHash/HashResistantPrimitives.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/HashResistantPrimitives.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1600 // Elements should be documented
+
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+internal static class HashResistantPrimitives
+{
+	private static int SecureHash<T>(T value)
+		where T : unmanaged
+		=> unchecked((int)SipHash.Default.Compute(MemoryMarshal.Cast<T, byte>(new Span<T>(ref value))));
+
+	private static int SecureHash(ReadOnlySpan<byte> data) => unchecked((int)SipHash.Default.Compute(data));
+
+	internal class BooleanEqualityComparer : CollisionResistantHasherUnmanaged<bool>
+	{
+		public override long GetSecureHashCode(bool value) => base.GetSecureHashCode(value is true);
+
+		public override bool Equals(bool x, bool y) => x is true == y is true;
+	}
+
+	internal class HalfEqualityComparer : CollisionResistantHasherUnmanaged<Half>
+	{
+		/// <inheritdoc/>
+		public override unsafe long GetSecureHashCode(Half value)
+			=> base.GetSecureHashCode(
+				value == (Half)0.0 ? (Half)0 : // Special check for 0.0 so that the hash of 0.0 and -0.0 will equal.
+				value == Half.NaN ? Half.NaN : // Standardize on the binary representation of NaN prior to hashing.
+				value);
+	}
+
+	internal class SingleEqualityComparer : CollisionResistantHasherUnmanaged<float>
+	{
+		/// <inheritdoc/>
+		public override unsafe long GetSecureHashCode(float value)
+			=> base.GetSecureHashCode(value switch
+			{
+				0.0f => 0, // Special check for 0.0 so that the hash of 0.0 and -0.0 will equal.
+				float.NaN => float.NaN, // Standardize on the binary representation of NaN prior to hashing.
+				_ => value,
+			});
+	}
+
+	internal class DoubleEqualityComparer : CollisionResistantHasherUnmanaged<double>
+	{
+		/// <inheritdoc/>
+		public override unsafe long GetSecureHashCode(double value)
+			=> base.GetSecureHashCode(value switch
+			{
+				0.0 => 0, // Special check for 0.0 so that the hash of 0.0 and -0.0 will equal.
+				double.NaN => double.NaN, // Standardize on the binary representation of NaN prior to hashing.
+				_ => value,
+			});
+	}
+
+	internal class DateTimeEqualityComparer : CollisionResistantHasherUnmanaged<DateTime>
+	{
+		/// <inheritdoc/>
+		public override unsafe long GetSecureHashCode(DateTime value) => SecureHash(value.Ticks);
+	}
+
+	internal class DateTimeOffsetEqualityComparer : CollisionResistantHasherUnmanaged<DateTimeOffset>
+	{
+		/// <inheritdoc/>
+		public override unsafe long GetSecureHashCode(DateTimeOffset value) => SecureHash(value.UtcDateTime.Ticks);
+	}
+
+	internal class StringEqualityComparer : SecureEqualityComparer<string>
+	{
+		/// <inheritdoc/>
+		public override long GetSecureHashCode(string value)
+		{
+			// The Cast call could result in OverflowException at runtime if value is greater than 1bn chars in length.
+			return SecureHash(MemoryMarshal.Cast<char, byte>(value.AsSpan()));
+		}
+
+		/// <inheritdoc/>
+		public override bool Equals(string? x, string? y) => x == y;
+	}
+
+	/// <summary>
+	/// A "secure" equality comparer that assumes the default one is secure.
+	/// This should only be used on <see cref="string"/> or types that defer hash code generation to their <see cref="string"/> components.
+	/// </summary>
+	/// <typeparam name="T">The type to equate and hash.</typeparam>
+	internal class AlreadySecureEqualityComparer<T> : SecureEqualityComparer<T>
+	{
+		public override bool Equals(T? x, T? y) => EqualityComparer<T>.Default.Equals(x, y);
+
+		public override long GetSecureHashCode([DisallowNull] T obj) => EqualityComparer<T>.Default.GetHashCode(obj);
+	}
+
+	internal class BigIntegerEqualityComparer : SecureEqualityComparer<BigInteger>
+	{
+		/// <inheritdoc/>
+		public override bool Equals(BigInteger x, BigInteger y) => x.Equals(y);
+
+		/// <inheritdoc/>
+		public override long GetSecureHashCode([DisallowNull] BigInteger obj)
+		{
+			Span<byte> bytes = stackalloc byte[obj.GetByteCount()];
+			Assumes.True(obj.TryWriteBytes(bytes, out _));
+			return SecureHash(bytes);
+		}
+	}
+
+	internal class DecimalEqualityComparer : SecureEqualityComparer<decimal>
+	{
+		/// <inheritdoc/>
+		public override bool Equals(decimal x, decimal y) => x.Equals(y);
+
+		/// <inheritdoc/>
+		public override long GetSecureHashCode([DisallowNull] decimal obj)
+		{
+			Span<int> bytes = stackalloc int[500];
+			if (!decimal.TryGetBits(obj, bytes, out int length))
+			{
+				throw new NotSupportedException("Decimal too long.");
+			}
+
+			return SecureHash(MemoryMarshal.Cast<int, byte>(bytes[..length]));
+		}
+	}
+
+	internal class VersionEqualityComparer : SecureEqualityComparer<Version>
+	{
+		/// <inheritdoc/>
+		public override bool Equals(Version? x, Version? y) => EqualityComparer<Version>.Default.Equals(x, y);
+
+		/// <inheritdoc/>
+		public override long GetSecureHashCode([DisallowNull] Version obj)
+		{
+			Span<int> bytes = [obj.Major, obj.Minor, obj.Build, obj.Revision];
+			return SecureHash(MemoryMarshal.Cast<int, byte>(bytes));
+		}
+	}
+
+	internal class ByteArrayEqualityComparer : SecureEqualityComparer<byte[]>
+	{
+		internal static readonly ByteArrayEqualityComparer Default = new();
+
+		private ByteArrayEqualityComparer()
+		{
+		}
+
+		public override bool Equals(byte[]? x, byte[]? y) => ReferenceEquals(x, y) || (x is null || y is null) ? false : x.SequenceEqual(y);
+
+		public override long GetSecureHashCode([DisallowNull] byte[] obj) => SecureHash(obj);
+	}
+
+	internal class CollisionResistantEnumHasher<TEnum, TUnderlying>(SecureEqualityComparer<TUnderlying> equalityComparer) : SecureEqualityComparer<TEnum>
+	{
+		/// <inheritdoc/>
+		public override bool Equals(TEnum? x, TEnum? y) => EqualityComparer<TEnum?>.Default.Equals(x, y);
+
+		/// <inheritdoc/>
+		public override long GetSecureHashCode(TEnum obj) => equalityComparer.GetSecureHashCode((TUnderlying)(object)obj!);
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/SecureAggregatingEqualityComparer`1.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecureAggregatingEqualityComparer`1.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A secure equality comparer that aggregates the results of multiple other secure equality comparers.
+/// </summary>
+/// <typeparam name="T">The type that the component equality comparers consider.</typeparam>
+/// <param name="components">
+/// This is expected to be a reasonably small number (e.g. properties on a type).
+/// While hashing, 8 bytes of stack space will be allocated for each of these.
+/// If this is an empty array, equality checking will always return <see langword="false" />.
+/// </param>
+internal class SecureAggregatingEqualityComparer<T>(ImmutableArray<SecureEqualityComparer<T>> components) : SecureEqualityComparer<T>
+{
+	/// <summary>
+	/// Gets a value indicating whether no components were given.
+	/// </summary>
+	internal bool IsEmpty => components.IsEmpty;
+
+	/// <inheritdoc/>
+	public override bool Equals(T? x, T? y) => components.All(c => c.Equals(x, y));
+
+	/// <inheritdoc/>
+	public override long GetSecureHashCode([DisallowNull] T obj)
+	{
+		// Ideally we could switch this to a SIP hash implementation that can process additional data in chunks with a constant amount of memory.
+		Span<long> componentHashes = stackalloc long[components.Length];
+		for (int i = 0; i < components.Length; i++)
+		{
+			componentHashes[i] = components[i].GetSecureHashCode(obj);
+		}
+
+		return SipHash.Default.Compute(MemoryMarshal.Cast<long, byte>(componentHashes));
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/SecureCustomEqualityComparer`1.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecureCustomEqualityComparer`1.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// An implementation of <see cref="SecureEqualityComparer{T}"/> that delegates to <see cref="IDeepSecureEqualityComparer{T}"/> on an object.
+/// </summary>
+/// <typeparam name="T">The self-implementing type to be compared.</typeparam>
+internal class SecureCustomEqualityComparer<T> : SecureEqualityComparer<T>
+{
+	/// <summary>
+	/// The singleton that may be used for any type that implements <see cref="IDeepSecureEqualityComparer{T}"/>.
+	/// </summary>
+	internal static readonly SecureCustomEqualityComparer<T> Default = new();
+
+	/// <inheritdoc/>
+	public override bool Equals(T? x, T? y)
+	{
+		if (x is null || y is null)
+		{
+			return ReferenceEquals(x, y);
+		}
+
+		return ((IDeepSecureEqualityComparer<T>)x).DeepEquals(y);
+	}
+
+	/// <inheritdoc/>
+	public override long GetSecureHashCode([DisallowNull] T obj) => ((IDeepSecureEqualityComparer<T>)obj).GetSecureHashCode();
+}

--- a/src/Nerdbank.MessagePack/SecureHash/SecureDictionaryEqualityComparer`3.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecureDictionaryEqualityComparer`3.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A by-value, hash-collision resistant equality comparer for dictionary types.
+/// </summary>
+/// <typeparam name="TDictionary">The type of dictionary.</typeparam>
+/// <typeparam name="TKey">The type of key.</typeparam>
+/// <typeparam name="TValue">The type of value.</typeparam>
+/// <param name="getDictionary">A function that can get a meaningful dictionary out of a <typeparamref name="TDictionary"/>.</param>
+/// <param name="keyEqualityComparer">The equality comparer to use for the key.</param>
+/// <param name="valueEqualityComparer">The equality comparer to use for the value.</param>
+internal class SecureDictionaryEqualityComparer<TDictionary, TKey, TValue>(
+	Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getDictionary,
+	SecureEqualityComparer<TKey> keyEqualityComparer,
+	SecureEqualityComparer<TValue> valueEqualityComparer) : SecureEqualityComparer<TDictionary>
+{
+	/// <inheritdoc/>
+	public override bool Equals(TDictionary? x, TDictionary? y)
+	{
+		if (x is null || y is null)
+		{
+			return x is null && y is null;
+		}
+
+		if (ReferenceEquals(x, y))
+		{
+			return true;
+		}
+
+		IReadOnlyDictionary<TKey, TValue> xDict = getDictionary(x);
+		IReadOnlyDictionary<TKey, TValue> yDict = getDictionary(y);
+
+		if (xDict.Count != yDict.Count)
+		{
+			return false;
+		}
+
+		foreach (KeyValuePair<TKey, TValue> pair in xDict)
+		{
+			if (!yDict.TryGetValue(pair.Key, out TValue? yValue) || !valueEqualityComparer.Equals(pair.Value, yValue))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/// <inheritdoc/>
+	public override long GetSecureHashCode([DisallowNull] TDictionary obj)
+	{
+		IReadOnlyDictionary<TKey, TValue> dict = getDictionary(obj);
+
+		// Ideally we could switch this to a SIP hash implementation that can process additional data in chunks with a constant amount of memory.
+		long[] hashes = new long[dict.Count * 2];
+		int index = 0;
+		foreach (KeyValuePair<TKey, TValue> pair in dict)
+		{
+			hashes[index++] = pair.Key is null ? 0 : keyEqualityComparer.GetSecureHashCode(pair.Key);
+			hashes[index++] = pair.Value is null ? 0 : valueEqualityComparer.GetSecureHashCode(pair.Value);
+		}
+
+		return SipHash.Default.Compute(MemoryMarshal.Cast<long, byte>(hashes));
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/SecureEnumerableEqualityComparer`2.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecureEnumerableEqualityComparer`2.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A secure equality comparer that performs deep by-value comparisons, and uses collision-resistant hashing.
+/// </summary>
+/// <typeparam name="TEnumerable">The type of the enumerable.</typeparam>
+/// <typeparam name="TElement">The type of element in the enumerable.</typeparam>
+/// <param name="equalityComparer">The equality comparer for individual elements.</param>
+/// <param name="getEnumerable">The function that gets the enumerable of the collection.</param>
+internal class SecureEnumerableEqualityComparer<TEnumerable, TElement>(
+	SecureEqualityComparer<TElement> equalityComparer,
+	Func<TEnumerable, IEnumerable<TElement>> getEnumerable) : SecureEqualityComparer<TEnumerable>
+{
+	/// <inheritdoc/>
+	public override bool Equals(TEnumerable? x, TEnumerable? y)
+	{
+		if (x is null || y is null)
+		{
+			return ReferenceEquals(x, y);
+		}
+
+		IEnumerable<TElement> enumerableX = getEnumerable(x);
+		IEnumerable<TElement> enumerableY = getEnumerable(y);
+
+		if (Enumerable.TryGetNonEnumeratedCount(enumerableX, out int countX) &&
+			Enumerable.TryGetNonEnumeratedCount(enumerableY, out int countY) &&
+			countX != countY)
+		{
+			return false;
+		}
+
+		using IEnumerator<TElement> enumeratorX = enumerableX.GetEnumerator();
+		using IEnumerator<TElement> enumeratorY = enumerableY.GetEnumerator();
+		while (enumeratorX.MoveNext())
+		{
+			if (!enumeratorY.MoveNext() || !equalityComparer.Equals(enumeratorX.Current, enumeratorY.Current))
+			{
+				return false;
+			}
+		}
+
+		return !enumeratorY.MoveNext();
+	}
+
+	/// <inheritdoc/>
+	public override long GetSecureHashCode([DisallowNull] TEnumerable obj)
+	{
+		IEnumerable<TElement> enumerable = getEnumerable(obj);
+
+		// Ideally we could switch this to a SIP hash implementation that can process additional data in chunks with a constant amount of memory.
+		List<long> hashes = Enumerable.TryGetNonEnumeratedCount(enumerable, out int count) ? new(count) : new();
+		foreach (TElement element in enumerable)
+		{
+			hashes.Add(element is null ? 0 : equalityComparer.GetSecureHashCode(element));
+		}
+
+		return SipHash.Default.Compute(MemoryMarshal.Cast<long, byte>(CollectionsMarshal.AsSpan(hashes)));
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/SecureEqualityComparer`1.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecureEqualityComparer`1.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Text;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A base class for all <see cref="IEqualityComparer{T}"/> implementations that are hash collision resistant.
+/// </summary>
+/// <typeparam name="T">The type of value to be compared or hashed.</typeparam>
+internal abstract class SecureEqualityComparer<T> : IEqualityComparer<T>, IEqualityComparer
+{
+	/// <summary>
+	/// Performs a by-value equality comparison that conforms to the invariant that
+	/// if <see cref="Equals(T?, T?)"/> returns <see langword="true"/> for two values,
+	/// then <see cref="GetHashCode(T)"/> must return the same value for both.
+	/// </summary>
+	/// <param name="x">The first value to compare.</param>
+	/// <param name="y">The second value to compare.</param>
+	/// <returns><see langword="true" /> if the two values are equivalent; <see langword="false"/> otherwise.</returns>
+	public abstract bool Equals(T? x, T? y);
+
+	/// <summary>
+	/// Gets a collision-resistant hash for the given value, truncated to just 32 bits.
+	/// </summary>
+	/// <param name="obj">The value to hash.</param>
+	/// <returns>The hash function result, truncated to 32 bits.</returns>
+	public int GetHashCode([DisallowNull] T obj) => unchecked((int)this.GetSecureHashCode(obj));
+
+	/// <summary>
+	/// Gets a collision-resistant hash for the given value, retaining the full 64 bits.
+	/// </summary>
+	/// <param name="obj">The value to hash.</param>
+	/// <returns>The 64 bit hash function result.</returns>
+	public abstract long GetSecureHashCode([DisallowNull] T obj);
+
+	/// <inheritdoc/>
+	bool IEqualityComparer.Equals(object? x, object? y) => this.Equals((T?)x, (T?)y);
+
+	/// <inheritdoc/>
+	int IEqualityComparer.GetHashCode(object obj) => this.GetHashCode((T)obj);
+}

--- a/src/Nerdbank.MessagePack/SecureHash/SecureNullableEqualityComparer`1.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecureNullableEqualityComparer`1.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// Implements a hash collision resistant <see cref="IEqualityComparer{T}"/> for nullable value types.
+/// </summary>
+/// <typeparam name="T">The value type.</typeparam>
+/// <param name="inner">The inner equality comparer for the non-nullable value type.</param>
+internal class SecureNullableEqualityComparer<T>(SecureEqualityComparer<T> inner) : SecureEqualityComparer<T?>
+	where T : struct
+{
+	/// <inheritdoc/>
+	public override bool Equals(T? x, T? y)
+	{
+		if (x is null || y is null)
+		{
+			return x is null && y is null;
+		}
+
+		return inner.Equals(x.Value, y.Value);
+	}
+
+	/// <inheritdoc/>
+	public override long GetSecureHashCode([DisallowNull] T? obj)
+	{
+		if (obj is null)
+		{
+			return 0;
+		}
+
+		return inner.GetSecureHashCode(obj.Value);
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/SecurePropertyEqualityComparer`2.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecurePropertyEqualityComparer`2.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A secure equality comparer that focuses on just one property for a given type.
+/// </summary>
+/// <typeparam name="TDeclaringType">The type that declares the property.</typeparam>
+/// <typeparam name="TPropertyType">The type of the property itself.</typeparam>
+/// <param name="getter">The function that can retrieve the value of the property from an instance of <typeparamref name="TDeclaringType"/>.</param>
+/// <param name="equalityComparer">The equality comparer to use for the value of the property.</param>
+internal class SecurePropertyEqualityComparer<TDeclaringType, TPropertyType>(
+	Getter<TDeclaringType, TPropertyType> getter,
+	SecureEqualityComparer<TPropertyType> equalityComparer) : SecureEqualityComparer<TDeclaringType>
+{
+	/// <inheritdoc/>
+	public override bool Equals(TDeclaringType? x, TDeclaringType? y)
+		=> x is null || y is null ? ReferenceEquals(x, y) : x.GetType() == y.GetType() && equalityComparer.Equals(getter(ref x), getter(ref y));
+
+	/// <inheritdoc/>
+	public override long GetSecureHashCode([DisallowNull] TDeclaringType obj)
+		=> getter(ref obj) is TPropertyType value ? equalityComparer.GetSecureHashCode(value) : 0;
+}

--- a/src/Nerdbank.MessagePack/SecureHash/SecureVisitor.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecureVisitor.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Frozen;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Text;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A visitor that creates a hash collision resistant <see cref="IEqualityComparer{T}"/> for a given type shape
+/// that compares values by value (deeply).
+/// </summary>
+internal class SecureVisitor : TypeShapeVisitor
+{
+	/// <summary>
+	/// A dictionary of primitive types and their corresponding hash-resistant equality comparers.
+	/// </summary>
+	internal static readonly FrozenDictionary<Type, object> HashResistantPrimitiveEqualityComparers = new Dictionary<Type, object>()
+	{
+		{ typeof(char), new CollisionResistantHasherUnmanaged<char>() },
+		{ typeof(Rune), new CollisionResistantHasherUnmanaged<Rune>() },
+		{ typeof(byte), new CollisionResistantHasherUnmanaged<byte>() },
+		{ typeof(ushort), new CollisionResistantHasherUnmanaged<ushort>() },
+		{ typeof(uint), new CollisionResistantHasherUnmanaged<uint>() },
+		{ typeof(ulong), new CollisionResistantHasherUnmanaged<ulong>() },
+		{ typeof(sbyte), new CollisionResistantHasherUnmanaged<sbyte>() },
+		{ typeof(short), new CollisionResistantHasherUnmanaged<short>() },
+		{ typeof(int), new CollisionResistantHasherUnmanaged<int>() },
+		{ typeof(long), new CollisionResistantHasherUnmanaged<long>() },
+		{ typeof(BigInteger), new HashResistantPrimitives.BigIntegerEqualityComparer() },
+		{ typeof(Int128), new CollisionResistantHasherUnmanaged<Int128>() },
+		{ typeof(UInt128), new CollisionResistantHasherUnmanaged<UInt128>() },
+		{ typeof(string), new HashResistantPrimitives.StringEqualityComparer() },
+		{ typeof(bool), new HashResistantPrimitives.BooleanEqualityComparer() },
+		{ typeof(Version), new HashResistantPrimitives.VersionEqualityComparer() },
+		{ typeof(Uri), new HashResistantPrimitives.AlreadySecureEqualityComparer<Uri>() },
+		{ typeof(Half), new HashResistantPrimitives.HalfEqualityComparer() },
+		{ typeof(float), new HashResistantPrimitives.SingleEqualityComparer() },
+		{ typeof(double), new HashResistantPrimitives.DoubleEqualityComparer() },
+		{ typeof(decimal), new HashResistantPrimitives.DecimalEqualityComparer() },
+		{ typeof(TimeOnly), new CollisionResistantHasherUnmanaged<TimeOnly>() },
+		{ typeof(DateOnly), new CollisionResistantHasherUnmanaged<DateOnly>() },
+		{ typeof(DateTime), new HashResistantPrimitives.DateTimeEqualityComparer() },
+		{ typeof(DateTimeOffset), new HashResistantPrimitives.DateTimeOffsetEqualityComparer() },
+		{ typeof(TimeSpan), new CollisionResistantHasherUnmanaged<TimeSpan>() },
+		{ typeof(Guid), new CollisionResistantHasherUnmanaged<Guid>() },
+	}.ToFrozenDictionary();
+
+	private readonly TypeDictionary equalityComparers = new();
+
+	/// <inheritdoc/>
+	public override object? VisitObject<T>(IObjectTypeShape<T> objectShape, object? state = null)
+	{
+		if (HashResistantPrimitiveEqualityComparers.TryGetValue(objectShape.Type, out object? primitiveEqualityComparer))
+		{
+			return primitiveEqualityComparer;
+		}
+
+		if (typeof(T) == typeof(byte[]))
+		{
+			return HashResistantPrimitives.ByteArrayEqualityComparer.Default;
+		}
+
+		if (typeof(IDeepSecureEqualityComparer<T>).IsAssignableFrom(objectShape.Type))
+		{
+			return SecureCustomEqualityComparer<T>.Default;
+		}
+
+		SecureAggregatingEqualityComparer<T> aggregatingEqualityComparer = new([
+			.. from property in objectShape.GetProperties()
+			   where property.HasGetter
+			   select (SecureEqualityComparer<T>)property.Accept(this, null)!]);
+
+		if (aggregatingEqualityComparer.IsEmpty)
+		{
+			throw new NotSupportedException($"The type {objectShape.Type} has no properties to compare by value.");
+		}
+
+		return aggregatingEqualityComparer;
+	}
+
+	/// <inheritdoc/>
+	public override object? VisitProperty<TDeclaringType, TPropertyType>(IPropertyShape<TDeclaringType, TPropertyType> propertyShape, object? state = null)
+		=> new SecurePropertyEqualityComparer<TDeclaringType, TPropertyType>(propertyShape.GetGetter(), this.GetEqualityComparer(propertyShape.PropertyType));
+
+	/// <inheritdoc/>
+	public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state = null)
+		=> new SecureEnumerableEqualityComparer<TEnumerable, TElement>(this.GetEqualityComparer(enumerableShape.ElementType), enumerableShape.GetGetEnumerable());
+
+	/// <inheritdoc/>
+	public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
+		=> new SecureDictionaryEqualityComparer<TDictionary, TKey, TValue>(dictionaryShape.GetGetDictionary(), this.GetEqualityComparer(dictionaryShape.KeyType), this.GetEqualityComparer(dictionaryShape.ValueType));
+
+	/// <inheritdoc/>
+	public override object? VisitEnum<TEnum, TUnderlying>(IEnumTypeShape<TEnum, TUnderlying> enumShape, object? state = null)
+		=> new HashResistantPrimitives.CollisionResistantEnumHasher<TEnum, TUnderlying>(this.GetEqualityComparer(enumShape.UnderlyingType));
+
+	/// <inheritdoc/>
+	public override object? VisitNullable<T>(INullableTypeShape<T> nullableShape, object? state = null)
+		=> new SecureNullableEqualityComparer<T>(this.GetEqualityComparer(nullableShape.ElementType));
+
+	/// <summary>
+	/// Gets or creates an equality comparer for the given type shape.
+	/// </summary>
+	/// <typeparam name="T">The data type to make convertible.</typeparam>
+	/// <param name="shape">The type shape.</param>
+	/// <param name="state">An optional state object to pass to the equality comparer.</param>
+	/// <returns>The equality comparer.</returns>
+	protected SecureEqualityComparer<T> GetEqualityComparer<T>(ITypeShape<T> shape, object? state = null)
+		=> this.equalityComparers.GetOrAdd<SecureEqualityComparer<T>>(shape, this, box => new DelayedEqualityComparer<T>(box));
+
+	private class DelayedEqualityComparer<T>(ResultBox<SecureEqualityComparer<T>> inner) : SecureEqualityComparer<T>
+	{
+		public override bool Equals(T? x, T? y) => inner.Result.Equals(x, y);
+
+		public override long GetSecureHashCode([DisallowNull] T obj) => inner.Result.GetSecureHashCode(obj);
+	}
+}

--- a/src/Nerdbank.MessagePack/SecureHash/SipHash.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SipHash.cs
@@ -1,0 +1,288 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+//// Originally from: https://github.com/paya-cz/siphash
+//// Author:          Pavel Werl
+//// License:         Public Domain
+//// SipHash website: https://131002.net/siphash/
+
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// Implements the <see href="https://en.wikipedia.org/wiki/SipHash">SipHash pseudo-random function</see>.
+/// </summary>
+/// <remarks>
+/// This class is immutable and thread-safe.
+/// </remarks>
+internal class SipHash
+{
+	/// <summary>
+	/// A shareable implementation initialized with a random key.
+	/// </summary>
+	internal static readonly SipHash Default = new();
+
+	/// <summary>
+	/// Part of the initial 256-bit internal state.
+	/// </summary>
+	private readonly ulong initialState0;
+
+	/// <summary>
+	/// Part of the initial 256-bit internal state.
+	/// </summary>
+	private readonly ulong initialState1;
+
+	/// <summary>Initializes a new instance of the <see cref="SipHash"/> class using a random key.</summary>
+	public SipHash()
+	{
+		using var rng = RandomNumberGenerator.Create();
+#if NET
+		Span<byte> key = stackalloc byte[16];
+		rng.GetBytes(key);
+#else
+		byte[] buffer = ArrayPool<byte>.Shared.Rent(16);
+		rng.GetBytes(buffer, 0, 16);
+		Span<byte> key = buffer;
+#endif
+
+		this.initialState0 = 0x736f6d6570736575UL ^ BinaryPrimitives.ReadUInt64LittleEndian(key);
+		this.initialState1 = 0x646f72616e646f6dUL ^ BinaryPrimitives.ReadUInt64LittleEndian(key.Slice(sizeof(ulong)));
+
+#if !NET
+		ArrayPool<byte>.Shared.Return(buffer);
+#endif
+	}
+
+	/// <summary>Initializes a new instance of the <see cref="SipHash"/> class using the specified 128-bit key.</summary>
+	/// <param name="key">Key for the SipHash pseudo-random function. Must be exactly 16 bytes long.</param>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="key"/> is not exactly 16 bytes long (128 bits).</exception>
+	public SipHash(ReadOnlySpan<byte> key)
+	{
+		if (key.Length != 16)
+		{
+			throw new ArgumentException("SipHash key must be exactly 128-bit long (16 bytes).", nameof(key));
+		}
+
+		this.initialState0 = 0x736f6d6570736575UL ^ BinaryPrimitives.ReadUInt64LittleEndian(key);
+		this.initialState1 = 0x646f72616e646f6dUL ^ BinaryPrimitives.ReadUInt64LittleEndian(key.Slice(sizeof(ulong)));
+	}
+
+	/// <summary>
+	/// Gets a 128-bit SipHash key.
+	/// </summary>
+	/// <param name="key">The 16-byte buffer that receives the key originally provided to the constructor.</param>
+	public void GetKey(Span<byte> key)
+	{
+		if (key.Length != 16)
+		{
+			throw new ArgumentException("SipHash key must be exactly 128-bit long (16 bytes).", nameof(key));
+		}
+
+		BinaryPrimitives.WriteUInt64LittleEndian(key, this.initialState0 ^ 0x736f6d6570736575UL);
+		BinaryPrimitives.WriteUInt64LittleEndian(key.Slice(sizeof(ulong)), this.initialState1 ^ 0x646f72616e646f6dUL);
+	}
+
+	/// <summary>Computes 64-bit SipHash tag for the specified message.</summary>
+	/// <param name="data">The byte array for which to compute a SipHash tag.</param>
+	/// <returns>Returns 64-bit (8 bytes) SipHash tag.</returns>
+	public long Compute(ReadOnlySpan<byte> data)
+	{
+		unchecked
+		{
+			// SipHash internal state
+			ulong v0 = this.initialState0;
+			ulong v1 = this.initialState1;
+
+			// It is faster to load the initialStateX fields from memory again than to reference v0 and v1:
+			ulong v2 = 0x1F160A001E161714UL ^ this.initialState0;
+			ulong v3 = 0x100A160317100A1EUL ^ this.initialState1;
+
+			// We process data in 64-bit blocks
+			ulong block;
+
+			// The last 64-bit block of data
+			int finalBlockPosition = data.Length & ~7;
+
+			// Process the input data in blocks of 64 bits
+			for (int blockPosition = 0; blockPosition < finalBlockPosition; blockPosition += sizeof(ulong))
+			{
+				block = MemoryMarshal.Read<ulong>(data.Slice(blockPosition));
+
+				v3 ^= block;
+
+				// Round 1
+				v0 += v1;
+				v2 += v3;
+				v1 = v1 << 13 | v1 >> 51;
+				v3 = v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 = v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 = v1 << 17 | v1 >> 47;
+				v3 = v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 = v2 << 32 | v2 >> 32;
+
+				// Round 2
+				v0 += v1;
+				v2 += v3;
+				v1 = v1 << 13 | v1 >> 51;
+				v3 = v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 = v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 = v1 << 17 | v1 >> 47;
+				v3 = v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 = v2 << 32 | v2 >> 32;
+
+				v0 ^= block;
+			}
+
+			// Load the remaining bytes
+			block = (ulong)data.Length << 56;
+			switch (data.Length & 7)
+			{
+				case 7:
+					block |= MemoryMarshal.Read<uint>(data.Slice(finalBlockPosition)) | (ulong)MemoryMarshal.Read<ushort>(data.Slice(finalBlockPosition + 4)) << 32 | (ulong)data[finalBlockPosition + 6] << 48;
+					break;
+				case 6:
+					block |= MemoryMarshal.Read<uint>(data.Slice(finalBlockPosition)) | (ulong)MemoryMarshal.Read<ushort>(data.Slice(finalBlockPosition + 4)) << 32;
+					break;
+				case 5:
+					block |= MemoryMarshal.Read<uint>(data.Slice(finalBlockPosition)) | (ulong)data[finalBlockPosition + 4] << 32;
+					break;
+				case 4:
+					block |= MemoryMarshal.Read<uint>(data.Slice(finalBlockPosition));
+					break;
+				case 3:
+					block |= MemoryMarshal.Read<ushort>(data.Slice(finalBlockPosition)) | (ulong)data[finalBlockPosition + 2] << 16;
+					break;
+				case 2:
+					block |= MemoryMarshal.Read<ushort>(data.Slice(finalBlockPosition));
+					break;
+				case 1:
+					block |= data[finalBlockPosition];
+					break;
+			}
+
+			// Process the final block
+			{
+				v3 ^= block;
+
+				// Round 1
+				v0 += v1;
+				v2 += v3;
+				v1 = v1 << 13 | v1 >> 51;
+				v3 = v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 = v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 = v1 << 17 | v1 >> 47;
+				v3 = v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 = v2 << 32 | v2 >> 32;
+
+				// Round 2
+				v0 += v1;
+				v2 += v3;
+				v1 = v1 << 13 | v1 >> 51;
+				v3 = v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 = v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 = v1 << 17 | v1 >> 47;
+				v3 = v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 = v2 << 32 | v2 >> 32;
+
+				v0 ^= block;
+				v2 ^= 0xff;
+			}
+
+			// 4 finalization rounds
+			{
+				// Round 1
+				v0 += v1;
+				v2 += v3;
+				v1 = v1 << 13 | v1 >> 51;
+				v3 = v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 = v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 = v1 << 17 | v1 >> 47;
+				v3 = v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 = v2 << 32 | v2 >> 32;
+
+				// Round 2
+				v0 += v1;
+				v2 += v3;
+				v1 = v1 << 13 | v1 >> 51;
+				v3 = v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 = v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 = v1 << 17 | v1 >> 47;
+				v3 = v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 = v2 << 32 | v2 >> 32;
+
+				// Round 3
+				v0 += v1;
+				v2 += v3;
+				v1 = v1 << 13 | v1 >> 51;
+				v3 = v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 = v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 = v1 << 17 | v1 >> 47;
+				v3 = v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 = v2 << 32 | v2 >> 32;
+
+				// Round 4
+				v0 += v1;
+				v2 += v3;
+				v1 = v1 << 13 | v1 >> 51;
+				v3 = v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 = v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 = v1 << 17 | v1 >> 47;
+				v3 = v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 = v2 << 32 | v2 >> 32;
+			}
+
+			return (long)(v0 ^ v1 ^ v2 ^ v3);
+		}
+	}
+}

--- a/test/Nerdbank.MessagePack.Tests/ByValueEqualityComparerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ByValueEqualityComparerTests.cs
@@ -1,0 +1,196 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Numerics;
+using PolyType.Tests;
+
+public abstract partial class ByValueEqualityComparerTests(ITestOutputHelper logger)
+{
+	internal enum FruitKind
+	{
+		Apple,
+		Banana,
+	}
+
+	[Fact]
+	public void Boolean() => this.AssertEqualityComparerBehavior<bool, Witness>([true], [false]);
+
+	[Fact]
+	public void BigInteger() => this.AssertEqualityComparerBehavior<BigInteger, Witness>([new BigInteger(5), new BigInteger(5)], [new BigInteger(10)]);
+
+	[Fact]
+	public void CustomType_Tree() => this.AssertEqualityComparerBehavior(
+		[new Tree([new Fruit(3, "Red"), new Fruit(4, "Green")], 4, FruitKind.Apple), new Tree([new Fruit(3, "Red"), new Fruit(4, "Green")], 4, FruitKind.Apple)],
+		[
+			new Tree([new Fruit(3, "Red"), new Fruit(4, "Yellow")], 4, FruitKind.Apple),
+			new Tree([new Fruit(3, "Red"), new Fruit(4, "Green")], 4, FruitKind.Banana),
+			new Tree([new Fruit(4, "Red")], 4, FruitKind.Banana),
+			new Tree([new Fruit(3, "Yellow")], 4, FruitKind.Apple)]);
+
+	[Fact]
+	public void CustomType_Fruit() => this.AssertEqualityComparerBehavior(
+		[new Fruit(3, "Red"), new Fruit(3, "Red")],
+		[new Fruit(4, "Red"), new Fruit(3, "Yellow")]);
+
+	[Fact]
+	public abstract void CustomHash();
+
+	[Fact]
+	public void CustomHashingAndEquality() => this.AssertEqualityComparerBehavior(
+		[new CustomHasher(), new CustomHasher()],
+		[new CustomHasher() { SpecialCode = 33 }]);
+
+	[Fact]
+	public void ReadOnlyMemoryOfByte() => this.AssertEqualityComparerBehavior(
+		[new HaveReadOnlyMemoryOfByte(new byte[] { 1, 2 }), new HaveReadOnlyMemoryOfByte(new byte[] { 1, 2 })],
+		[new HaveReadOnlyMemoryOfByte(new byte[] { 1, 3 }), new HaveReadOnlyMemoryOfByte(new byte[] { 1, 2, 3 })]);
+
+	[SkippableTheory(typeof(NotSupportedException))]
+	[MemberData(nameof(TestTypes.GetTestCases), MemberType = typeof(TestTypes))]
+	public void Equals_Exhaustive<T, TProvider>(TestCase<T, TProvider> testCase)
+		where TProvider : IShapeable<T>
+	{
+		// We do not expect these cases to work.
+		Skip.If(typeof(T) == typeof(object));
+
+		ITypeShape<T> shape = TProvider.GetShape();
+		IEqualityComparer<T> equalityComparer = this.GetEqualityComparer<T, TProvider>();
+		Assert.True(equalityComparer.Equals(testCase.Value, testCase.Value));
+	}
+
+	[SkippableTheory(typeof(NotSupportedException))]
+	[MemberData(nameof(TestTypes.GetTestCases), MemberType = typeof(TestTypes))]
+	public void GetHashCode_Exhaustive<T, TProvider>(TestCase<T, TProvider> testCase)
+		where TProvider : IShapeable<T>
+	{
+		// We do not expect these cases to work.
+		Skip.If(typeof(T) == typeof(object));
+
+		ITypeShape<T> shape = TProvider.GetShape();
+		IEqualityComparer<T> equalityComparer = this.GetEqualityComparer<T, TProvider>();
+
+		// We don't really have anything useful to check the return value against, but
+		// at least verify it doesn't throw.
+		if (testCase.Value is not null)
+		{
+			equalityComparer.GetHashCode(testCase.Value);
+		}
+	}
+
+	protected abstract IEqualityComparer<T> GetEqualityComparer<T, TProvider>()
+		where TProvider : IShapeable<T>;
+
+	/// <inheritdoc cref="AssertEqualityComparerBehavior{T, TProvider}(T[], T[])"/>
+	private void AssertEqualityComparerBehavior<T>(T[] equivalent, T[] different)
+		where T : notnull, IShapeable<T>
+		=> this.AssertEqualityComparerBehavior<T, T>(equivalent, different);
+
+	/// <summary>
+	/// Asserts that hash codes and equality checks match or mismatch for various values.
+	/// </summary>
+	/// <typeparam name="T">The type of the values to be tested.</typeparam>
+	/// <typeparam name="TProvider">The witness type for the data type.</typeparam>
+	/// <param name="equivalent">An array of values that should all be considered equivalent.</param>
+	/// <param name="different">An array of values that are each distinct from any of the values in the <paramref name="equivalent"/> array.</param>
+	private void AssertEqualityComparerBehavior<T, TProvider>(T[] equivalent, T[] different)
+		where TProvider : IShapeable<T>
+		where T : notnull
+	{
+		IEqualityComparer<T> eq = this.GetEqualityComparer<T, TProvider>();
+		foreach (T valueA in equivalent)
+		{
+			int valueAHashCode = eq.GetHashCode(valueA);
+			logger.WriteLine($"{valueA} hash code: {valueAHashCode}");
+
+			foreach (T valueB in equivalent)
+			{
+				int valueBHashCode = eq.GetHashCode(valueB);
+				logger.WriteLine($"{valueB} hash code: {valueBHashCode}");
+				Assert.True(eq.Equals(valueA, valueB));
+				Assert.Equal(valueAHashCode, valueBHashCode);
+			}
+		}
+
+		T baseline = equivalent[0];
+		int baselineHashCode = eq.GetHashCode(baseline);
+		foreach (T differentValue in different)
+		{
+			int differentValueHashCode = eq.GetHashCode(differentValue);
+			logger.WriteLine($"{differentValue} hash code: {differentValueHashCode}");
+			Assert.False(eq.Equals(equivalent[0], differentValue));
+			Assert.NotEqual(baselineHashCode, differentValueHashCode);
+		}
+	}
+
+	public class DefaultByValue(ITestOutputHelper logger) : ByValueEqualityComparerTests(logger)
+	{
+		[Fact]
+		public override void CustomHash()
+		{
+			CustomHasher obj = new();
+			Assert.Equal(obj.SpecialCode, this.GetEqualityComparer<CustomHasher, CustomHasher>().GetHashCode(obj));
+		}
+
+		protected override IEqualityComparer<T> GetEqualityComparer<T, TProvider>()
+			=> ByValueEqualityComparer<T, TProvider>.Default;
+	}
+
+	public class HashCollisionResistant(ITestOutputHelper logger) : ByValueEqualityComparerTests(logger)
+	{
+		[Fact]
+		public override void CustomHash()
+		{
+			CustomHasher obj = new();
+			Assert.Equal(obj.SpecialCode * 2, this.GetEqualityComparer<CustomHasher, CustomHasher>().GetHashCode(obj));
+		}
+
+		protected override IEqualityComparer<T> GetEqualityComparer<T, TProvider>()
+			=> ByValueEqualityComparer<T, TProvider>.HashResistant;
+	}
+
+	[GenerateShape<bool>]
+	[GenerateShape<BigInteger>]
+	internal partial class Witness;
+
+	[GenerateShape]
+	internal partial class Tree(Fruit[] fruits, int height, FruitKind kind)
+	{
+		public Fruit[] Fruits => fruits;
+
+		public int Height => height;
+
+		public FruitKind Kind => kind;
+
+		public override string ToString() => $"{kind} tree with {fruits.Length} fruits and height {height}";
+	}
+
+	[GenerateShape]
+	internal partial class Fruit(int weight, string color)
+	{
+		public int Weight => weight;
+
+		public string Color => color;
+
+		public override string ToString() => $"Fruit weighing {weight} and color {color}";
+	}
+
+	[GenerateShape]
+	internal partial class HaveReadOnlyMemoryOfByte(ReadOnlyMemory<byte> buffer)
+	{
+		public ReadOnlyMemory<byte> Buffer => buffer;
+	}
+
+	[GenerateShape]
+	internal partial class CustomHasher : IDeepSecureEqualityComparer<CustomHasher>
+	{
+		// This is internal on purpose, so that PolyType will ignore the property for purposes of equality
+		// and hashing, and tests will only pass if the custom hash and equality methods on this class are used.
+		internal int SpecialCode { get; set; } = 42;
+
+		public bool DeepEquals(CustomHasher? other) => other is not null && this.SpecialCode == other.SpecialCode;
+
+		public long GetSecureHashCode() => this.SpecialCode * 2;
+
+		public override int GetHashCode() => this.SpecialCode;
+	}
+}

--- a/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
+++ b/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Xunit.Combinatorial" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This makes it easy to use secure, hash-collision resistant equality comparer with arbitrary types for safely deserializing data.

This improves the #33 story, but doesn't close it.