### PR TITLE
Improve byte buffer (de)serialization

### DIFF
--- a/src/Nerdbank.MessagePack/Converters/EnumerableConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/EnumerableConverter`2.cs
@@ -52,7 +52,7 @@ internal class EnumerableConverter<TEnumerable, TElement>(Func<TEnumerable, IEnu
 		}
 		else
 		{
-			TElement?[] array = enumerable.ToArray();
+			TElement[] array = enumerable.ToArray();
 			writer.WriteArrayHeader(array.Length);
 			for (int i = 0; i < array.Length; i++)
 			{

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -57,7 +57,9 @@ public partial record MessagePackSerializer
 		{ typeof(DateTimeOffset), new DateTimeOffsetConverter() },
 		{ typeof(TimeSpan), new TimeSpanConverter() },
 		{ typeof(Guid), new GuidConverter() },
-		{ typeof(byte[]), new ByteArrayConverter() },
+		{ typeof(byte[]), ByteArrayConverter.Instance },
+		{ typeof(Memory<byte>), new MemoryOfByteConverter() },
+		{ typeof(ReadOnlyMemory<byte>), new ReadOnlyMemoryOfByteConverter() },
 	}.ToFrozenDictionary();
 
 	private static readonly FrozenDictionary<Type, object> PrimitiveReferencePreservingConverters = PrimitiveConverters.ToFrozenDictionary(

--- a/src/Nerdbank.MessagePack/MessagePackWriter.cs
+++ b/src/Nerdbank.MessagePack/MessagePackWriter.cs
@@ -508,7 +508,7 @@ public ref struct MessagePackWriter
 	/// </remarks>
 	public void Write(ReadOnlySpan<byte> src)
 	{
-		int length = (int)src.Length;
+		int length = src.Length;
 		this.WriteBinHeader(length);
 		Span<byte> span = this.writer.GetSpan(length);
 		src.CopyTo(span);

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
@@ -3,7 +3,7 @@
 
 public abstract class MessagePackSerializerTestBase(ITestOutputHelper logger)
 {
-	private ReadOnlySequence<byte> lastRoundtrippedMsgpack;
+	protected ReadOnlySequence<byte> lastRoundtrippedMsgpack;
 
 	/// <summary>
 	/// Gets the time for a delay that is likely (but not guaranteed) to let concurrent work make progress in a way that is conducive to the test's intent.


### PR DESCRIPTION
Various forms of byte buffers (`byte[]`, `Memory<byte>` and `ReadOnlyMemory<byte>`) should serialize using msgpack's special binary buffer format as it is far more compact and faster than using a msgpack array of bytes. This change ensures we use the more efficient form when serializing.

This change also fixes deserialization so that it supports either form.