### PR TITLE
Support serializing index-based types as maps as well as arrays

### DIFF
--- a/docfx/docs/migrating.md
+++ b/docfx/docs/migrating.md
@@ -24,7 +24,8 @@ Custom converters         | [✅](custom-converters.md) | ✅ |
 Deserialization callback  | ❌ | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#serialization-callback) |
 MsgPack extensions        | ✅ | ✅ |
 LZ4 compression           | [❌](https://github.com/AArnott/Nerdbank.MessagePack/issues/34) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#lz4-compression) |
-NativeAOT                 | ✅ | ❌[^2] |
+Trim-safe                 | ✅ | ❌ |
+NativeAOT ready           | ✅ | ❌[^2] |
 Unity                     | ❓[^3] | ✅ |
 Async                     | [✅](xref:Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync*) | ❌ |
 Reference preservation    | [✅](xref:Nerdbank.MessagePack.MessagePackSerializer.PreserveReferences) | ❌ |

--- a/docfx/docs/migrating.md
+++ b/docfx/docs/migrating.md
@@ -18,6 +18,7 @@ Contractless data types   | [✅](getting-started.md)[^1] | [✅](https://github
 Attributed data types     | [✅](customizing-serialization.md) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#object-serialization) |
 Polymorphic serialization | [✅](unions.md) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#union) |
 Skip serializing default values | [✅](xref:Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues) | [❌](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/678) |
+Dynamically use maps or arrays for most compact format | [✅](customizing-serialization.md#array-or-map) | [❌](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/1953) |
 Typeless serialization    | ❌ | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#typeless) |
 Custom converters         | [✅](custom-converters.md) | ✅ |
 Deserialization callback  | ❌ | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#serialization-callback) |

--- a/samples/CustomizingSerialization.cs
+++ b/samples/CustomizingSerialization.cs
@@ -88,4 +88,16 @@ namespace SerializeWithKey
 		public string? AnotherProperty { get; set; }
 	}
 	#endregion
+
+	#region SerializeWithKeyAndGaps
+	[GenerateShape]
+	partial class MyTypeWithGaps
+	{
+		[Key(0)]
+		public string? OneProperty { get; set; }
+
+		[Key(5)]
+		public string? AnotherProperty { get; set; }
+	}
+	#endregion
 }

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace Nerdbank.MessagePack.Converters;
 
@@ -10,7 +11,7 @@ namespace Nerdbank.MessagePack.Converters;
 /// Only data types with default constructors may be deserialized.
 /// </summary>
 /// <typeparam name="T">The type of objects that can be serialized or deserialized with this converter.</typeparam>
-internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<T>? constructor) : MessagePackConverter<T>
+internal class ObjectArrayConverter<T>(ReadOnlyMemory<PropertyAccessors<T>?> properties, Func<T>? constructor, bool callShouldSerialize) : MessagePackConverter<T>
 {
 	/// <inheritdoc/>
 	public override bool PreferAsyncSerialization => true;
@@ -30,16 +31,36 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 
 		context.DepthStep();
 		T value = constructor();
-		int count = reader.ReadArrayHeader();
-		for (int i = 0; i < count; i++)
+		if (reader.NextMessagePackType == MessagePackType.Map)
 		{
-			if (properties.Length > i && properties[i]?.MsgPackReaders is var (deserialize, _))
+			// The indexes we have are the keys in the map rather than indexes into the array.
+			int count = reader.ReadMapHeader();
+			for (int i = 0; i < count; i++)
 			{
-				deserialize(ref value, ref reader, context);
+				int index = reader.ReadInt32();
+				if (properties.Length > index && properties.Span[index]?.MsgPackReaders is var (deserialize, _))
+				{
+					deserialize(ref value, ref reader, context);
+				}
+				else
+				{
+					reader.Skip(context);
+				}
 			}
-			else
+		}
+		else
+		{
+			int count = reader.ReadArrayHeader();
+			for (int i = 0; i < count; i++)
 			{
-				reader.Skip(context);
+				if (properties.Length > i && properties.Span[i]?.MsgPackReaders is var (deserialize, _))
+				{
+					deserialize(ref value, ref reader, context);
+				}
+				else
+				{
+					reader.Skip(context);
+				}
 			}
 		}
 
@@ -57,16 +78,64 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 
 		context.DepthStep();
 
-		writer.WriteArrayHeader(properties.Length);
-		for (int i = 0; i < properties.Length; i++)
+		if (callShouldSerialize && properties.Length > 0)
 		{
-			if (properties[i]?.MsgPackWriters is var (serialize, _))
+			int[]? indexesToIncludeArray = null;
+			try
 			{
-				serialize(value, ref writer, context);
+				if (this.ShouldUseMap(value, ref indexesToIncludeArray, out _, out ReadOnlySpan<int> indexesToInclude))
+				{
+					writer.WriteMapHeader(indexesToInclude.Length);
+					for (int i = 0; i < indexesToInclude.Length; i++)
+					{
+						int index = indexesToInclude[i];
+
+						// In this case, we're serializing the *index* as the key rather than the property name.
+						// It is faster and more compact that way, and we have the user-assigned indexes to use anyway.
+						writer.Write(index);
+
+						// The null forgiveness operators are safe because our filter would only have included
+						// this index if these values are non-null.
+						properties.Span[index]!.Value.MsgPackWriters!.Value.Serialize(value, ref writer, context);
+					}
+				}
+				else if (indexesToInclude.Length == 0)
+				{
+					writer.WriteArrayHeader(0);
+				}
+				else
+				{
+					// Just serialize as an array, but truncate to the last index that *wanted* to be serialized.
+					// We +1 to the last index because the slice has an exclusive end index.
+					WriteArray(ref writer, value, properties.Span[..(indexesToInclude[^1] + 1)], context);
+				}
 			}
-			else
+			finally
 			{
-				writer.WriteNil();
+				if (indexesToIncludeArray is not null)
+				{
+					ArrayPool<int>.Shared.Return(indexesToIncludeArray);
+				}
+			}
+		}
+		else
+		{
+			WriteArray(ref writer, value, properties.Span, context);
+		}
+
+		static void WriteArray(ref MessagePackWriter writer, in T value, ReadOnlySpan<PropertyAccessors<T>?> properties, SerializationContext context)
+		{
+			writer.WriteArrayHeader(properties.Length);
+			for (int i = 0; i < properties.Length; i++)
+			{
+				if (properties[i]?.MsgPackWriters is var (serialize, _))
+				{
+					serialize(value, ref writer, context);
+				}
+				else
+				{
+					writer.WriteNil();
+				}
 			}
 		}
 	}
@@ -83,62 +152,158 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 
 		context.DepthStep();
 
-		writer.WriteArrayHeader(properties.Length);
-		int i = 0;
-		while (i < properties.Length)
+		if (callShouldSerialize && properties.Length > 0)
 		{
-			// Do a batch of all the consecutive properties that should be written synchronously.
-			int syncBatchSize = NextSyncBatchSize();
-			int syncWriteEndExclusive = i + syncBatchSize;
-			while (i < syncWriteEndExclusive)
+			int[]? indexesToIncludeArray = null;
+			try
 			{
-				// We use a nested loop here because even during synchronous writing, we may need to occasionally yield to
-				// flush what we've written so far, but then we want to come right back to synchronous writing.
-				MessagePackWriter syncWriter = writer.CreateWriter();
-				for (; i < syncWriteEndExclusive && !writer.IsTimeToFlush(context, syncWriter); i++)
+				if (this.ShouldUseMap(value, ref indexesToIncludeArray, out ReadOnlyMemory<int> indexesToInclude, out _))
 				{
-					if (properties[i] is { MsgPackWriters: var (serialize, _) })
+					await WriteAsMapAsync(writer, value, indexesToInclude, properties, context, cancellationToken);
+				}
+				else if (indexesToInclude.Length == 0)
+				{
+					writer.WriteArrayHeader(0);
+				}
+				else
+				{
+					// Just serialize as an array, but truncate to the last index that *wanted* to be serialized.
+					// We +1 to the last index because the slice has an exclusive end index.
+					await WriteAsArrayAsync(writer, value, properties[..(indexesToInclude.Span[^1] + 1)], context, cancellationToken);
+				}
+			}
+			finally
+			{
+				if (indexesToIncludeArray is not null)
+				{
+					ArrayPool<int>.Shared.Return(indexesToIncludeArray);
+				}
+			}
+		}
+		else
+		{
+			await WriteAsArrayAsync(writer, value, properties, context, cancellationToken);
+		}
+
+		static async ValueTask WriteAsMapAsync(MessagePackAsyncWriter writer, T value, ReadOnlyMemory<int> properties, ReadOnlyMemory<PropertyAccessors<T>?> allProperties, SerializationContext context, CancellationToken cancellationToken)
+		{
+			writer.WriteMapHeader(properties.Length);
+			int i = 0;
+			while (i < properties.Length)
+			{
+				// Do a batch of all the consecutive properties that should be written synchronously.
+				int syncBatchSize = NextSyncBatchSize();
+				int syncWriteEndExclusive = i + syncBatchSize;
+				while (i < syncWriteEndExclusive)
+				{
+					// We use a nested loop here because even during synchronous writing, we may need to occasionally yield to
+					// flush what we've written so far, but then we want to come right back to synchronous writing.
+					MessagePackWriter syncWriter = writer.CreateWriter();
+					for (; i < syncWriteEndExclusive && !writer.IsTimeToFlush(context, syncWriter); i++)
 					{
-						serialize(value, ref syncWriter, context);
+						syncWriter.Write(properties.Span[i]);
+
+						// The null forgiveness operators are safe because our filter would only have included
+						// this index if these values are non-null.
+						allProperties.Span[properties.Span[i]]!.Value.MsgPackWriters!.Value.Serialize(value, ref syncWriter, context);
 					}
-					else
-					{
-						syncWriter.WriteNil();
-					}
+
+					syncWriter.Flush();
+					await writer.FlushIfAppropriateAsync(context, cancellationToken).ConfigureAwait(false);
 				}
 
-				syncWriter.Flush();
-				await writer.FlushIfAppropriateAsync(context, cancellationToken).ConfigureAwait(false);
-			}
-
-			// Write all consecutive async properties.
-			for (; i < properties.Length; i++)
-			{
-				if (properties[i] is not PropertyAccessors<T> { PreferAsyncSerialization: true, MsgPackWriters: var (_, serializeAsync) })
+				// Write all consecutive async properties.
+				for (; i < properties.Length; i++)
 				{
-					break;
+					if (allProperties.Span[properties.Span[i]] is not PropertyAccessors<T> { PreferAsyncSerialization: true, MsgPackWriters: var (_, serializeAsync) })
+					{
+						break;
+					}
+
+					writer.Write(static (ref MessagePackWriter w, int i) => w.Write(i), properties.Span[i]);
+					await serializeAsync(value, writer, context, cancellationToken).ConfigureAwait(false);
 				}
 
-				await serializeAsync(value, writer, context, cancellationToken).ConfigureAwait(false);
-			}
-
-			int NextSyncBatchSize()
-			{
-				// We want to count the number of array elements need to be written up to the next async property.
-				for (int j = i; j < properties.Length; j++)
+				int NextSyncBatchSize()
 				{
-					if (properties.Length > j)
+					// We want to count the number of array elements need to be written up to the next async property.
+					for (int j = i; j < properties.Length; j++)
 					{
-						PropertyAccessors<T>? property = properties[j];
-						if (property?.PreferAsyncSerialization is true && property.Value.MsgPackWriters is not null)
+						if (properties.Length > j)
 						{
-							return j - i;
+							PropertyAccessors<T>? property = allProperties.Span[properties.Span[j]];
+							if (property?.PreferAsyncSerialization is true && property.Value.MsgPackWriters is not null)
+							{
+								return j - i;
+							}
 						}
 					}
+
+					// We didn't encounter any more async property readers.
+					return properties.Length - i;
+				}
+			}
+		}
+
+		static async ValueTask WriteAsArrayAsync(MessagePackAsyncWriter writer, T value, ReadOnlyMemory<PropertyAccessors<T>?> properties, SerializationContext context, CancellationToken cancellationToken)
+		{
+			writer.WriteArrayHeader(properties.Length);
+			int i = 0;
+			while (i < properties.Length)
+			{
+				// Do a batch of all the consecutive properties that should be written synchronously.
+				int syncBatchSize = NextSyncBatchSize();
+				int syncWriteEndExclusive = i + syncBatchSize;
+				while (i < syncWriteEndExclusive)
+				{
+					// We use a nested loop here because even during synchronous writing, we may need to occasionally yield to
+					// flush what we've written so far, but then we want to come right back to synchronous writing.
+					MessagePackWriter syncWriter = writer.CreateWriter();
+					for (; i < syncWriteEndExclusive && !writer.IsTimeToFlush(context, syncWriter); i++)
+					{
+						if (properties.Span[i] is { MsgPackWriters: var (serialize, _) })
+						{
+							serialize(value, ref syncWriter, context);
+						}
+						else
+						{
+							syncWriter.WriteNil();
+						}
+					}
+
+					syncWriter.Flush();
+					await writer.FlushIfAppropriateAsync(context, cancellationToken).ConfigureAwait(false);
 				}
 
-				// We didn't encounter any more async property readers.
-				return properties.Length - i;
+				// Write all consecutive async properties.
+				for (; i < properties.Length; i++)
+				{
+					if (properties.Span[i] is not PropertyAccessors<T> { PreferAsyncSerialization: true, MsgPackWriters: var (_, serializeAsync) })
+					{
+						break;
+					}
+
+					await serializeAsync(value, writer, context, cancellationToken).ConfigureAwait(false);
+				}
+
+				int NextSyncBatchSize()
+				{
+					// We want to count the number of array elements need to be written up to the next async property.
+					for (int j = i; j < properties.Length; j++)
+					{
+						if (properties.Length > j)
+						{
+							PropertyAccessors<T>? property = properties.Span[j];
+							if (property?.PreferAsyncSerialization is true && property.Value.MsgPackWriters is not null)
+							{
+								return j - i;
+							}
+						}
+					}
+
+					// We didn't encounter any more async property readers.
+					return properties.Length - i;
+				}
 			}
 		}
 	}
@@ -159,19 +324,22 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 
 		context.DepthStep();
 		T value = constructor();
-		int arrayLength = await reader.ReadArrayHeaderAsync(cancellationToken).ConfigureAwait(false);
-		int i = 0;
-		while (i < arrayLength)
+		if (await reader.TryPeekNextMessagePackTypeAsync(cancellationToken) == MessagePackType.Map)
 		{
-			// Do a batch of all the consecutive properties that should be read synchronously.
-			int syncBatchSize = NextSyncReadBatchSize();
-			if (syncBatchSize > 0)
+			int mapEntries = await reader.ReadMapHeaderAsync(cancellationToken).ConfigureAwait(false);
+
+			// We're going to read in bursts. Anything we happen to get in one buffer, we'll ready synchronously regardless of whether the property is async.
+			// But when we run out of buffer, if the next thing to read is async, we'll read it async.
+			int remainingEntries = mapEntries;
+			while (remainingEntries > 0)
 			{
-				ReadOnlySequence<byte> buffer = await reader.ReadNextStructuresAsync(syncBatchSize, context, cancellationToken).ConfigureAwait(false);
+				(ReadOnlySequence<byte> buffer, int bufferedStructures) = await reader.ReadNextStructuresAsync(1, remainingEntries * 2, context, cancellationToken).ConfigureAwait(false);
 				MessagePackReader syncReader = new(buffer);
-				for (int syncReadEndExclusive = i + syncBatchSize; i < syncReadEndExclusive; i++)
+				int bufferedEntries = bufferedStructures / 2;
+				for (int i = 0; i < bufferedEntries; i++)
 				{
-					if (properties.Length > i && properties[i]?.MsgPackReaders is var (deserialize, _))
+					int propertyIndex = syncReader.ReadInt32();
+					if (propertyIndex < properties.Length && properties.Span[propertyIndex] is { MsgPackReaders: { Deserialize: { } deserialize } })
 					{
 						deserialize(ref value, ref syncReader, context);
 					}
@@ -179,42 +347,145 @@ internal class ObjectArrayConverter<T>(PropertyAccessors<T>?[] properties, Func<
 					{
 						syncReader.Skip(context);
 					}
+
+					remainingEntries--;
+				}
+
+				if (remainingEntries > 0)
+				{
+					// To know whether the next property is async, we need to know its index.
+					// If its index isn't in the buffer, we'll just loop around and get it in the next buffer.
+					if (bufferedStructures % 2 == 1)
+					{
+						// The property name has already been buffered.
+						int propertyIndex = syncReader.ReadInt32();
+						if (propertyIndex < properties.Length && properties.Span[propertyIndex] is { PreferAsyncSerialization: true, MsgPackReaders: { } propertyReader })
+						{
+							// The next property value is async, so turn in our sync reader and read it asynchronously.
+							reader.AdvanceTo(syncReader.Position);
+							value = await propertyReader.DeserializeAsync(value, reader, context, cancellationToken).ConfigureAwait(false);
+							remainingEntries--;
+
+							// Now loop around to see what else we can do with the next buffer.
+							continue;
+						}
+					}
+					else
+					{
+						// The property name isn't in the buffer, and thus whether it'll have an async reader.
+						// Advance the reader so it knows we need more buffer than we got last time.
+						reader.AdvanceTo(syncReader.Position, buffer.End);
+						continue;
+					}
 				}
 
 				reader.AdvanceTo(syncReader.Position);
 			}
-
-			// Read any consecutive async properties.
-			for (; i < arrayLength && properties.Length > i; i++)
+		}
+		else
+		{
+			int arrayLength = await reader.ReadArrayHeaderAsync(cancellationToken).ConfigureAwait(false);
+			int i = 0;
+			while (i < arrayLength)
 			{
-				if (properties[i] is not PropertyAccessors<T> { PreferAsyncSerialization: true, MsgPackReaders: (_, { } deserializeAsync) })
+				// Do a batch of all the consecutive properties that should be read synchronously.
+				int syncBatchSize = NextSyncReadBatchSize();
+				if (syncBatchSize > 0)
 				{
-					break;
-				}
-
-				value = await deserializeAsync(value, reader, context, cancellationToken).ConfigureAwait(false);
-			}
-
-			int NextSyncReadBatchSize()
-			{
-				// We want to count the number of array elements need to be read up to the next async property.
-				for (int j = i; j < arrayLength; j++)
-				{
-					if (properties.Length > j)
+					ReadOnlySequence<byte> buffer = await reader.ReadNextStructuresAsync(syncBatchSize, context, cancellationToken).ConfigureAwait(false);
+					MessagePackReader syncReader = new(buffer);
+					for (int syncReadEndExclusive = i + syncBatchSize; i < syncReadEndExclusive; i++)
 					{
-						PropertyAccessors<T>? property = properties[j];
-						if (property?.PreferAsyncSerialization is true && property.Value.MsgPackReaders is not null)
+						if (properties.Length > i && properties.Span[i]?.MsgPackReaders is var (deserialize, _))
 						{
-							return j - i;
+							deserialize(ref value, ref syncReader, context);
+						}
+						else
+						{
+							syncReader.Skip(context);
 						}
 					}
+
+					reader.AdvanceTo(syncReader.Position);
 				}
 
-				// We didn't encounter any more async property readers.
-				return arrayLength - i;
+				// Read any consecutive async properties.
+				for (; i < arrayLength && properties.Length > i; i++)
+				{
+					if (properties.Span[i] is not PropertyAccessors<T> { PreferAsyncSerialization: true, MsgPackReaders: (_, { } deserializeAsync) })
+					{
+						break;
+					}
+
+					value = await deserializeAsync(value, reader, context, cancellationToken).ConfigureAwait(false);
+				}
+
+				int NextSyncReadBatchSize()
+				{
+					// We want to count the number of array elements need to be read up to the next async property.
+					for (int j = i; j < arrayLength; j++)
+					{
+						if (properties.Length > j)
+						{
+							PropertyAccessors<T>? property = properties.Span[j];
+							if (property?.PreferAsyncSerialization is true && property.Value.MsgPackReaders is not null)
+							{
+								return j - i;
+							}
+						}
+					}
+
+					// We didn't encounter any more async property readers.
+					return arrayLength - i;
+				}
 			}
 		}
 
 		return value;
+	}
+
+	private Memory<int> GetPropertiesToSerialize(in T value, Memory<int> include)
+	{
+		return include[..this.GetPropertiesToSerialize(value, include.Span)];
+	}
+
+	private int GetPropertiesToSerialize(in T value, Span<int> include)
+	{
+		ReadOnlySpan<PropertyAccessors<T>?> propertiesSpan = properties.Span;
+		int propertyCount = 0;
+		for (int i = 0; i < propertiesSpan.Length; i++)
+		{
+			if (propertiesSpan[i] is { MsgPackWriters: not null } property && property.ShouldSerialize?.Invoke(value) is not false)
+			{
+				include[propertyCount++] = i;
+			}
+		}
+
+		return propertyCount;
+	}
+
+	private bool ShouldUseMap(in T value, ref int[]? indexesToIncludeArray, out ReadOnlyMemory<int> indexesToIncludeMemory, out ReadOnlySpan<int> indexesToIncludeSpan)
+	{
+		indexesToIncludeArray = ArrayPool<int>.Shared.Rent(properties.Length);
+
+		indexesToIncludeMemory = this.GetPropertiesToSerialize(value, indexesToIncludeArray.AsMemory());
+		indexesToIncludeSpan = indexesToIncludeMemory.Span;
+		if (indexesToIncludeMemory.Length == 0)
+		{
+			return false;
+		}
+
+		// Determine whether an array or a map would be more efficient.
+		// A map will incur a penalty for writing the indexes as the key, which we'll estimate based on the size of the largest index's msgpack representation.
+		// There's no way in an array to represent a "missing" value (since Nil is in fact a valid value), so ShouldSerialize is only useful for
+		// array representations when we can truncate the array.
+		// We can't cheaply predict how large a value that didn't need to be serialized would be, but since they are 'default' values for their type,
+		// we'll assume each is just 1 byte.
+		int maxKeyLength = MessagePackWriter.GetEncodedLength(indexesToIncludeSpan[^1]);
+		int mapOverhead = maxKeyLength * indexesToIncludeSpan.Length;
+		int arrayOverhead = indexesToIncludeSpan[^1] + 1 - indexesToIncludeSpan.Length; // number of indexes that are required - number of indexes that are useful.
+
+		// Go with whichever representation will be most compact, by estimate.
+		return mapOverhead < arrayOverhead;
 	}
 }

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayWithNonDefaultCtorConverter`2.cs
@@ -15,11 +15,13 @@ namespace Nerdbank.MessagePack.Converters;
 /// <param name="argStateCtor">The constructor for the <typeparamref name="TArgumentState"/> that is later passed to the <typeparamref name="TDeclaringType"/> constructor.</param>
 /// <param name="ctor">The data type's constructor helper.</param>
 /// <param name="parameters">Constructor parameter initializers, in array positions matching serialization indexes.</param>
+/// <param name="callShouldSerialize"><inheritdoc cref="ObjectArrayConverter{T}.ObjectArrayConverter(ReadOnlyMemory{PropertyAccessors{T}?}, Func{T}?, bool)" path="/param[@name='callShouldSerialize']"/></param>
 internal class ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentState>(
 	PropertyAccessors<TDeclaringType>?[] properties,
 	Func<TArgumentState> argStateCtor,
 	Constructor<TArgumentState, TDeclaringType> ctor,
-	DeserializableProperty<TArgumentState>?[] parameters) : ObjectArrayConverter<TDeclaringType>(properties, null)
+	DeserializableProperty<TArgumentState>?[] parameters,
+	bool callShouldSerialize) : ObjectArrayConverter<TDeclaringType>(properties, null, callShouldSerialize)
 {
 	/// <inheritdoc/>
 	public override TDeclaringType? Read(ref MessagePackReader reader, SerializationContext context)
@@ -32,16 +34,36 @@ internal class ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentS
 		context.DepthStep();
 		TArgumentState argState = argStateCtor();
 
-		int count = reader.ReadArrayHeader();
-		for (int i = 0; i < count; i++)
+		if (reader.NextMessagePackType == MessagePackType.Map)
 		{
-			if (parameters.Length > i && parameters[i] is { } deserialize)
+			// The indexes we have are the keys in the map rather than indexes into the array.
+			int count = reader.ReadMapHeader();
+			for (int i = 0; i < count; i++)
 			{
-				deserialize.Read(ref argState, ref reader, context);
+				int index = reader.ReadInt32();
+				if (properties.Length > index && parameters[index] is { } deserialize)
+				{
+					deserialize.Read(ref argState, ref reader, context);
+				}
+				else
+				{
+					reader.Skip(context);
+				}
 			}
-			else
+		}
+		else
+		{
+			int count = reader.ReadArrayHeader();
+			for (int i = 0; i < count; i++)
 			{
-				reader.Skip(context);
+				if (parameters.Length > i && parameters[i] is { } deserialize)
+				{
+					deserialize.Read(ref argState, ref reader, context);
+				}
+				else
+				{
+					reader.Skip(context);
+				}
 			}
 		}
 
@@ -60,19 +82,22 @@ internal class ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentS
 		context.DepthStep();
 		TArgumentState argState = argStateCtor();
 
-		int arrayLength = await reader.ReadArrayHeaderAsync(cancellationToken).ConfigureAwait(false);
-		int i = 0;
-		while (i < arrayLength)
+		if (await reader.TryPeekNextMessagePackTypeAsync(cancellationToken) == MessagePackType.Map)
 		{
-			// Do a batch of all the consecutive properties that should be read synchronously.
-			int syncBatchSize = NextSyncReadBatchSize();
-			if (syncBatchSize > 0)
+			int mapEntries = await reader.ReadMapHeaderAsync(cancellationToken).ConfigureAwait(false);
+
+			// We're going to read in bursts. Anything we happen to get in one buffer, we'll ready synchronously regardless of whether the property is async.
+			// But when we run out of buffer, if the next thing to read is async, we'll read it async.
+			int remainingEntries = mapEntries;
+			while (remainingEntries > 0)
 			{
-				ReadOnlySequence<byte> buffer = await reader.ReadNextStructuresAsync(syncBatchSize, context, cancellationToken).ConfigureAwait(false);
+				(ReadOnlySequence<byte> buffer, int bufferedStructures) = await reader.ReadNextStructuresAsync(1, remainingEntries * 2, context, cancellationToken).ConfigureAwait(false);
 				MessagePackReader syncReader = new(buffer);
-				for (int syncReadEndExclusive = i + syncBatchSize; i < syncReadEndExclusive; i++)
+				int bufferedEntries = bufferedStructures / 2;
+				for (int i = 0; i < bufferedEntries; i++)
 				{
-					if (parameters.Length > i && parameters[i] is { Read: { } deserialize })
+					int propertyIndex = syncReader.ReadInt32();
+					if (propertyIndex < parameters.Length && parameters[propertyIndex] is { Read: { } deserialize })
 					{
 						deserialize(ref argState, ref syncReader, context);
 					}
@@ -80,39 +105,97 @@ internal class ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentS
 					{
 						syncReader.Skip(context);
 					}
+
+					remainingEntries--;
+				}
+
+				if (remainingEntries > 0)
+				{
+					// To know whether the next property is async, we need to know its index.
+					// If its index isn't in the buffer, we'll just loop around and get it in the next buffer.
+					if (bufferedStructures % 2 == 1)
+					{
+						// The property name has already been buffered.
+						int propertyIndex = syncReader.ReadInt32();
+						if (propertyIndex < parameters.Length && parameters[propertyIndex] is { PreferAsyncSerialization: true, ReadAsync: { } deserializeAsync })
+						{
+							// The next property value is async, so turn in our sync reader and read it asynchronously.
+							reader.AdvanceTo(syncReader.Position);
+							argState = await deserializeAsync(argState, reader, context, cancellationToken).ConfigureAwait(false);
+							remainingEntries--;
+
+							// Now loop around to see what else we can do with the next buffer.
+							continue;
+						}
+					}
+					else
+					{
+						// The property name isn't in the buffer, and thus whether it'll have an async reader.
+						// Advance the reader so it knows we need more buffer than we got last time.
+						reader.AdvanceTo(syncReader.Position, buffer.End);
+						continue;
+					}
 				}
 
 				reader.AdvanceTo(syncReader.Position);
 			}
-
-			// Read any consecutive async parameters.
-			for (; i < arrayLength && parameters.Length > i; i++)
+		}
+		else
+		{
+			int arrayLength = await reader.ReadArrayHeaderAsync(cancellationToken).ConfigureAwait(false);
+			int i = 0;
+			while (i < arrayLength)
 			{
-				if (parameters[i] is not DeserializableProperty<TArgumentState> { PreferAsyncSerialization: true, ReadAsync: { } deserializeAsync })
+				// Do a batch of all the consecutive properties that should be read synchronously.
+				int syncBatchSize = NextSyncReadBatchSize();
+				if (syncBatchSize > 0)
 				{
-					break;
-				}
-
-				argState = await deserializeAsync(argState, reader, context, cancellationToken).ConfigureAwait(false);
-			}
-
-			int NextSyncReadBatchSize()
-			{
-				// We want to count the number of array elements need to be read up to the next async property.
-				for (int j = i; j < arrayLength; j++)
-				{
-					if (parameters.Length > j)
+					ReadOnlySequence<byte> buffer = await reader.ReadNextStructuresAsync(syncBatchSize, context, cancellationToken).ConfigureAwait(false);
+					MessagePackReader syncReader = new(buffer);
+					for (int syncReadEndExclusive = i + syncBatchSize; i < syncReadEndExclusive; i++)
 					{
-						DeserializableProperty<TArgumentState>? property = parameters[j];
-						if (property is { PreferAsyncSerialization: true })
+						if (parameters.Length > i && parameters[i] is { Read: { } deserialize })
 						{
-							return j - i;
+							deserialize(ref argState, ref syncReader, context);
+						}
+						else
+						{
+							syncReader.Skip(context);
 						}
 					}
+
+					reader.AdvanceTo(syncReader.Position);
 				}
 
-				// We didn't encounter any more async property readers.
-				return arrayLength - i;
+				// Read any consecutive async parameters.
+				for (; i < arrayLength && parameters.Length > i; i++)
+				{
+					if (parameters[i] is not DeserializableProperty<TArgumentState> { PreferAsyncSerialization: true, ReadAsync: { } deserializeAsync })
+					{
+						break;
+					}
+
+					argState = await deserializeAsync(argState, reader, context, cancellationToken).ConfigureAwait(false);
+				}
+
+				int NextSyncReadBatchSize()
+				{
+					// We want to count the number of array elements need to be read up to the next async property.
+					for (int j = i; j < arrayLength; j++)
+					{
+						if (parameters.Length > j)
+						{
+							DeserializableProperty<TArgumentState>? property = parameters[j];
+							if (property is { PreferAsyncSerialization: true })
+							{
+								return j - i;
+							}
+						}
+					}
+
+					// We didn't encounter any more async property readers.
+					return arrayLength - i;
+				}
 			}
 		}
 

--- a/src/Nerdbank.MessagePack/KeyAttribute.cs
+++ b/src/Nerdbank.MessagePack/KeyAttribute.cs
@@ -4,14 +4,24 @@
 namespace Nerdbank.MessagePack;
 
 /// <summary>
-/// Specifies an ordinal key that may be used when the object serializes its properties as an array of values instead of a map of property names to values.
+/// Specifies an ordinal key that may be used when the object serializes its properties for a faster and/or more compact binary representation.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Once this key is applied to <em>any</em> field or property of a type,
 /// it must be applied to <em>all</em> fields and properties of that type that are candidates for serialization.
 /// Reassigning a key to a different member of the same type is an unversioned breaking change in the serialization schema and should be avoided
 /// when reading or writing across versions is supported.
 /// Unassigned indexes in the array will be left as nil during serialization and ignored during deserialization.
+/// </para>
+/// <para>
+/// An object that uses this attribute may be serialized as an array of values where the index given to this attribute becomes the index into the array for the value of the applied property,
+/// or the object may be serialized as a map where the index given to this attribute provides the key instead of the property name, and the map value is set to the value of the property.
+/// Whether an object serializes as a map or an array is determined at runtime.
+/// When <see cref="MessagePackSerializer.SerializeDefaultValues"/> is <see langword="false"/> and there are "holes" in the would-be array (due to properties with default values or unused indexes),
+/// the map format will be chosen when a quick estimate determines that it will be a more compact representation than an array with holes in it.
+/// Deserializers should always be prepared for either the map or the array representation of the object.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class KeyAttribute : Attribute

--- a/src/Nerdbank.MessagePack/MessagePackAsyncReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackAsyncReader.cs
@@ -115,6 +115,22 @@ public class MessagePackAsyncReader(PipeReader pipeReader)
 		return isNil;
 	}
 
+	/// <inheritdoc cref="MessagePackReader.NextMessagePackType"/>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	public async ValueTask<MessagePackType> TryPeekNextMessagePackTypeAsync(CancellationToken cancellationToken)
+	{
+		ReadResult readResult = await this.ReadAsync(cancellationToken).ConfigureAwait(false);
+		if (readResult.IsCanceled)
+		{
+			throw new OperationCanceledException();
+		}
+
+		MessagePackReader reader = new(readResult.Buffer);
+		MessagePackType result = reader.NextMessagePackType;
+		this.AdvanceTo(readResult.Buffer.Start); // this was a peek. Don't consume anything.
+		return result;
+	}
+
 	/// <inheritdoc cref="MessagePackReader.ReadMapHeader"/>
 	/// <param name="cancellationToken">A cancellation token.</param>
 	public async ValueTask<int> ReadMapHeaderAsync(CancellationToken cancellationToken)

--- a/src/Nerdbank.MessagePack/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/PublicAPI.Unshipped.txt
@@ -88,6 +88,7 @@ Nerdbank.MessagePack.MessagePackAsyncReader.ReadNextStructureAsync(Nerdbank.Mess
 Nerdbank.MessagePack.MessagePackAsyncReader.ReadNextStructuresAsync(int minimumDesiredBufferedStructures, int countUpTo, Nerdbank.MessagePack.SerializationContext context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<(System.Buffers.ReadOnlySequence<byte> Buffer, int IncludedStructures)>
 Nerdbank.MessagePack.MessagePackAsyncReader.ReadNextStructuresAsync(int minimumDesiredBufferedStructures, Nerdbank.MessagePack.SerializationContext context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Buffers.ReadOnlySequence<byte>>
 Nerdbank.MessagePack.MessagePackAsyncReader.SkipAsync(Nerdbank.MessagePack.SerializationContext context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+Nerdbank.MessagePack.MessagePackAsyncReader.TryPeekNextMessagePackTypeAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Nerdbank.MessagePack.MessagePackType>
 Nerdbank.MessagePack.MessagePackAsyncReader.TryReadNilAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<bool>
 Nerdbank.MessagePack.MessagePackAsyncWriter
 Nerdbank.MessagePack.MessagePackAsyncWriter.CreateWriter() -> Nerdbank.MessagePack.MessagePackWriter

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -118,7 +118,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			ArrayConstructorVisitorInputs<T> inputs = new(propertyAccessors);
 			converter = ctorShape is not null
 				? (MessagePackConverter<T>)ctorShape.Accept(this, inputs)!
-				: new ObjectArrayConverter<T>(inputs.GetJustAccessors(), null);
+				: new ObjectArrayConverter<T>(inputs.GetJustAccessors(), null, !this.owner.SerializeDefaultValues);
 		}
 		else
 		{
@@ -304,7 +304,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				{
 					if (constructorShape.ParameterCount == 0)
 					{
-						return new ObjectArrayConverter<TDeclaringType>(inputs.GetJustAccessors(), constructorShape.GetDefaultConstructor());
+						return new ObjectArrayConverter<TDeclaringType>(inputs.GetJustAccessors(), constructorShape.GetDefaultConstructor(), !this.owner.SerializeDefaultValues);
 					}
 
 					Dictionary<string, int> propertyIndexesByName = new(StringComparer.Ordinal);
@@ -327,7 +327,8 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 						inputs.GetJustAccessors(),
 						constructorShape.GetArgumentStateConstructor(),
 						constructorShape.GetParameterizedConstructor(),
-						parameters);
+						parameters,
+						!this.owner.SerializeDefaultValues);
 				}
 
 			default:

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO.Pipelines;
-
 public abstract class MessagePackSerializerTestBase(ITestOutputHelper logger)
 {
 	private ReadOnlySequence<byte> lastRoundtrippedMsgpack;
+
+	/// <summary>
+	/// Gets the time for a delay that is likely (but not guaranteed) to let concurrent work make progress in a way that is conducive to the test's intent.
+	/// </summary>
+	public static TimeSpan AsyncDelay => TimeSpan.FromMilliseconds(250);
 
 	protected MessagePackSerializer Serializer { get; set; } = new();
 

--- a/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
@@ -29,7 +29,7 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void Person_SerializesAsArray()
 	{
-		Person person = new Person { FirstName = "Andrew", LastName = "Arnott" };
+		Person person = new() { FirstName = "Andrew", LastName = "Arnott" };
 		Sequence<byte> buffer = new();
 		this.Serializer.Serialize(buffer, person);
 		this.LogMsgPack(buffer);
@@ -45,14 +45,294 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 		Assert.Equal(person, deserialized);
 	}
 
+	[Theory, PairwiseData]
+	public async Task Person_WithoutLastName(bool async)
+	{
+		// The most compact representation of this is an array of length 1.
+		// Verify that this is what the converter chose.
+		Person person = new() { FirstName = "Andrew", LastName = null };
+		ReadOnlySequence<byte> msgpack = async ? await this.AssertRoundtripAsync(person) : this.AssertRoundtrip(person);
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(1, reader.ReadArrayHeader());
+	}
+
+	[Theory, PairwiseData]
+	public async Task Person_WithoutFirstName(bool async)
+	{
+		// The most compact representation of this is a map of length 1.
+		// Verify that this is what the converter chose.
+		Person person = new() { FirstName = null, LastName = "Arnott" };
+		ReadOnlySequence<byte> msgpack = async ? await this.AssertRoundtripAsync(person) : this.AssertRoundtrip(person);
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(1, reader.ReadMapHeader());
+	}
+
+	[Theory, PairwiseData]
+	public async Task Person_AllDefaultValues(bool async)
+	{
+		// The most compact representation of this is a map of length 1.
+		// Verify that this is what the converter chose.
+		Person person = new Person { FirstName = null, LastName = null };
+		ReadOnlySequence<byte> msgpack = async ? await this.AssertRoundtripAsync(person) : this.AssertRoundtrip(person);
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(0, reader.ReadArrayHeader());
+	}
+
+	[Theory, PairwiseData]
+	public async Task Person_UnexpectedlyLongArray(bool async)
+	{
+		Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		writer.WriteArrayHeader(4);
+		writer.Write("A");
+		writer.WriteNil();
+		writer.Write("B");
+		writer.Write("C"); // This should be ignored.
+		writer.Flush();
+
+		Person? person = async ? await this.Serializer.DeserializeAsync<Person>(PipeReader.Create(sequence)) : this.Serializer.Deserialize<Person>(sequence);
+		Assert.Equal(new Person { FirstName = "A", LastName = "B" }, person);
+	}
+
+	[Theory, PairwiseData]
+	public async Task Person_UnknownIndexesInMap(bool async)
+	{
+		Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		writer.WriteMapHeader(3);
+
+		writer.Write(0);
+		writer.Write("A");
+
+		writer.Write(15);  // This should be ignored.
+		writer.Write("C");
+
+		writer.Write(2);
+		writer.Write("B");
+		writer.Flush();
+
+		Person? person = async ? await this.Serializer.DeserializeAsync<Person>(PipeReader.Create(sequence)) : this.Serializer.Deserialize<Person>(sequence);
+		Assert.Equal(new Person { FirstName = "A", LastName = "B" }, person);
+	}
+
+	[Theory, PairwiseData]
+	public async Task PersonWithDefaultConstructor_WithoutLastName(bool async)
+	{
+		// The most compact representation of this is an array of length 1.
+		// Verify that this is what the converter chose.
+		PersonWithDefaultConstructor person = new() { FirstName = "Andrew", LastName = null };
+		ReadOnlySequence<byte> msgpack = async ? await this.AssertRoundtripAsync(person) : this.AssertRoundtrip(person);
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(1, reader.ReadArrayHeader());
+	}
+
+	[Theory, PairwiseData]
+	public async Task PersonWithDefaultConstructor_WithoutFirstName(bool async)
+	{
+		// The most compact representation of this is a map of length 1.
+		// Verify that this is what the converter chose.
+		PersonWithDefaultConstructor person = new() { FirstName = null, LastName = "Arnott" };
+		ReadOnlySequence<byte> msgpack = async ? await this.AssertRoundtripAsync(person) : this.AssertRoundtrip(person);
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(1, reader.ReadMapHeader());
+	}
+
+	[Theory, PairwiseData]
+	public async Task PersonWithDefaultConstructor_AllDefaultValues(bool async, bool serializeDefaultValues)
+	{
+		// The most compact representation of this is a map of length 1.
+		// Verify that this is what the converter chose, iff we're in that mode.
+		this.Serializer = this.Serializer with { SerializeDefaultValues = serializeDefaultValues };
+
+		PersonWithDefaultConstructor person = new() { FirstName = null, LastName = null };
+		ReadOnlySequence<byte> msgpack = async ? await this.AssertRoundtripAsync(person) : this.AssertRoundtrip(person);
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(serializeDefaultValues ? 3 : 0, reader.ReadArrayHeader());
+	}
+
+	[Theory, PairwiseData]
+	public async Task PersonWithDefaultConstructor_UnexpectedlyLongArray(bool async)
+	{
+		Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		writer.WriteArrayHeader(4);
+		writer.Write("A");
+		writer.WriteNil();
+		writer.Write("B");
+		writer.Write("C"); // This should be ignored.
+		writer.Flush();
+
+		PersonWithDefaultConstructor? person = async ? await this.Serializer.DeserializeAsync<PersonWithDefaultConstructor>(PipeReader.Create(sequence)) : this.Serializer.Deserialize<PersonWithDefaultConstructor>(sequence);
+		Assert.Equal(new PersonWithDefaultConstructor { FirstName = "A", LastName = "B" }, person);
+	}
+
+	[Theory, PairwiseData]
+	public async Task PersonWithDefaultConstructor_UnknownIndexesInMap(bool async)
+	{
+		Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		writer.WriteMapHeader(3);
+
+		writer.Write(0);
+		writer.Write("A");
+
+		writer.Write(15);  // This should be ignored.
+		writer.Write("C");
+
+		writer.Write(2);
+		writer.Write("B");
+		writer.Flush();
+
+		PersonWithDefaultConstructor? person = async ? await this.Serializer.DeserializeAsync<PersonWithDefaultConstructor>(PipeReader.Create(sequence)) : this.Serializer.Deserialize<PersonWithDefaultConstructor>(sequence);
+		Assert.Equal(new PersonWithDefaultConstructor { FirstName = "A", LastName = "B" }, person);
+	}
+
+	[Fact]
+	public async Task AsyncAndSyncPropertyMix()
+	{
+		FamilyWithAsyncProperties family = new()
+		{
+			Father = new() { FirstName = "Dad", LastName = "family" },
+			Mother = new() { FirstName = "Mom", LastName = "family" },
+			FirstChild = new() { FirstName = "Child", LastName = "family" },
+			FamilySize = 3,
+		};
+
+		ReadOnlySequence<byte> msgpack = await this.AssertRoundtripAsync(family);
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(5, reader.ReadArrayHeader());
+	}
+
+	[Fact]
+	public async Task AsyncAndSyncPropertyMix_AsMap()
+	{
+		// Initialize a default late in the array to motivate serialization as a map.
+		FamilyWithAsyncProperties family = new()
+		{
+			Father = null,
+			Mother = null,
+			FirstChild = new() { FirstName = "Child", LastName = "family" },
+			FamilySize = 0,
+		};
+
+		ReadOnlySequence<byte> msgpack = await this.AssertRoundtripAsync(family);
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(1, reader.ReadMapHeader());
+	}
+
+	[Theory, PairwiseData]
+	public async Task AsyncAndSyncPropertyMix_ReadMapFromNonContiguousBuffer(bool breakBeforeIndex)
+	{
+		FamilyWithAsyncProperties expectedFamily = new()
+		{
+			Father = null,
+			Mother = null,
+			FirstChild = new() { FirstName = "child", LastName = "family" },
+			FamilySize = 2,
+		};
+
+		Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		writer.WriteMapHeader(2);
+
+		writer.Write(3);
+		writer.Write(expectedFamily.FamilySize);
+
+		writer.Flush();
+		long positionBeforeIndex = sequence.Length;
+		writer.Write(4);
+		writer.Flush();
+		long positionAfterIndex = sequence.Length;
+
+		this.Serializer.Serialize(ref writer, expectedFamily.FirstChild, GetShape<Person>());
+		writer.Flush();
+		this.LogMsgPack(sequence);
+
+		// Split the buffer up.
+		long splitPosition = breakBeforeIndex ? positionBeforeIndex : positionAfterIndex;
+		byte[] firstSegment = sequence.AsReadOnlySequence.Slice(0, splitPosition).ToArray();
+		byte[] secondSegment = sequence.AsReadOnlySequence.Slice(splitPosition).ToArray();
+
+		// Recombine as a sequence as two segments.
+		sequence.Reset();
+		sequence.Append(firstSegment);
+		sequence.Append(secondSegment);
+
+		// Deserialize, through a pipe that lets us control the buffer segments.
+		Pipe pipe = new();
+
+		ValueTask<FamilyWithAsyncProperties?> familyTask = this.Serializer.DeserializeAsync<FamilyWithAsyncProperties>(pipe.Reader);
+
+		await pipe.Writer.WriteAsync(firstSegment);
+		await Task.Delay(AsyncDelay); // give the deserializer time to run.
+		await pipe.Writer.WriteAsync(secondSegment);
+
+		FamilyWithAsyncProperties? family = await familyTask;
+		Assert.Equal(expectedFamily, family);
+	}
+
+	[Theory, PairwiseData]
+	public async Task AsyncAndSyncPropertyMix_ReadMapFromNonContiguousBuffer_DefaultCtor(bool breakBeforeIndex)
+	{
+		FamilyWithAsyncPropertiesWithDefaultCtor expectedFamily = new()
+		{
+			Father = null,
+			Mother = null,
+			FirstChild = new() { FirstName = "child", LastName = "family" },
+			FamilySize = 2,
+		};
+
+		Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		writer.WriteMapHeader(2);
+
+		writer.Write(3);
+		writer.Write(expectedFamily.FamilySize);
+
+		writer.Flush();
+		long positionBeforeIndex = sequence.Length;
+		writer.Write(4);
+		writer.Flush();
+		long positionAfterIndex = sequence.Length;
+
+		this.Serializer.Serialize(ref writer, expectedFamily.FirstChild, GetShape<Person>());
+		writer.Flush();
+		this.LogMsgPack(sequence);
+
+		// Split the buffer up.
+		long splitPosition = breakBeforeIndex ? positionBeforeIndex : positionAfterIndex;
+		byte[] firstSegment = sequence.AsReadOnlySequence.Slice(0, splitPosition).ToArray();
+		byte[] secondSegment = sequence.AsReadOnlySequence.Slice(splitPosition).ToArray();
+
+		// Recombine as a sequence as two segments.
+		sequence.Reset();
+		sequence.Append(firstSegment);
+		sequence.Append(secondSegment);
+
+		// Deserialize, through a pipe that lets us control the buffer segments.
+		Pipe pipe = new();
+
+		ValueTask<FamilyWithAsyncPropertiesWithDefaultCtor?> familyTask = this.Serializer.DeserializeAsync<FamilyWithAsyncPropertiesWithDefaultCtor>(pipe.Reader);
+
+		await pipe.Writer.WriteAsync(firstSegment);
+		await Task.Delay(AsyncDelay); // give the deserializer time to run.
+		await pipe.Writer.WriteAsync(secondSegment);
+
+		FamilyWithAsyncPropertiesWithDefaultCtor? family = await familyTask;
+		Assert.Equal(expectedFamily, family);
+	}
+
+	private static ITypeShape<T> GetShape<T>()
+		where T : IShapeable<T> => T.GetShape();
+
 	[GenerateShape]
 	public partial record Person
 	{
 		[Key(0)]
-		public required string FirstName { get; init; }
+		public required string? FirstName { get; init; }
 
-		[Key(2)] // Deliberately leave an empty spot.
-		public required string LastName { get; init; }
+		[Key(2)] // Deliberately skip index 1 to test array "hole" handling.
+		public required string? LastName { get; init; }
 	}
 
 	[GenerateShape]
@@ -61,7 +341,51 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 		[Key(0)]
 		public string? FirstName { get; set; }
 
-		[Key(2)] // Deliberately leave an empty spot.
+		[Key(2)] // Deliberately skip index 1 to test array "hole" handling.
 		public string? LastName { get; set; }
+	}
+
+	/// <summary>
+	/// A data type made up of complex and primitive properties such that they'll exercise the async converter code.
+	/// </summary>
+	/// <remarks>
+	/// The key indexes are chosen to include holes to test handling of that.
+	/// </remarks>
+	[GenerateShape]
+	public partial record FamilyWithAsyncProperties
+	{
+		[Key(0)]
+		public required Person? Father { get; init; }
+
+		[Key(1)]
+		public required Person? Mother { get; init; }
+
+		[Key(3)]
+		public int FamilySize { get; init; }
+
+		[Key(4)]
+		public required Person? FirstChild { get; init; }
+	}
+
+	/// <summary>
+	/// A data type made up of complex and primitive properties such that they'll exercise the async converter code.
+	/// </summary>
+	/// <remarks>
+	/// The key indexes are chosen to include holes to test handling of that.
+	/// </remarks>
+	[GenerateShape]
+	public partial record FamilyWithAsyncPropertiesWithDefaultCtor
+	{
+		[Key(0)]
+		public Person? Father { get; set; }
+
+		[Key(1)]
+		public Person? Mother { get; set; }
+
+		[Key(3)]
+		public int FamilySize { get; set; }
+
+		[Key(4)]
+		public Person? FirstChild { get; set; }
 	}
 }


### PR DESCRIPTION
Arrays are most compact when they are packed with data. But if there are 'holes' in the indexes (whether by missing indexes in the key attributes or by properties having default values and thus not serialized), a map that uses those same ordinal indexes as keys can be more compact.
With this new feature, the more compact of the two formats is automatically chosen (when `SerializeDefaultValues == false`) during serialization.
