### PR TITLE
Leverage C# 13 to simplify and optimize async serialization

### DIFF
--- a/src/Nerdbank.MessagePack/BufferWriter.cs
+++ b/src/Nerdbank.MessagePack/BufferWriter.cs
@@ -84,6 +84,11 @@ internal ref struct BufferWriter
 	internal Span<byte> Span => this.span;
 
 	/// <summary>
+	/// Gets the number of bytes written but not yet <see cref="Commit">committed</see>.
+	/// </summary>
+	internal int UncommittedBytes => this.buffered;
+
+	/// <summary>
 	/// Gets the rental.
 	/// </summary>
 	internal SequencePool.Rental SequenceRental => this.rental;

--- a/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
+++ b/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
@@ -68,7 +68,8 @@ internal record struct MapSerializableProperties<TDeclaringType>(List<Serializab
 /// <param name="Write">A delegate that synchronously serializes the value of the property.</param>
 /// <param name="WriteAsync">A delegate that asynchonously serializes the value of the property.</param>
 /// <param name="SuppressIfNoConstructorParameter">A value indicating whether this property should <em>not</em> be serialized if no matching constructor parameter is discovered such that the value could be deserialized.</param>
-internal record struct SerializableProperty<TDeclaringType>(string Name, ReadOnlyMemory<byte> RawPropertyNameString, SerializeProperty<TDeclaringType> Write, SerializePropertyAsync<TDeclaringType> WriteAsync, bool SuppressIfNoConstructorParameter);
+/// <param name="PreferAsyncSerialization"><inheritdoc cref="MessagePackConverter{T}.PreferAsyncSerialization"/></param>
+internal record struct SerializableProperty<TDeclaringType>(string Name, ReadOnlyMemory<byte> RawPropertyNameString, SerializeProperty<TDeclaringType> Write, SerializePropertyAsync<TDeclaringType> WriteAsync, bool SuppressIfNoConstructorParameter, bool PreferAsyncSerialization);
 
 /// <summary>
 /// A map of deserializable properties.
@@ -85,7 +86,8 @@ internal record struct MapDeserializableProperties<TDeclaringType>(SpanDictionar
 /// <param name="PropertyNameUtf8">The UTF-8 encoding of the property name.</param>
 /// <param name="Read">A delegate that synchronously initializes the value of the property with a value deserialized from msgpack.</param>
 /// <param name="ReadAsync">A delegate that asynchronously initializes the value of the property with a value deserialized from msgpack.</param>
-internal record struct DeserializableProperty<TDeclaringType>(string Name, ReadOnlyMemory<byte> PropertyNameUtf8, DeserializeProperty<TDeclaringType> Read, DeserializePropertyAsync<TDeclaringType> ReadAsync);
+/// <param name="PreferAsyncSerialization"><inheritdoc cref="MessagePackConverter{T}.PreferAsyncSerialization"/></param>
+internal record struct DeserializableProperty<TDeclaringType>(string Name, ReadOnlyMemory<byte> PropertyNameUtf8, DeserializeProperty<TDeclaringType> Read, DeserializePropertyAsync<TDeclaringType> ReadAsync, bool PreferAsyncSerialization);
 
 /// <summary>
 /// Encapsulates serializing accessors for a particular property of some data type.
@@ -94,10 +96,12 @@ internal record struct DeserializableProperty<TDeclaringType>(string Name, ReadO
 /// <param name="MsgPackWriters">Delegates that can serialize the value of a property.</param>
 /// <param name="MsgPackReaders">Delegates that can initialize the property with a value deserialized from msgpack.</param>
 /// <param name="SuppressIfNoConstructorParameter">A value indicating whether this property should <em>not</em> be serialized if no matching constructor parameter is discovered such that the value could be deserialized.</param>
+/// <param name="PreferAsyncSerialization"><inheritdoc cref="MessagePackConverter{T}.PreferAsyncSerialization"/></param>
 internal record struct PropertyAccessors<TDeclaringType>(
 	(SerializeProperty<TDeclaringType> Serialize, SerializePropertyAsync<TDeclaringType> SerializeAsync)? MsgPackWriters,
 	(DeserializeProperty<TDeclaringType> Deserialize, DeserializePropertyAsync<TDeclaringType> DeserializeAsync)? MsgPackReaders,
-	bool SuppressIfNoConstructorParameter);
+	bool SuppressIfNoConstructorParameter,
+	bool PreferAsyncSerialization);
 
 /// <summary>
 /// Encapsulates the data passed through <see cref="ITypeShapeVisitor.VisitConstructor{TDeclaringType, TArgumentState}(IConstructorShape{TDeclaringType, TArgumentState}, object?)"/> state arguments

--- a/src/Nerdbank.MessagePack/Converters/DictionaryConverter`3.cs
+++ b/src/Nerdbank.MessagePack/Converters/DictionaryConverter`3.cs
@@ -158,18 +158,15 @@ internal class MutableDictionaryConverter<TDictionary, TKey, TValue>(
 		else
 		{
 			ReadOnlySequence<byte> map = await reader.ReadNextStructureAsync(context, cancellationToken).ConfigureAwait(false);
-			Read(new MessagePackReader(map));
-			reader.AdvanceTo(map.End);
-
-			void Read(MessagePackReader syncReader)
+			MessagePackReader syncReader = new(map);
+			int count = syncReader.ReadMapHeader();
+			for (int i = 0; i < count; i++)
 			{
-				int count = syncReader.ReadMapHeader();
-				for (int i = 0; i < count; i++)
-				{
-					this.ReadEntry(ref syncReader, context, out TKey key, out TValue value);
-					addEntry(ref collection, new KeyValuePair<TKey, TValue>(key, value));
-				}
+				this.ReadEntry(ref syncReader, context, out TKey key, out TValue value);
+				addEntry(ref collection, new KeyValuePair<TKey, TValue>(key, value));
 			}
+
+			reader.AdvanceTo(map.End);
 		}
 	}
 }

--- a/src/Nerdbank.MessagePack/Converters/EnumerableConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/EnumerableConverter`2.cs
@@ -136,17 +136,14 @@ internal class MutableEnumerableConverter<TEnumerable, TElement>(
 		else
 		{
 			ReadOnlySequence<byte> map = await reader.ReadNextStructureAsync(context, cancellationToken).ConfigureAwait(false);
-			Read(new MessagePackReader(map));
-			reader.AdvanceTo(map.End);
-
-			void Read(MessagePackReader syncReader)
+			MessagePackReader syncReader = new(map);
+			int count = syncReader.ReadArrayHeader();
+			for (int i = 0; i < count; i++)
 			{
-				int count = syncReader.ReadArrayHeader();
-				for (int i = 0; i < count; i++)
-				{
-					addElement(ref collection, this.ReadElement(ref syncReader, context));
-				}
+				addElement(ref collection, this.ReadElement(ref syncReader, context));
 			}
+
+			reader.AdvanceTo(map.End);
 		}
 	}
 }

--- a/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
@@ -70,34 +70,66 @@ internal class ObjectMapWithNonDefaultCtorConverter<TDeclaringType, TArgumentSta
 
 		if (parameters.Readers is not null)
 		{
-			int count = await reader.ReadMapHeaderAsync(cancellationToken).ConfigureAwait(false);
-			for (int i = 0; i < count; i++)
-			{
-				ReadOnlySequence<byte> buffer = await reader.ReadNextStructureAsync(context, cancellationToken).ConfigureAwait(false);
-				bool matchedProperty = TryMatchProperty(buffer, out DeserializableProperty<TArgumentState> propertyReader);
-				reader.AdvanceTo(buffer.End);
+			int mapEntries = await reader.ReadMapHeaderAsync(cancellationToken).ConfigureAwait(false);
 
-				if (matchedProperty)
+			// We're going to read in bursts. Anything we happen to get in one buffer, we'll ready synchronously regardless of whether the property is async.
+			// But when we run out of buffer, if the next thing to read is async, we'll read it async.
+			int remainingEntries = mapEntries;
+			while (remainingEntries > 0)
+			{
+				(ReadOnlySequence<byte> buffer, int bufferedStructures) = await reader.ReadNextStructuresAsync(1, remainingEntries * 2, context, cancellationToken).ConfigureAwait(false);
+				MessagePackReader syncReader = new(buffer);
+				int bufferedEntries = bufferedStructures / 2;
+				for (int i = 0; i < bufferedEntries; i++)
 				{
-					argState = await propertyReader.ReadAsync(argState, reader, context, cancellationToken).ConfigureAwait(false);
+					ReadOnlySpan<byte> propertyName = CodeGenHelpers.ReadStringSpan(ref syncReader);
+					if (parameters.Readers.TryGetValue(propertyName, out DeserializableProperty<TArgumentState> propertyReader))
+					{
+						propertyReader.Read(ref argState, ref syncReader, context);
+					}
+					else
+					{
+						syncReader.Skip(context);
+					}
+
+					remainingEntries--;
 				}
-				else
+
+				if (remainingEntries > 0)
 				{
-					await reader.SkipAsync(context, cancellationToken).ConfigureAwait(false);
+					// To know whether the next property is async, we need to know its name.
+					// If its name isn't in the buffer, we'll just loop around and get it in the next buffer.
+					if (bufferedStructures % 2 == 1)
+					{
+						// The property name has already been buffered.
+						ReadOnlySpan<byte> propertyName = CodeGenHelpers.ReadStringSpan(ref syncReader);
+						if (parameters.Readers.TryGetValue(propertyName, out DeserializableProperty<TArgumentState> propertyReader) && propertyReader.PreferAsyncSerialization)
+						{
+							// The next property value is async, so turn in our sync reader and read it asynchronously.
+							reader.AdvanceTo(syncReader.Position);
+							argState = await propertyReader.ReadAsync(argState, reader, context, cancellationToken).ConfigureAwait(false);
+							remainingEntries--;
+
+							// Now loop around to see what else we can do with the next buffer.
+							continue;
+						}
+					}
+					else
+					{
+						// The property name isn't in the buffer, and thus whether it'll have an async reader.
+						// Advance the reader so it knows we need more buffer than we got last time.
+						reader.AdvanceTo(syncReader.Position, buffer.End);
+						continue;
+					}
 				}
+
+				reader.AdvanceTo(syncReader.Position);
 			}
 		}
 		else
 		{
 			// We have nothing to read into, so just skip any data in the object.
 			await reader.SkipAsync(context, cancellationToken).ConfigureAwait(false);
-		}
-
-		bool TryMatchProperty(ReadOnlySequence<byte> propertyName, out DeserializableProperty<TArgumentState> propertyReader)
-		{
-			MessagePackReader reader = new(propertyName);
-			ReadOnlySpan<byte> propertyNameSpan = CodeGenHelpers.ReadStringSpan(ref reader);
-			return parameters.Readers.TryGetValue(propertyNameSpan, out propertyReader);
 		}
 
 		return ctor(ref argState);

--- a/src/Nerdbank.MessagePack/MessagePackAsyncWriter.cs
+++ b/src/Nerdbank.MessagePack/MessagePackAsyncWriter.cs
@@ -153,4 +153,15 @@ public class MessagePackAsyncWriter(PipeWriter pipeWriter)
 	{
 		return pipeWriter.CanGetUnflushedBytes && pipeWriter.UnflushedBytes > context.UnflushedBytesThreshold;
 	}
+
+	/// <summary>
+	/// Gets a value indicating whether it is time to flush the pipe.
+	/// </summary>
+	/// <param name="context">The serialization context.</param>
+	/// <param name="syncWriter">The synchronous writer that may have unflushed bytes to consider as well.</param>
+	/// <returns><see langword="true" /> if the pipe buffers are reaching their preferred capacity; <see langword="false" /> otherwise.</returns>
+	public bool IsTimeToFlush(SerializationContext context, in MessagePackWriter syncWriter)
+	{
+		return pipeWriter.CanGetUnflushedBytes && (pipeWriter.UnflushedBytes + syncWriter.UnflushedBytes) > context.UnflushedBytesThreshold;
+	}
 }

--- a/src/Nerdbank.MessagePack/MessagePackWriter.cs
+++ b/src/Nerdbank.MessagePack/MessagePackWriter.cs
@@ -60,6 +60,11 @@ public ref struct MessagePackWriter
 	public CancellationToken CancellationToken { get; set; }
 
 	/// <summary>
+	/// Gets the number of bytes that have been written but not yet committed <see cref="Flush">flushed</see> to the underlying <see cref="IBufferWriter{T}"/>.
+	/// </summary>
+	public int UnflushedBytes => this.writer.UncommittedBytes;
+
+	/// <summary>
 	/// Gets or sets a value indicating whether to write in <see href="https://github.com/msgpack/msgpack/blob/master/spec-old.md">old spec</see> compatibility mode.
 	/// </summary>
 	public bool OldSpec { get; set; }

--- a/src/Nerdbank.MessagePack/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/PublicAPI.Unshipped.txt
@@ -80,6 +80,8 @@ Nerdbank.MessagePack.MessagePackAsyncReader.MessagePackAsyncReader(System.IO.Pip
 Nerdbank.MessagePack.MessagePackAsyncReader.ReadArrayHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
 Nerdbank.MessagePack.MessagePackAsyncReader.ReadMapHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
 Nerdbank.MessagePack.MessagePackAsyncReader.ReadNextStructureAsync(Nerdbank.MessagePack.SerializationContext context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Buffers.ReadOnlySequence<byte>>
+Nerdbank.MessagePack.MessagePackAsyncReader.ReadNextStructuresAsync(int minimumDesiredBufferedStructures, int countUpTo, Nerdbank.MessagePack.SerializationContext context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<(System.Buffers.ReadOnlySequence<byte> Buffer, int IncludedStructures)>
+Nerdbank.MessagePack.MessagePackAsyncReader.ReadNextStructuresAsync(int minimumDesiredBufferedStructures, Nerdbank.MessagePack.SerializationContext context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Buffers.ReadOnlySequence<byte>>
 Nerdbank.MessagePack.MessagePackAsyncReader.SkipAsync(Nerdbank.MessagePack.SerializationContext context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 Nerdbank.MessagePack.MessagePackAsyncReader.TryReadNilAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<bool>
 Nerdbank.MessagePack.MessagePackAsyncWriter
@@ -87,6 +89,7 @@ Nerdbank.MessagePack.MessagePackAsyncWriter.CreateWriter() -> Nerdbank.MessagePa
 Nerdbank.MessagePack.MessagePackAsyncWriter.Flush() -> void
 Nerdbank.MessagePack.MessagePackAsyncWriter.FlushIfAppropriateAsync(Nerdbank.MessagePack.SerializationContext context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 Nerdbank.MessagePack.MessagePackAsyncWriter.IsTimeToFlush(Nerdbank.MessagePack.SerializationContext context) -> bool
+Nerdbank.MessagePack.MessagePackAsyncWriter.IsTimeToFlush(Nerdbank.MessagePack.SerializationContext context, in Nerdbank.MessagePack.MessagePackWriter syncWriter) -> bool
 Nerdbank.MessagePack.MessagePackAsyncWriter.MessagePackAsyncWriter(System.IO.Pipelines.PipeWriter! pipeWriter) -> void
 Nerdbank.MessagePack.MessagePackAsyncWriter.SyncWriter<T>
 Nerdbank.MessagePack.MessagePackAsyncWriter.Write<TState>(Nerdbank.MessagePack.MessagePackAsyncWriter.SyncWriter<TState>! writer, TState state) -> void
@@ -212,6 +215,7 @@ Nerdbank.MessagePack.MessagePackWriter.MessagePackWriter() -> void
 Nerdbank.MessagePack.MessagePackWriter.MessagePackWriter(System.Buffers.IBufferWriter<byte>! writer) -> void
 Nerdbank.MessagePack.MessagePackWriter.OldSpec.get -> bool
 Nerdbank.MessagePack.MessagePackWriter.OldSpec.set -> void
+Nerdbank.MessagePack.MessagePackWriter.UnflushedBytes.get -> int
 Nerdbank.MessagePack.MessagePackWriter.Write(bool value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(byte value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(byte[]? src) -> void

--- a/src/Nerdbank.MessagePack/RawMessagePack.cs
+++ b/src/Nerdbank.MessagePack/RawMessagePack.cs
@@ -16,10 +16,8 @@ namespace Nerdbank.MessagePack;
 /// The envelope could use this <see cref="RawMessagePack"/> in order to facilitate this by allowing pre-serialization and deferred deserialization of user data.
 /// </para>
 /// <para>
-/// When synchronously deserialized, this struct uses bytes borrowed from the underlying <see cref="MessagePackReader.Sequence"/>
-/// and thus should either be used immediately or have <see cref="ToOwned"/> called to make a durable copy of the data.
-/// When <em>asynchronously</em> deserialized (e.g. using <see cref="MessagePackSerializer.DeserializeAsync{T}(System.IO.Pipelines.PipeReader, CancellationToken)"/>)
-/// the buffers are subject to recycling during deserialization itself, so this struct is deserialized with its own copy of the data.
+/// The <see cref="MessagePackConverter{T}"/> for this type will always copy the memory from the buffers being read so that this struct has
+/// an independent lifetime.
 /// </para>
 /// </remarks>
 [MessagePackConverter(typeof(RawMessagePackConverter))]

--- a/test/Nerdbank.MessagePack.Tests/RawMessagePackTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/RawMessagePackTests.cs
@@ -29,7 +29,7 @@ public partial class RawMessagePackTests(ITestOutputHelper logger) : MessagePack
 
 		Assert.NotNull(deserializedEnvelope);
 		Assert.Equal(envelope, deserializedEnvelope);
-		Assert.False(deserializedEnvelope.Deferred.IsOwned);
+		Assert.True(deserializedEnvelope.Deferred.IsOwned);
 		DeferredData? deserializedUserData = this.Serializer.Deserialize<DeferredData>(deserializedEnvelope.Deferred);
 		Assert.Equal(userData, deserializedUserData);
 	}


### PR DESCRIPTION
## Summary 
- async _serialize_ dropped from a 25-66% async tax to roughly 0.
- async _deserialize_ dropped from a 1100% async task to 400-800%. 

DeserializeAsync obviously needs more work, but there are plenty opportunities for improvement.

In the following metrics, pay attention to the improved ratios instead of looking at the Mean column, which shows significant regressions for unchanged code paths and it didn't repro later.

## Before

| Method                      | Categories             | Mean        | Error     | StdDev    | Ratio | RatioSD |
|---------------------------- |----------------------- |------------:|----------:|----------:|------:|--------:|
| DeserializeAsArrayInit      | array-init,Deserialize |    54.43 ns |  0.289 ns |  0.256 ns |  1.00 |    0.01 |
| DeserializeAsyncAsArrayInit | array-init,Deserialize |   637.12 ns |  5.798 ns |  5.423 ns | 11.70 |    0.11 |
|                             |                        |             |           |           |       |         |
| SerializeAsArrayInit        | array-init,Serialize   |    86.64 ns |  1.101 ns |  1.030 ns |  1.00 |    0.02 |
| SerializeAsyncAsArrayInit   | array-init,Serialize   |   107.98 ns |  0.843 ns |  0.704 ns |  1.25 |    0.02 |
|                             |                        |             |           |           |       |         |
| DeserializeAsArray          | array,Deserialize      |    52.79 ns |  0.608 ns |  0.569 ns |  1.00 |    0.01 |
| DeserializeAsyncAsArray     | array,Deserialize      |   622.12 ns |  7.645 ns |  7.151 ns | 11.79 |    0.18 |
|                             |                        |             |           |           |       |         |
| SerializeAsArray            | array,Serialize        |    80.59 ns |  1.099 ns |  1.028 ns |  1.00 |    0.02 |
| SerializeAsyncAsArray       | array,Serialize        |   100.56 ns |  1.927 ns |  1.802 ns |  1.25 |    0.03 |
|                             |                        |             |           |           |       |         |
| DeserializeMapInit          | map-init,Deserialize   |   103.90 ns |  1.047 ns |  0.979 ns |  1.00 |    0.01 |
| DeserializeAsyncMapInit     | map-init,Deserialize   | 1,168.60 ns | 23.107 ns | 54.466 ns | 11.25 |    0.53 |
|                             |                        |             |           |           |       |         |
| SerializeMapInit            | map-init,Serialize     |    97.32 ns |  1.033 ns |  0.967 ns |  1.00 |    0.01 |
| SerializeAsyncMapInit       | map-init,Serialize     |   161.89 ns |  2.195 ns |  2.054 ns |  1.66 |    0.03 |
|                             |                        |             |           |           |       |         |
| DeserializeMap              | map,Deserialize        |   100.33 ns |  0.610 ns |  0.541 ns |  1.00 |    0.01 |
| DeserializeAsyncMap         | map,Deserialize        | 1,040.28 ns | 20.102 ns | 19.743 ns | 10.37 |    0.20 |
|                             |                        |             |           |           |       |         |
| SerializeMap                | map,Serialize          |    99.47 ns |  0.667 ns |  0.624 ns |  1.00 |    0.01 |
| SerializeAsyncMap           | map,Serialize          |   159.49 ns |  1.741 ns |  1.628 ns |  1.60 |    0.02 |

## After

| Method                      | Categories             | Mean      | Error     | StdDev    | Ratio | RatioSD |
|---------------------------- |----------------------- |----------:|----------:|----------:|------:|--------:|
| DeserializeAsArrayInit      | array-init,Deserialize |  94.40 ns |  1.886 ns |  4.372 ns |  1.00 |    0.06 |
| DeserializeAsyncAsArrayInit | array-init,Deserialize | 758.08 ns | 14.929 ns | 24.529 ns |  8.05 |    0.45 |
|                             |                        |           |           |           |       |         |
| SerializeAsArrayInit        | array-init,Serialize   | 145.46 ns |  2.902 ns |  6.058 ns |  1.00 |    0.06 |
| SerializeAsyncAsArrayInit   | array-init,Serialize   | 136.35 ns |  2.720 ns |  3.023 ns |  0.94 |    0.04 |
|                             |                        |           |           |           |       |         |
| DeserializeAsArray          | array,Deserialize      |  92.38 ns |  1.820 ns |  4.071 ns |  1.00 |    0.06 |
| DeserializeAsyncAsArray     | array,Deserialize      | 749.10 ns | 14.508 ns | 19.859 ns |  8.12 |    0.41 |
|                             |                        |           |           |           |       |         |
| SerializeAsArray            | array,Serialize        | 136.23 ns |  2.293 ns |  2.144 ns |  1.00 |    0.02 |
| SerializeAsyncAsArray       | array,Serialize        | 140.85 ns |  2.784 ns |  5.750 ns |  1.03 |    0.04 |
|                             |                        |           |           |           |       |         |
| DeserializeMapInit          | map-init,Deserialize   | 188.56 ns |  3.727 ns |  9.281 ns |  1.00 |    0.07 |
| DeserializeAsyncMapInit     | map-init,Deserialize   | 801.47 ns | 15.379 ns | 15.794 ns |  4.26 |    0.23 |
|                             |                        |           |           |           |       |         |
| SerializeMapInit            | map-init,Serialize     | 170.40 ns |  3.343 ns |  4.463 ns |  1.00 |    0.04 |
| SerializeAsyncMapInit       | map-init,Serialize     | 162.65 ns |  3.241 ns |  5.761 ns |  0.96 |    0.04 |
|                             |                        |           |           |           |       |         |
| DeserializeMap              | map,Deserialize        | 181.09 ns |  3.359 ns |  7.444 ns |  1.00 |    0.06 |
| DeserializeAsyncMap         | map,Deserialize        | 800.18 ns | 15.741 ns | 30.327 ns |  4.43 |    0.24 |
|                             |                        |           |           |           |       |         |
| SerializeMap                | map,Serialize          | 165.76 ns |  2.583 ns |  2.416 ns |  1.00 |    0.02 |
| SerializeAsyncMap           | map,Serialize          | 166.74 ns |  2.860 ns |  2.676 ns |  1.01 |    0.02 |
