### PR TITLE
Fix async serialization corruption

### DIFF
--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
@@ -103,7 +103,7 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 					}
 					else
 					{
-						writer.WriteNil();
+						syncWriter.WriteNil();
 					}
 				}
 

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.AutomatedFriendlyOverloads.tt
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.AutomatedFriendlyOverloads.tt
@@ -28,6 +28,7 @@ public partial record MessagePackSerializer
         {
             ShapeSource.T => ("T","T : IShapeable<T>","T"),
             ShapeSource.TProvider => ("T, TProvider","TProvider : IShapeable<T>","TProvider"),
+            _ => throw new NotSupportedException(),
         };
 
         foreach (SerializeTransport transport in Enum.GetValues(typeof(SerializeTransport)))
@@ -37,6 +38,7 @@ public partial record MessagePackSerializer
                 SerializeTransport.ByteArray => ("byte[]", "", ""),
                 SerializeTransport.IBufferWriter => ("void", "IBufferWriter<byte>", "writer"),
                 SerializeTransport.Stream => ("void", "Stream", "stream"),
+                _ => throw new NotSupportedException(),
             };
             AssembleInputs(firstParameterType, firstParameterName, true, out string firstParameter, out string firstArg, out string firstParameterDocId);
 #>
@@ -55,6 +57,7 @@ public partial record MessagePackSerializer
                 DeserializeTransport.ReadOnlyMemory => ("ReadOnlyMemory<byte>", "bytes"),
                 DeserializeTransport.ReadOnlySequence => ("scoped in ReadOnlySequence<byte>", "bytes"),
                 DeserializeTransport.Stream => ("Stream", "stream"),
+                _ => throw new NotSupportedException(),
             };
             AssembleInputs(firstParameterType, firstParameterName, false, out string firstParameter, out string firstArg, out string firstParameterDocId);
 #>
@@ -72,6 +75,7 @@ public partial record MessagePackSerializer
             {
                 DeserializeAsyncTransport.PipeReader => ("PipeReader", "reader"),
                 DeserializeAsyncTransport.Stream => ("Stream", "stream"),
+                _ => throw new NotSupportedException(),
             };
             AssembleInputs(firstParameterType, firstParameterName, false, out string firstParameter, out string firstArg, out string firstParameterDocId);
 #>
@@ -93,6 +97,7 @@ public partial record MessagePackSerializer
             {
                 SerializeAsyncTransport.PipeWriter => ("PipeWriter", "writer"),
                 SerializeAsyncTransport.Stream => ("Stream", "stream"),
+                _ => throw new NotSupportedException(),
             };
             AssembleInputs(firstParameterType, firstParameterName, false, out string firstParameter, out string firstArg, out string firstParameterDocId);
 #>

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
@@ -110,9 +110,16 @@ public abstract class MessagePackSerializerTestBase(ITestOutputHelper logger)
 		// But if tests hang, enabling this can help turn them into EndOfStreamException.
 		////await pipe.Writer.CompleteAsync();
 
-		T? result = await resultTask;
-		this.lastRoundtrippedMsgpack = loggingSequence;
-		return result;
+		try
+		{
+			T? result = await resultTask;
+			return result;
+		}
+		finally
+		{
+			this.lastRoundtrippedMsgpack = loggingSequence;
+			this.LogMsgPack(loggingSequence);
+		}
 	}
 
 	protected void LogMsgPack(ReadOnlySequence<byte> msgPack)

--- a/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
@@ -3,8 +3,19 @@
 
 public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
 {
-	[Fact]
-	public void Person_Roundtrip() => this.AssertRoundtrip(new Person { FirstName = "Andrew", LastName = "Arnott" });
+	[Theory, PairwiseData]
+	public async Task Person_Roundtrip(bool async)
+	{
+		var person = new Person { FirstName = "Andrew", LastName = "Arnott" };
+		if (async)
+		{
+			await this.AssertRoundtripAsync(person);
+		}
+		else
+		{
+			this.AssertRoundtrip(person);
+		}
+	}
 
 	[Fact]
 	public void PersonWithDefaultConstructor_Roundtrip() => this.AssertRoundtrip(new PersonWithDefaultConstructor { FirstName = "Andrew", LastName = "Arnott" });


### PR DESCRIPTION
Fix a mixed use of sync and async writers that led to data corruption in the serialized output.

Also:
- Add logging of async msgpack in tests.
- Fix T4 compilation warnings.