### PR TITLE
Accept values to be serialized with `in` instead of `ref`

### DIFF
--- a/docfx/analyzers/NBMsgPack020.md
+++ b/docfx/analyzers/NBMsgPack020.md
@@ -32,6 +32,6 @@ class MyType
 public class MyTypeConverter : MessagePackConverter<MyType>
 {
 	public override MyType Deserialize(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
-	public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context) => throw new System.NotImplementedException();
+	public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context) => throw new System.NotImplementedException();
 }
 ```

--- a/docfx/analyzers/NBMsgPack021.md
+++ b/docfx/analyzers/NBMsgPack021.md
@@ -18,7 +18,7 @@ public class MyTypeConverter : MessagePackConverter<MyType>
 {
 	private MyTypeConverter() { }
 	public override MyType Deserialize(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
-	public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context) => throw new System.NotImplementedException();
+	public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context) => throw new System.NotImplementedException();
 }
 ```
 
@@ -35,6 +35,6 @@ public class MyType
 public class MyTypeConverter : MessagePackConverter<MyType>
 {
 	public override MyType Deserialize(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
-	public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context) => throw new System.NotImplementedException();
+	public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context) => throw new System.NotImplementedException();
 }
 ```

--- a/docfx/analyzers/NBMsgPack030.md
+++ b/docfx/analyzers/NBMsgPack030.md
@@ -15,7 +15,7 @@ public class MyTypeConverter : MessagePackConverter<MyType>
 {
     public override MyType? Deserialize(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
 
-    public override void Serialize(ref MessagePackWriter writer, ref MyType? value, SerializationContext context)
+    public override void Serialize(ref MessagePackWriter writer, in MyType? value, SerializationContext context)
     {
         var serializer = new MessagePackSerializer(); // NBMsgPack030
         serializer.Serialize(value.SomeProperty);     // NBMsgPack030
@@ -36,7 +36,7 @@ public class SomeOtherType {}
 Replace top-level calls to the serializer to direct calls to a converter, which may come from @Nerdbank.MessagePack.SerializationContext.GetConverter*?displayProperty=nameWithType.
 
 ```cs
-public override void Serialize(ref MessagePackWriter writer, ref MyType? value, SerializationContext context)
+public override void Serialize(ref MessagePackWriter writer, in MyType? value, SerializationContext context)
 {
     SomeOtherType? someProperty = value.SomeProperty;
     context.GetConverter<SomeOtherType>().Serialize(ref writer, ref someProperty, context);

--- a/docfx/analyzers/NBMsgPack031.md
+++ b/docfx/analyzers/NBMsgPack031.md
@@ -20,7 +20,7 @@ public class MyTypeConverter : MessagePackConverter<MyType>
         return new MyType(a, b);
     }
 
-    public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+    public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context)
     {
         writer.Write(value.A);
         writer.Write(value.B);  // NBMsgPack031
@@ -40,7 +40,7 @@ public class MyTypeConverter : MessagePackConverter<MyType>
         return new MyType(a, b);
     }
 
-    public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+    public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context)
     {
         AnotherType a = context.GetConverter<AnotherType>().Serialize(ref writer, ref value.A, context);
         YetAnotherType b = context.GetConverter<YetAnotherType>().Serialize(ref writer, ref value.B, context);  // NBMsgPack031
@@ -73,7 +73,7 @@ public class MyTypeConverter : MessagePackConverter<MyType>
         return new MyType(property1, property2);
     }
 
-    public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+    public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context)
     {
         writer.WriteArrayHeader(2);
         writer.Write(value.Property1);

--- a/docfx/docs/custom-converters.md
+++ b/docfx/docs/custom-converters.md
@@ -46,7 +46,7 @@ class FooConverter : MessagePackConverter<Foo?>
         return new Foo(property1, property2);
     }
 
-    public override void Serialize(ref MessagePackWriter writer, ref Foo? value, SerializationContext context)
+    public override void Serialize(ref MessagePackWriter writer, in Foo? value, SerializationContext context)
     {
         if (value is null)
         {
@@ -81,7 +81,7 @@ In the @"Nerdbank.MessagePack.MessagePackConverter`1.Deserialize*" method, use @
 The @Nerdbank.MessagePack.SerializationContext.GetConverter* method may be used to obtain a converter to use for members of the type your converter is serializing or deserializing.
 
 ```cs
-public override void Serialize(ref MessagePackWriter writer, ref Foo? value, SerializationContext context)
+public override void Serialize(ref MessagePackWriter writer, in Foo? value, SerializationContext context)
 {
     if (value is null)
     {
@@ -108,7 +108,7 @@ For convenience, you may want to apply it directly to your custom converter:
 [GenerateShape<SomeOtherType>]
 class FooConverter : MessagePackConverter<Foo>
 {
-    public override void Serialize(ref MessagePackWriter writer, ref Foo? value, SerializationContext context)
+    public override void Serialize(ref MessagePackWriter writer, in Foo? value, SerializationContext context)
     {
         // ...
         context.GetConverter<SomeOtherType, FooConverter>().Serialize(ref writer, ref propertyValue, context);

--- a/src/Nerdbank.MessagePack/Converters/ArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayConverter`1.cs
@@ -34,7 +34,7 @@ internal class ArrayConverter<TElement>(MessagePackConverter<TElement> elementCo
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref TElement[]? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in TElement[]? value, SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -46,7 +46,7 @@ internal class ArrayConverter<TElement>(MessagePackConverter<TElement> elementCo
 		writer.WriteArrayHeader(value.Length);
 		for (int i = 0; i < value.Length; i++)
 		{
-			elementConverter.Serialize(ref writer, ref value[i]!, context);
+			elementConverter.Serialize(ref writer, value[i], context);
 		}
 	}
 
@@ -97,7 +97,7 @@ internal class ArrayConverter<TElement>(MessagePackConverter<TElement> elementCo
 						break;
 					}
 
-					elementConverter.Serialize(ref syncWriter, ref value[progress]!, context);
+					elementConverter.Serialize(ref syncWriter, value[progress], context);
 					cancellationToken.ThrowIfCancellationRequested();
 				}
 

--- a/src/Nerdbank.MessagePack/Converters/ArrayWithFlattenedDimensionsConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayWithFlattenedDimensionsConverter`2.cs
@@ -62,7 +62,7 @@ internal class ArrayWithFlattenedDimensionsConverter<TArray, TElement>(MessagePa
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref TArray? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in TArray? value, SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -87,7 +87,7 @@ internal class ArrayWithFlattenedDimensionsConverter<TArray, TElement>(MessagePa
 		writer.WriteArrayHeader(elements.Length);
 		for (int i = 0; i < elements.Length; i++)
 		{
-			elementConverter.Serialize(ref writer, ref elements[i]!, context);
+			elementConverter.Serialize(ref writer, elements[i], context);
 		}
 	}
 

--- a/src/Nerdbank.MessagePack/Converters/ArrayWithNestedDimensionsConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayWithNestedDimensionsConverter`2.cs
@@ -43,7 +43,7 @@ internal class ArrayWithNestedDimensionsConverter<TArray, TElement>(MessagePackC
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref TArray? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in TArray? value, SerializationContext context)
 	{
 		Array? array = (Array?)(object?)value;
 		if (array is null)
@@ -96,7 +96,7 @@ internal class ArrayWithNestedDimensionsConverter<TArray, TElement>(MessagePackC
 		{
 			for (int i = 0; i < outerDimension; i++)
 			{
-				elementConverter.Serialize(ref writer, ref elements[i]!, context);
+				elementConverter.Serialize(ref writer, elements[i], context);
 			}
 		}
 	}

--- a/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
+++ b/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
@@ -17,7 +17,7 @@ namespace Nerdbank.MessagePack.Converters;
 /// <param name="container">The instance of the data type to be serialized.</param>
 /// <param name="writer">The means by which msgpack should be written.</param>
 /// <param name="context"><inheritdoc cref="MessagePackConverter{T}.Serialize" path="/param[@name='context']"/></param>
-internal delegate void SerializeProperty<TDeclaringType>(ref TDeclaringType container, ref MessagePackWriter writer, SerializationContext context);
+internal delegate void SerializeProperty<TDeclaringType>(in TDeclaringType container, ref MessagePackWriter writer, SerializationContext context);
 
 /// <summary>
 /// A delegate that can asynchronously serialize a property to a <see cref="MessagePackAsyncWriter"/>.

--- a/src/Nerdbank.MessagePack/Converters/DelayedConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/DelayedConverter`1.cs
@@ -14,5 +14,5 @@ internal class DelayedConverter<T>(ResultBox<MessagePackConverter<T>> box) : Mes
 	public override T? Deserialize(ref MessagePackReader reader, SerializationContext context) => box.Result.Deserialize(ref reader, context);
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context) => box.Result.Serialize(ref writer, ref value, context);
+	public override void Serialize(ref MessagePackWriter writer, in T? value, SerializationContext context) => box.Result.Serialize(ref writer, value, context);
 }

--- a/src/Nerdbank.MessagePack/Converters/DictionaryConverter`3.cs
+++ b/src/Nerdbank.MessagePack/Converters/DictionaryConverter`3.cs
@@ -36,7 +36,7 @@ internal class DictionaryConverter<TDictionary, TKey, TValue>(Func<TDictionary, 
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref TDictionary? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in TDictionary? value, SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -52,8 +52,8 @@ internal class DictionaryConverter<TDictionary, TKey, TValue>(Func<TDictionary, 
 			TKey? entryKey = pair.Key;
 			TValue? entryValue = pair.Value;
 
-			keyConverter.Serialize(ref writer, ref entryKey, context);
-			valueConverter.Serialize(ref writer, ref entryValue, context);
+			keyConverter.Serialize(ref writer, entryKey, context);
+			valueConverter.Serialize(ref writer, entryValue, context);
 		}
 	}
 

--- a/src/Nerdbank.MessagePack/Converters/EnumAsOrdinalConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/EnumAsOrdinalConverter`2.cs
@@ -14,9 +14,8 @@ internal class EnumAsOrdinalConverter<TEnum, TUnderlyingType>(MessagePackConvert
 	public override TEnum? Deserialize(ref MessagePackReader reader, SerializationContext context) => (TEnum?)(object?)primitiveConverter.Deserialize(ref reader, context);
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref TEnum? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in TEnum? value, SerializationContext context)
 	{
-		TUnderlyingType? intValue = (TUnderlyingType?)(object?)value;
-		primitiveConverter.Serialize(ref writer, ref intValue, context);
+		primitiveConverter.Serialize(ref writer, (TUnderlyingType?)(object?)value, context);
 	}
 }

--- a/src/Nerdbank.MessagePack/Converters/EnumerableConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/EnumerableConverter`2.cs
@@ -32,7 +32,7 @@ internal class EnumerableConverter<TEnumerable, TElement>(Func<TEnumerable, IEnu
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref TEnumerable? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in TEnumerable? value, SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -47,8 +47,7 @@ internal class EnumerableConverter<TEnumerable, TElement>(Func<TEnumerable, IEnu
 			writer.WriteArrayHeader(count);
 			foreach (TElement element in enumerable)
 			{
-				TElement? el = element;
-				elementConverter.Serialize(ref writer, ref el, context);
+				elementConverter.Serialize(ref writer, element, context);
 			}
 		}
 		else
@@ -57,7 +56,7 @@ internal class EnumerableConverter<TEnumerable, TElement>(Func<TEnumerable, IEnu
 			writer.WriteArrayHeader(array.Length);
 			for (int i = 0; i < array.Length; i++)
 			{
-				elementConverter.Serialize(ref writer, ref array[i], context);
+				elementConverter.Serialize(ref writer, array[i], context);
 			}
 		}
 	}

--- a/src/Nerdbank.MessagePack/Converters/IntConverters.cs
+++ b/src/Nerdbank.MessagePack/Converters/IntConverters.cs
@@ -17,7 +17,7 @@ internal class SByteConverter : MessagePackConverter<SByte>
 	public override SByte Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadSByte();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref SByte value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in SByte value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="Int16"/> as a MessagePack integer.</summary>
@@ -27,7 +27,7 @@ internal class Int16Converter : MessagePackConverter<Int16>
 	public override Int16 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt16();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref Int16 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in Int16 value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="Int32"/> as a MessagePack integer.</summary>
@@ -37,7 +37,7 @@ internal class Int32Converter : MessagePackConverter<Int32>
 	public override Int32 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt32();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref Int32 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in Int32 value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="Int64"/> as a MessagePack integer.</summary>
@@ -47,7 +47,7 @@ internal class Int64Converter : MessagePackConverter<Int64>
 	public override Int64 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt64();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref Int64 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in Int64 value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="Byte"/> as a MessagePack integer.</summary>
@@ -57,7 +57,7 @@ internal class ByteConverter : MessagePackConverter<Byte>
 	public override Byte Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadByte();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref Byte value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in Byte value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="UInt16"/> as a MessagePack integer.</summary>
@@ -67,7 +67,7 @@ internal class UInt16Converter : MessagePackConverter<UInt16>
 	public override UInt16 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadUInt16();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref UInt16 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in UInt16 value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="UInt32"/> as a MessagePack integer.</summary>
@@ -77,7 +77,7 @@ internal class UInt32Converter : MessagePackConverter<UInt32>
 	public override UInt32 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadUInt32();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref UInt32 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in UInt32 value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>Serializes the primitive integer type <see cref="UInt64"/> as a MessagePack integer.</summary>
@@ -87,5 +87,5 @@ internal class UInt64Converter : MessagePackConverter<UInt64>
 	public override UInt64 Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadUInt64();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref UInt64 value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in UInt64 value, SerializationContext context) => writer.Write(value);
 }

--- a/src/Nerdbank.MessagePack/Converters/IntConverters.tt
+++ b/src/Nerdbank.MessagePack/Converters/IntConverters.tt
@@ -21,6 +21,6 @@ internal class <#=type#>Converter : MessagePackConverter<<#=type#>>
 	public override <#=type#> Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.Read<#=type#>();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref <#=type#> value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in <#=type#> value, SerializationContext context) => writer.Write(value);
 }
 <# } #>

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
@@ -47,7 +47,7 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in T? value, SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -62,7 +62,7 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 		{
 			if (properties[i]?.MsgPackWriters is var (serialize, _))
 			{
-				serialize(ref value, ref writer, context);
+				serialize(value, ref writer, context);
 			}
 			else
 			{

--- a/src/Nerdbank.MessagePack/Converters/ObjectMapConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapConverter`1.cs
@@ -19,7 +19,7 @@ internal class ObjectMapConverter<T>(MapSerializableProperties<T> serializable, 
 	public override bool PreferAsyncSerialization => true;
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in T? value, SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -34,7 +34,7 @@ internal class ObjectMapConverter<T>(MapSerializableProperties<T> serializable, 
 			foreach (SerializableProperty<T> property in serializable.Properties)
 			{
 				writer.WriteRaw(property.RawPropertyNameString.Span);
-				property.Write(ref value, ref writer, context);
+				property.Write(value, ref writer, context);
 			}
 		}
 	}

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
@@ -20,7 +20,7 @@ internal class StringConverter : MessagePackConverter<string>
 	public override string? Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadString();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref string? value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in string? value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
@@ -32,7 +32,7 @@ internal class BooleanConverter : MessagePackConverter<bool>
 	public override bool Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadBoolean();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref bool value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in bool value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
@@ -44,7 +44,7 @@ internal class VersionConverter : MessagePackConverter<Version?>
 	public override Version? Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadString() is string value ? new Version(value) : null;
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref Version? value, SerializationContext context) => writer.Write(value?.ToString());
+	public override void Serialize(ref MessagePackWriter writer, in Version? value, SerializationContext context) => writer.Write(value?.ToString());
 }
 
 /// <summary>
@@ -56,7 +56,7 @@ internal class UriConverter : MessagePackConverter<Uri?>
 	public override Uri? Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadString() is string value ? new Uri(value, UriKind.RelativeOrAbsolute) : null;
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref Uri? value, SerializationContext context) => writer.Write(value?.OriginalString);
+	public override void Serialize(ref MessagePackWriter writer, in Uri? value, SerializationContext context) => writer.Write(value?.OriginalString);
 }
 
 /// <summary>
@@ -68,7 +68,7 @@ internal class HalfConverter : MessagePackConverter<Half>
 	public override Half Deserialize(ref MessagePackReader reader, SerializationContext context) => (Half)reader.ReadSingle();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref Half value, SerializationContext context) => writer.Write((float)value);
+	public override void Serialize(ref MessagePackWriter writer, in Half value, SerializationContext context) => writer.Write((float)value);
 }
 
 /// <summary>
@@ -80,7 +80,7 @@ internal class SingleConverter : MessagePackConverter<float>
 	public override float Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadSingle();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref float value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in float value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
@@ -92,7 +92,7 @@ internal class DoubleConverter : MessagePackConverter<double>
 	public override double Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadDouble();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref double value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in double value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
@@ -166,7 +166,7 @@ internal class DecimalConverter : MessagePackConverter<decimal>
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref decimal value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in decimal value, SerializationContext context)
 	{
 		Span<byte> dest = writer.GetSpan(1 + MessagePackRange.MaxFixStringLength);
 		if (System.Buffers.Text.Utf8Formatter.TryFormat(value, dest.Slice(1, MessagePackRange.MaxFixStringLength), out var written))
@@ -236,7 +236,7 @@ internal class Int128Converter : MessagePackConverter<Int128>
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref Int128 value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in Int128 value, SerializationContext context)
 	{
 		Span<byte> dest = writer.GetSpan(1 + MessagePackRange.MaxFixStringLength);
 		if (value.TryFormat(dest.Slice(1, MessagePackRange.MaxFixStringLength), out var written, provider: CultureInfo.InvariantCulture))
@@ -306,7 +306,7 @@ internal class UInt128Converter : MessagePackConverter<UInt128>
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref UInt128 value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in UInt128 value, SerializationContext context)
 	{
 		Span<byte> dest = writer.GetSpan(1 + MessagePackRange.MaxFixStringLength);
 		if (value.TryFormat(dest.Slice(1, MessagePackRange.MaxFixStringLength), out var written, provider: CultureInfo.InvariantCulture))
@@ -353,7 +353,7 @@ internal class BigIntegerConverter : MessagePackConverter<BigInteger>
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref BigInteger value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in BigInteger value, SerializationContext context)
 	{
 		// try to get bin8 buffer.
 		Span<byte> span = writer.GetSpan(byte.MaxValue);
@@ -382,7 +382,7 @@ internal class DateTimeConverter : MessagePackConverter<DateTime>
 	public override DateTime Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadDateTime();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref DateTime value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in DateTime value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
@@ -405,7 +405,7 @@ internal class DateTimeOffsetConverter : MessagePackConverter<DateTimeOffset>
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref DateTimeOffset value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in DateTimeOffset value, SerializationContext context)
 	{
 		writer.WriteArrayHeader(2);
 		writer.Write(new DateTime(value.Ticks, DateTimeKind.Utc));
@@ -422,7 +422,7 @@ internal class DateOnlyConverter : MessagePackConverter<DateOnly>
 	public override DateOnly Deserialize(ref MessagePackReader reader, SerializationContext context) => DateOnly.FromDayNumber(reader.ReadInt32());
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref DateOnly value, SerializationContext context) => writer.Write(value.DayNumber);
+	public override void Serialize(ref MessagePackWriter writer, in DateOnly value, SerializationContext context) => writer.Write(value.DayNumber);
 }
 
 /// <summary>
@@ -434,7 +434,7 @@ internal class TimeOnlyConverter : MessagePackConverter<TimeOnly>
 	public override TimeOnly Deserialize(ref MessagePackReader reader, SerializationContext context) => new TimeOnly(reader.ReadInt64());
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref TimeOnly value, SerializationContext context) => writer.Write(value.Ticks);
+	public override void Serialize(ref MessagePackWriter writer, in TimeOnly value, SerializationContext context) => writer.Write(value.Ticks);
 }
 
 /// <summary>
@@ -446,7 +446,7 @@ internal class TimeSpanConverter : MessagePackConverter<TimeSpan>
 	public override TimeSpan Deserialize(ref MessagePackReader reader, SerializationContext context) => new TimeSpan(reader.ReadInt64());
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref TimeSpan value, SerializationContext context) => writer.Write(value.Ticks);
+	public override void Serialize(ref MessagePackWriter writer, in TimeSpan value, SerializationContext context) => writer.Write(value.Ticks);
 }
 
 /// <summary>
@@ -458,7 +458,7 @@ internal class RuneConverter : MessagePackConverter<Rune>
 	public override Rune Deserialize(ref MessagePackReader reader, SerializationContext context) => new Rune(reader.ReadInt32());
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref Rune value, SerializationContext context) => writer.Write(value.Value);
+	public override void Serialize(ref MessagePackWriter writer, in Rune value, SerializationContext context) => writer.Write(value.Value);
 }
 
 /// <summary>
@@ -470,7 +470,7 @@ internal class CharConverter : MessagePackConverter<char>
 	public override char Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadChar();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref char value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in char value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
@@ -482,7 +482,7 @@ internal class ByteArrayConverter : MessagePackConverter<byte[]?>
 	public override byte[]? Deserialize(ref MessagePackReader reader, SerializationContext context) => reader.ReadBytes()?.ToArray();
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref byte[]? value, SerializationContext context) => writer.Write(value);
+	public override void Serialize(ref MessagePackWriter writer, in byte[]? value, SerializationContext context) => writer.Write(value);
 }
 
 /// <summary>
@@ -510,7 +510,7 @@ internal class GuidConverter : MessagePackConverter<Guid>
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref Guid value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in Guid value, SerializationContext context)
 	{
 		writer.WriteBinHeader(GuidLength);
 		Assumes.True(value.TryWriteBytes(writer.GetSpan(GuidLength)));
@@ -527,12 +527,11 @@ internal class NullableConverter<T>(MessagePackConverter<T> elementConverter) : 
 	where T : struct
 {
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in T? value, SerializationContext context)
 	{
 		if (value.HasValue)
 		{
-			T nonnullValue = value.Value;
-			elementConverter.Serialize(ref writer, ref nonnullValue, context);
+			elementConverter.Serialize(ref writer, value.Value, context);
 		}
 		else
 		{

--- a/src/Nerdbank.MessagePack/Converters/SubTypeUnionConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/SubTypeUnionConverter`1.cs
@@ -41,7 +41,7 @@ internal class SubTypeUnionConverter<TBase>(SubTypes subTypes, MessagePackConver
 	}
 
 	/// <inheritdoc/>
-	public override void Serialize(ref MessagePackWriter writer, ref TBase? value, SerializationContext context)
+	public override void Serialize(ref MessagePackWriter writer, in TBase? value, SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -56,7 +56,7 @@ internal class SubTypeUnionConverter<TBase>(SubTypes subTypes, MessagePackConver
 		{
 			// The runtime type of the value matches the base exactly. Use nil as the alias.
 			writer.WriteNil();
-			baseConverter.Serialize(ref writer, ref value, context);
+			baseConverter.Serialize(ref writer, value, context);
 		}
 		else if (subTypes.Serializers.TryGetValue(valueType, out (int Alias, IMessagePackConverter Converter) result))
 		{

--- a/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
+++ b/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
@@ -28,7 +28,7 @@ public abstract class MessagePackConverter<T> : IMessagePackConverter
 	/// <param name="writer">The writer to use.</param>
 	/// <param name="value">The value to serialize.</param>
 	/// <param name="context">Context for the serialization.</param>
-	public abstract void Serialize(ref MessagePackWriter writer, ref T? value, SerializationContext context);
+	public abstract void Serialize(ref MessagePackWriter writer, in T? value, SerializationContext context);
 
 	/// <summary>
 	/// Deserializes an instance of <typeparamref name="T"/>.
@@ -65,7 +65,7 @@ public abstract class MessagePackConverter<T> : IMessagePackConverter
 		cancellationToken.ThrowIfCancellationRequested();
 
 		MessagePackWriter syncWriter = writer.CreateWriter();
-		this.Serialize(ref syncWriter, ref value, context);
+		this.Serialize(ref syncWriter, value, context);
 		syncWriter.Flush();
 
 		// On our way out, pause to flush the pipe if a lot of data has accumulated in the buffer.
@@ -108,8 +108,7 @@ public abstract class MessagePackConverter<T> : IMessagePackConverter
 	/// <inheritdoc/>
 	void IMessagePackConverter.Serialize(ref MessagePackWriter writer, ref object? value, SerializationContext context)
 	{
-		T? typedValue = (T?)value;
-		this.Serialize(ref writer, ref typedValue, context);
+		this.Serialize(ref writer, (T?)value, context);
 	}
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -107,7 +107,7 @@ public record MessagePackSerializer
 	/// <typeparam name="T">The type of value to be serialized. This must be able to disclose its own shape.</typeparam>
 	/// <param name="value">The value to be serialized.</param>
 	/// <returns>The byte array.</returns>
-	public byte[] Serialize<T>(T? value)
+	public byte[] Serialize<T>(in T? value)
 		where T : IShapeable<T> => this.Serialize(value, T.GetShape());
 
 	/// <summary>
@@ -117,7 +117,7 @@ public record MessagePackSerializer
 	/// <param name="value">The value to be serialized.</param>
 	/// <param name="shape">The shape of the type.</param>
 	/// <returns>The byte array.</returns>
-	public byte[] Serialize<T>(T? value, ITypeShape<T> shape)
+	public byte[] Serialize<T>(in T? value, ITypeShape<T> shape)
 	{
 		byte[]? array = scratchArray;
 		if (array == null)
@@ -130,12 +130,12 @@ public record MessagePackSerializer
 		return writer.FlushAndGetArray();
 	}
 
-	/// <inheritdoc cref="Serialize{T, TProvider}(IBufferWriter{byte}, T)"/>
-	public void Serialize<T>(IBufferWriter<byte> writer, T? value)
+	/// <inheritdoc cref="Serialize{T, TProvider}(IBufferWriter{byte}, in T)"/>
+	public void Serialize<T>(IBufferWriter<byte> writer, in T? value)
 		where T : IShapeable<T> => this.Serialize(writer, value, T.GetShape());
 
-	/// <inheritdoc cref="Serialize{T}(IBufferWriter{byte}, T, ITypeShape{T})"/>
-	public void Serialize<T, TProvider>(IBufferWriter<byte> writer, T? value)
+	/// <inheritdoc cref="Serialize{T}(IBufferWriter{byte}, in T, ITypeShape{T})"/>
+	public void Serialize<T, TProvider>(IBufferWriter<byte> writer, in T? value)
 		where TProvider : IShapeable<T> => this.Serialize(writer, value, TProvider.GetShape());
 
 	/// <summary>
@@ -145,15 +145,15 @@ public record MessagePackSerializer
 	/// <param name="writer">The writer to use.</param>
 	/// <param name="value">The value to serialize.</param>
 	/// <param name="shape">The shape of <typeparamref name="T"/>.</param>
-	public void Serialize<T>(IBufferWriter<byte> writer, T? value, ITypeShape<T> shape)
+	public void Serialize<T>(IBufferWriter<byte> writer, in T? value, ITypeShape<T> shape)
 	{
 		MessagePackWriter msgpackWriter = new(writer);
 		this.Serialize(ref msgpackWriter, value, shape);
 		msgpackWriter.Flush();
 	}
 
-	/// <inheritdoc cref="Serialize{T, TProvider}(ref MessagePackWriter, T)"/>
-	public void Serialize<T>(ref MessagePackWriter writer, T? value)
+	/// <inheritdoc cref="Serialize{T, TProvider}(ref MessagePackWriter, in T)"/>
+	public void Serialize<T>(ref MessagePackWriter writer, in T? value)
 		where T : IShapeable<T> => this.Serialize(ref writer, value, T.GetShape());
 
 	/// <summary>
@@ -163,7 +163,7 @@ public record MessagePackSerializer
 	/// <typeparam name="TProvider">The shape provider of <typeparamref name="T"/>. This may be the same as <typeparamref name="T"/> when the data type is attributed with <see cref="GenerateShapeAttribute"/>, or it may be another "witness" partial class that was annotated with <see cref="GenerateShapeAttribute{T}"/> where T for the attribute is the same as the <typeparamref name="T"/> used here.</typeparam>
 	/// <param name="writer">The writer to use.</param>
 	/// <param name="value">The value to serialize.</param>
-	public void Serialize<T, TProvider>(ref MessagePackWriter writer, T? value)
+	public void Serialize<T, TProvider>(ref MessagePackWriter writer, in T? value)
 		where TProvider : IShapeable<T> => this.Serialize<T>(ref writer, value, TProvider.GetShape());
 
 	/// <summary>
@@ -173,7 +173,7 @@ public record MessagePackSerializer
 	/// <param name="writer">The msgpack writer to use.</param>
 	/// <param name="value">The value to serialize.</param>
 	/// <param name="shape">The shape of <typeparamref name="T"/>.</param>
-	public void Serialize<T>(ref MessagePackWriter writer, T? value, ITypeShape<T> shape) => this.GetOrAddConverter(shape).Serialize(ref writer, ref value, this.CreateSerializationContext());
+	public void Serialize<T>(ref MessagePackWriter writer, in T? value, ITypeShape<T> shape) => this.GetOrAddConverter(shape).Serialize(ref writer, value, this.CreateSerializationContext());
 
 	/// <inheritdoc cref="Deserialize{T, TProvider}(ReadOnlySequence{byte})"/>
 	public T? Deserialize<T>(byte[] buffer)
@@ -227,7 +227,7 @@ public record MessagePackSerializer
 	/// Deserializes a value from a <see cref="PipeReader"/>.
 	/// </summary>
 	/// <typeparam name="T">The type of value to deserialize.</typeparam>
-	/// <typeparam name="TProvider"><inheritdoc cref="Serialize{T, TProvider}(ref MessagePackWriter, T)" path="/typeparam[@name='TProvider']"/></typeparam>
+	/// <typeparam name="TProvider"><inheritdoc cref="Serialize{T, TProvider}(ref MessagePackWriter, in T)" path="/typeparam[@name='TProvider']"/></typeparam>
 	/// <param name="reader">The reader to deserialize from.</param>
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>The deserialized value.</returns>
@@ -266,7 +266,7 @@ public record MessagePackSerializer
 	/// Deserializes a value from a <see cref="MessagePackReader"/>.
 	/// </summary>
 	/// <typeparam name="T">The type of value to deserialize.</typeparam>
-	/// <typeparam name="TProvider"><inheritdoc cref="Serialize{T, TProvider}(ref MessagePackWriter, T)" path="/typeparam[@name='TProvider']"/></typeparam>
+	/// <typeparam name="TProvider"><inheritdoc cref="Serialize{T, TProvider}(ref MessagePackWriter, in T)" path="/typeparam[@name='TProvider']"/></typeparam>
 	/// <param name="reader">The msgpack reader to deserialize from.</param>
 	/// <returns>The deserialized value.</returns>
 	public T? Deserialize<T, TProvider>(ref MessagePackReader reader)

--- a/src/Nerdbank.MessagePack/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 abstract Nerdbank.MessagePack.MessagePackConverter<T>.Deserialize(ref Nerdbank.MessagePack.MessagePackReader reader, Nerdbank.MessagePack.SerializationContext context) -> T?
-abstract Nerdbank.MessagePack.MessagePackConverter<T>.Serialize(ref Nerdbank.MessagePack.MessagePackWriter writer, ref T? value, Nerdbank.MessagePack.SerializationContext context) -> void
+abstract Nerdbank.MessagePack.MessagePackConverter<T>.Serialize(ref Nerdbank.MessagePack.MessagePackWriter writer, in T? value, Nerdbank.MessagePack.SerializationContext context) -> void
 abstract Nerdbank.MessagePack.MessagePackNamingPolicy.ConvertName(string! name) -> string!
 const Nerdbank.MessagePack.MessagePackCode.Array16 = 220 -> byte
 const Nerdbank.MessagePack.MessagePackCode.Array32 = 221 -> byte
@@ -171,14 +171,14 @@ Nerdbank.MessagePack.MessagePackSerializer.MultiDimensionalArrayFormat.init -> v
 Nerdbank.MessagePack.MessagePackSerializer.PropertyNamingPolicy.get -> Nerdbank.MessagePack.MessagePackNamingPolicy?
 Nerdbank.MessagePack.MessagePackSerializer.PropertyNamingPolicy.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.RegisterConverter<T>(Nerdbank.MessagePack.MessagePackConverter<T>! converter) -> void
-Nerdbank.MessagePack.MessagePackSerializer.Serialize<T, TProvider>(ref Nerdbank.MessagePack.MessagePackWriter writer, T? value) -> void
-Nerdbank.MessagePack.MessagePackSerializer.Serialize<T, TProvider>(System.Buffers.IBufferWriter<byte>! writer, T? value) -> void
-Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(ref Nerdbank.MessagePack.MessagePackWriter writer, T? value) -> void
-Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(ref Nerdbank.MessagePack.MessagePackWriter writer, T? value, PolyType.Abstractions.ITypeShape<T>! shape) -> void
-Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(System.Buffers.IBufferWriter<byte>! writer, T? value) -> void
-Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(System.Buffers.IBufferWriter<byte>! writer, T? value, PolyType.Abstractions.ITypeShape<T>! shape) -> void
-Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(T? value) -> byte[]!
-Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(T? value, PolyType.Abstractions.ITypeShape<T>! shape) -> byte[]!
+Nerdbank.MessagePack.MessagePackSerializer.Serialize<T, TProvider>(ref Nerdbank.MessagePack.MessagePackWriter writer, in T? value) -> void
+Nerdbank.MessagePack.MessagePackSerializer.Serialize<T, TProvider>(System.Buffers.IBufferWriter<byte>! writer, in T? value) -> void
+Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(in T? value) -> byte[]!
+Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(in T? value, PolyType.Abstractions.ITypeShape<T>! shape) -> byte[]!
+Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(ref Nerdbank.MessagePack.MessagePackWriter writer, in T? value) -> void
+Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(ref Nerdbank.MessagePack.MessagePackWriter writer, in T? value, PolyType.Abstractions.ITypeShape<T>! shape) -> void
+Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(System.Buffers.IBufferWriter<byte>! writer, in T? value) -> void
+Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(System.Buffers.IBufferWriter<byte>! writer, in T? value, PolyType.Abstractions.ITypeShape<T>! shape) -> void
 Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T, TProvider>(System.IO.Pipelines.PipeWriter! writer, T? value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Pipelines.PipeWriter! writer, T? value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Nerdbank.MessagePack.MessagePackSerializer.StartingContext.get -> Nerdbank.MessagePack.SerializationContext

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/ConverterAnalyzersTests.cs
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/ConverterAnalyzersTests.cs
@@ -17,7 +17,7 @@ public class ConverterAnalyzersTests
 			public class MyTypeConverter : MessagePackConverter<MyType>
 			{
 				public override MyType Deserialize(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
-				public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context) => throw new System.NotImplementedException();
+				public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context) => throw new System.NotImplementedException();
 			}
 			""";
 
@@ -51,7 +51,7 @@ public class ConverterAnalyzersTests
 					return new MyType();
 				}
 
-				public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+				public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context)
 				{
 					if (value is null)
 					{
@@ -100,7 +100,7 @@ public class ConverterAnalyzersTests
 					}
 				}
 
-				public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+				public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context)
 				{
 					if (value is null)
 					{
@@ -157,7 +157,7 @@ public class ConverterAnalyzersTests
 					}
 				}
 
-				public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+				public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context)
 				{
 					if (value is null)
 					{
@@ -165,7 +165,7 @@ public class ConverterAnalyzersTests
 						return;
 					}
 
-					context.GetConverter<SomeOtherType>().Serialize(ref writer, ref value.SomeField, context);
+					context.GetConverter<SomeOtherType>().Serialize(ref writer, value.SomeField, context);
 				}
 			}
 			""";
@@ -189,7 +189,7 @@ public class ConverterAnalyzersTests
 			public class MyTypeConverter : MessagePackConverter<MyType>
 			{
 				public override MyType Deserialize(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
-				public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+				public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context)
 				{
 					var serializer = {|NBMsgPack030:new MessagePackSerializer()|};
 					{|NBMsgPack030:serializer.Serialize(value)|};
@@ -219,7 +219,7 @@ public class ConverterAnalyzersTests
 					return new MyType();
 				}
 
-				public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+				public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context)
 				{
 					writer.Write(1);
 					{|NBMsgPack031:writer.Write(2)|};
@@ -246,7 +246,7 @@ public class ConverterAnalyzersTests
 					return new MyType();
 				}
 
-				public override void {|NBMsgPack031:Serialize|}(ref MessagePackWriter writer, ref MyType value, SerializationContext context)
+				public override void {|NBMsgPack031:Serialize|}(ref MessagePackWriter writer, in MyType value, SerializationContext context)
 				{
 				}
 

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/MessagePackConverterAttributeAnalyzerTests.cs
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/MessagePackConverterAttributeAnalyzerTests.cs
@@ -20,7 +20,7 @@ public class MessagePackConverterAttributeAnalyzerTests
 			public class MyTypeConverter : MessagePackConverter<MyType>
 			{
 				public override MyType Deserialize(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
-				public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context) => throw new System.NotImplementedException();
+				public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context) => throw new System.NotImplementedException();
 			}
 			""";
 
@@ -43,7 +43,7 @@ public class MessagePackConverterAttributeAnalyzerTests
 			{
 				private MyTypeConverter() { }
 				public override MyType Deserialize(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
-				public override void Serialize(ref MessagePackWriter writer, ref MyType value, SerializationContext context) => throw new System.NotImplementedException();
+				public override void Serialize(ref MessagePackWriter writer, in MyType value, SerializationContext context) => throw new System.NotImplementedException();
 			}
 			""";
 
@@ -87,7 +87,7 @@ public class MessagePackConverterAttributeAnalyzerTests
 			public class IntConverter : MessagePackConverter<int>
 			{
 				public override int Deserialize(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
-				public override void Serialize(ref MessagePackWriter writer, ref int value, SerializationContext context) => throw new System.NotImplementedException();
+				public override void Serialize(ref MessagePackWriter writer, in int value, SerializationContext context) => throw new System.NotImplementedException();
 			}
 			""";
 

--- a/test/Nerdbank.MessagePack.Tests/CustomConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/CustomConverterTests.cs
@@ -25,10 +25,9 @@ public partial class CustomConverterTests(ITestOutputHelper logger) : MessagePac
 				return new CustomType { InternalProperty = value };
 			}
 
-			public override void Serialize(ref MessagePackWriter writer, ref CustomType? value, SerializationContext context)
+			public override void Serialize(ref MessagePackWriter writer, in CustomType? value, SerializationContext context)
 			{
-				string? internalProperty = value?.InternalProperty;
-				context.GetConverter<string, CustomTypeConverter>().Serialize(ref writer, ref internalProperty, context);
+				context.GetConverter<string, CustomTypeConverter>().Serialize(ref writer, value?.InternalProperty, context);
 			}
 		}
 	}

--- a/test/Nerdbank.MessagePack.Tests/MessagePackConverterAttributeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackConverterAttributeTests.cs
@@ -27,7 +27,7 @@ public partial class MessagePackConverterAttributeTests(ITestOutputHelper logger
 			return new() { InternalProperty = reader.ReadString() };
 		}
 
-		public override void Serialize(ref MessagePackWriter writer, ref CustomType? value, SerializationContext context)
+		public override void Serialize(ref MessagePackWriter writer, in CustomType? value, SerializationContext context)
 		{
 			writer.Write(value?.InternalProperty);
 		}


### PR DESCRIPTION
This dramatically improves usability (and potentially perf as well), particularly for folks writing custom converters.