### PR TITLE
Faster primitive arrays

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Andrew Arnott
+Copyright (c) Andrew Arnott (https://github.com/aarnott/)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -9,5 +9,5 @@ Notices appear in the individual source files, but are also listed here for conv
 
 Copyright for the original work that was copied down (or derived from) belong to the original authors, including:
 
-- Eirik Tsarpalis
-- Yoshifumi Kawai
+- Eirik Tsarpalis - https://github.com/eiriktsarpalis/
+- Yoshifumi Kawai - https://github.com/neuecc

--- a/src/Nerdbank.MessagePack/Converters/ArraysOfPrimitivesConverters.Generated.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArraysOfPrimitivesConverters.Generated.cs
@@ -1,0 +1,273 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Microsoft;
+
+namespace Nerdbank.MessagePack.Converters;
+
+
+/// <summary>
+/// Contains a bunch of converters for arrays of primitives.
+/// </summary>
+/// <remarks>
+/// These aren't strictly necessary, but because we can predict their max encoded representation and embed the
+/// direct reader/writer calls, we can avoid the overhead of many tiny calls to
+/// <see cref="MessagePackWriter.GetSpan(int)"/> and <see cref="MessagePackWriter.Advance(int)"/>,
+/// which speeds things up considerably.
+/// </remarks>
+internal static partial class ArraysOfPrimitivesConverters
+{
+	/// <summary>
+	/// Creates a converter optimized for primitive arrays if one is available for the given enumerable and element type.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The type of enumerable.</typeparam>
+	/// <typeparam name="TElement">The type of element.</typeparam>
+	/// <param name="getEnumerable">The function that produces an <see cref="IEnumerable{T}"/> for a given <typeparamref name="TEnumerable"/>.</param>
+	/// <param name="spanConstructor">The constructor for the enumerable type.</param>
+	/// <param name="converter">Receives the hardware-accelerated converter if one is available.</param>
+	/// <returns>A value indicating whether a converter is available.</returns>
+	internal static bool TryGetConverter<TEnumerable, TElement>(
+		Func<TEnumerable, IEnumerable<TElement>> getEnumerable,
+		SpanConstructor<TElement, TEnumerable> spanConstructor,
+		[NotNullWhen(true)] out MessagePackConverter<TEnumerable>? converter)
+	{
+		object? spanConstructorToUse = typeof(TElement[]).IsAssignableTo(typeof(TEnumerable)) ? null : spanConstructor;
+
+		if (typeof(TElement) == typeof(SByte))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new SByteArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<SByte>>)getEnumerable,
+				(SpanConstructor<SByte, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+		if (typeof(TElement) == typeof(Int16))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new Int16ArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<Int16>>)getEnumerable,
+				(SpanConstructor<Int16, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+		if (typeof(TElement) == typeof(Int32))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new Int32ArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<Int32>>)getEnumerable,
+				(SpanConstructor<Int32, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+		if (typeof(TElement) == typeof(Int64))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new Int64ArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<Int64>>)getEnumerable,
+				(SpanConstructor<Int64, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+		if (typeof(TElement) == typeof(UInt16))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new UInt16ArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<UInt16>>)getEnumerable,
+				(SpanConstructor<UInt16, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+		if (typeof(TElement) == typeof(UInt32))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new UInt32ArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<UInt32>>)getEnumerable,
+				(SpanConstructor<UInt32, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+		if (typeof(TElement) == typeof(UInt64))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new UInt64ArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<UInt64>>)getEnumerable,
+				(SpanConstructor<UInt64, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+		if (typeof(TElement) == typeof(Single))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new SingleArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<Single>>)getEnumerable,
+				(SpanConstructor<Single, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+		if (typeof(TElement) == typeof(Double))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new DoubleArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<Double>>)getEnumerable,
+				(SpanConstructor<Double, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+		if (typeof(TElement) == typeof(Boolean))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new BooleanArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<Boolean>>)getEnumerable,
+				(SpanConstructor<Boolean, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+		converter = null;
+		return false;
+	}
+
+	/// <summary>
+	/// A converter for <see cref="SByte"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class SByteArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<SByte>> getEnumerable,
+		SpanConstructor<SByte, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, SByte>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override SByte Read(ref MessagePackReader reader) => reader.ReadSByte();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, SByte value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+
+	/// <summary>
+	/// A converter for <see cref="Int16"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class Int16ArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<Int16>> getEnumerable,
+		SpanConstructor<Int16, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, Int16>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override Int16 Read(ref MessagePackReader reader) => reader.ReadInt16();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, Int16 value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+
+	/// <summary>
+	/// A converter for <see cref="Int32"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class Int32ArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<Int32>> getEnumerable,
+		SpanConstructor<Int32, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, Int32>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override Int32 Read(ref MessagePackReader reader) => reader.ReadInt32();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, Int32 value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+
+	/// <summary>
+	/// A converter for <see cref="Int64"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class Int64ArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<Int64>> getEnumerable,
+		SpanConstructor<Int64, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, Int64>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override Int64 Read(ref MessagePackReader reader) => reader.ReadInt64();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, Int64 value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+
+	/// <summary>
+	/// A converter for <see cref="UInt16"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class UInt16ArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<UInt16>> getEnumerable,
+		SpanConstructor<UInt16, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, UInt16>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override UInt16 Read(ref MessagePackReader reader) => reader.ReadUInt16();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, UInt16 value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+
+	/// <summary>
+	/// A converter for <see cref="UInt32"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class UInt32ArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<UInt32>> getEnumerable,
+		SpanConstructor<UInt32, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, UInt32>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override UInt32 Read(ref MessagePackReader reader) => reader.ReadUInt32();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, UInt32 value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+
+	/// <summary>
+	/// A converter for <see cref="UInt64"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class UInt64ArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<UInt64>> getEnumerable,
+		SpanConstructor<UInt64, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, UInt64>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override UInt64 Read(ref MessagePackReader reader) => reader.ReadUInt64();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, UInt64 value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+
+	/// <summary>
+	/// A converter for <see cref="Single"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class SingleArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<Single>> getEnumerable,
+		SpanConstructor<Single, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, Single>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override Single Read(ref MessagePackReader reader) => reader.ReadSingle();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, Single value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+
+	/// <summary>
+	/// A converter for <see cref="Double"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class DoubleArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<Double>> getEnumerable,
+		SpanConstructor<Double, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, Double>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override Double Read(ref MessagePackReader reader) => reader.ReadDouble();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, Double value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+
+	/// <summary>
+	/// A converter for <see cref="Boolean"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class BooleanArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<Boolean>> getEnumerable,
+		SpanConstructor<Boolean, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, Boolean>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override Boolean Read(ref MessagePackReader reader) => reader.ReadBoolean();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, Boolean value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+}

--- a/src/Nerdbank.MessagePack/Converters/ArraysOfPrimitivesConverters.Generated.tt
+++ b/src/Nerdbank.MessagePack/Converters/ArraysOfPrimitivesConverters.Generated.tt
@@ -1,0 +1,84 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Microsoft;
+
+namespace Nerdbank.MessagePack.Converters;
+
+<#
+    // We don't bother with Byte because byte[] has a far superior encoding (binary) so we don't need to optimize it here.
+    string[] primitiveTypeNames = ["SByte", "Int16", "Int32", "Int64", /*"Byte",*/ "UInt16", "UInt32", "UInt64", "Single", "Double", "Boolean"];
+#>
+
+/// <summary>
+/// Contains a bunch of converters for arrays of primitives.
+/// </summary>
+/// <remarks>
+/// These aren't strictly necessary, but because we can predict their max encoded representation and embed the
+/// direct reader/writer calls, we can avoid the overhead of many tiny calls to
+/// <see cref="MessagePackWriter.GetSpan(int)"/> and <see cref="MessagePackWriter.Advance(int)"/>,
+/// which speeds things up considerably.
+/// </remarks>
+internal static partial class ArraysOfPrimitivesConverters
+{
+	/// <summary>
+	/// Creates a converter optimized for primitive arrays if one is available for the given enumerable and element type.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The type of enumerable.</typeparam>
+	/// <typeparam name="TElement">The type of element.</typeparam>
+	/// <param name="getEnumerable">The function that produces an <see cref="IEnumerable{T}"/> for a given <typeparamref name="TEnumerable"/>.</param>
+	/// <param name="spanConstructor">The constructor for the enumerable type.</param>
+	/// <param name="converter">Receives the hardware-accelerated converter if one is available.</param>
+	/// <returns>A value indicating whether a converter is available.</returns>
+	internal static bool TryGetConverter<TEnumerable, TElement>(
+		Func<TEnumerable, IEnumerable<TElement>> getEnumerable,
+		SpanConstructor<TElement, TEnumerable> spanConstructor,
+		[NotNullWhen(true)] out MessagePackConverter<TEnumerable>? converter)
+	{
+		object? spanConstructorToUse = typeof(TElement[]).IsAssignableTo(typeof(TEnumerable)) ? null : spanConstructor;
+
+<#
+    foreach (string primitive in primitiveTypeNames)
+    {
+#>
+		if (typeof(TElement) == typeof(<#=primitive#>))
+		{
+			converter = (MessagePackConverter<TEnumerable>)(object)new <#=primitive#>ArrayConverter<TEnumerable>(
+				(Func<TEnumerable, IEnumerable<<#=primitive#>>>)getEnumerable,
+				(SpanConstructor<<#=primitive#>, TEnumerable>?)spanConstructorToUse);
+			return true;
+		}
+
+<#
+    }
+#>
+		converter = null;
+		return false;
+	}
+<#
+    foreach (string primitive in primitiveTypeNames)
+    {
+#>
+
+	/// <summary>
+	/// A converter for <see cref="<#=primitive#>"/> enumerables.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The concrete type of enumerable.</typeparam>
+	private class <#=primitive#>ArrayConverter<TEnumerable>(
+		Func<TEnumerable, IEnumerable<<#=primitive#>>> getEnumerable,
+		SpanConstructor<<#=primitive#>, TEnumerable>? spanConstructor) : PrimitiveArrayConverter<TEnumerable, <#=primitive#>>(getEnumerable, spanConstructor)
+	{
+		/// <inheritdoc/>
+		protected override <#=primitive#> Read(ref MessagePackReader reader) => reader.Read<#=primitive#>();
+
+		/// <inheritdoc/>
+		protected override bool TryWrite(Span<byte> msgpack, <#=primitive#> value, out int written) => MessagePackPrimitives.TryWrite(msgpack, value, out written);
+	}
+<#
+    }
+#>
+}

--- a/src/Nerdbank.MessagePack/Converters/ArraysOfPrimitivesConverters.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArraysOfPrimitivesConverters.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using Microsoft;
+
+namespace Nerdbank.MessagePack.Converters;
+
+/// <summary>
+/// Contains a bunch of converters for arrays of primitives.
+/// </summary>
+/// <remarks>
+/// These aren't strictly necessary, but because we can predict their max encoded representation and embed the
+/// direct reader/writer calls, we can avoid the overhead of many tiny calls to
+/// <see cref="MessagePackWriter.GetSpan(int)"/> and <see cref="MessagePackWriter.Advance(int)"/>,
+/// which speeds things up considerably.
+/// </remarks>
+internal static partial class ArraysOfPrimitivesConverters
+{
+	/// <summary>
+	/// An abstract base class for converting arrays of primitive types.
+	/// </summary>
+	/// <typeparam name="TEnumerable">The type of enumerable.</typeparam>
+	/// <typeparam name="TElement">The type of element.</typeparam>
+	/// <param name="getEnumerable">The function that produces an <see cref="IEnumerable{T}"/> for a given <typeparamref name="TEnumerable"/>.</param>
+	/// <param name="spanConstructor">The constructor for the enumerable type.</param>
+	private abstract class PrimitiveArrayConverter<TEnumerable, TElement>(
+		Func<TEnumerable, IEnumerable<TElement>> getEnumerable,
+		SpanConstructor<TElement, TEnumerable>? spanConstructor) : MessagePackConverter<TEnumerable>
+		where TElement : unmanaged
+	{
+		/// <summary>
+		/// The factor by which the input values span length should be multiplied to get the minimum output buffer length.
+		/// </summary>
+		/// <remarks>
+		/// Booleans are unique in that they always take exactly one byte.
+		/// All other primitives are assumed to take a max of their own full memory size + a single byte for the msgpack header.
+		/// </remarks>
+		private static readonly unsafe int MsgPackBufferLengthFactor = typeof(TElement) == typeof(bool) ? 1 : (sizeof(TElement) + 1);
+
+		/// <inheritdoc/>
+		public override void Write(ref MessagePackWriter writer, in TEnumerable? value, SerializationContext context)
+		{
+			if (value is null)
+			{
+				writer.WriteNil();
+				return;
+			}
+
+			int totalBytesWritten = 0;
+			if (TryGetSpan(value, out ReadOnlySpan<TElement> values))
+			{
+				writer.WriteArrayHeader(values.Length);
+				Span<byte> span = writer.GetSpan(values.Length * MsgPackBufferLengthFactor);
+				for (int i = 0; i < values.Length; i++)
+				{
+					Assumes.True(this.TryWrite(span[totalBytesWritten..], values[i], out int justWritten));
+					totalBytesWritten += justWritten;
+				}
+			}
+			else
+			{
+				IEnumerable<TElement> enumerable = getEnumerable(value);
+				if (Enumerable.TryGetNonEnumeratedCount(enumerable, out int count))
+				{
+					writer.WriteArrayHeader(count);
+					Span<byte> span = writer.GetSpan(count * MsgPackBufferLengthFactor);
+					foreach (TElement element in enumerable)
+					{
+						Assumes.True(this.TryWrite(span[totalBytesWritten..], element, out int justWritten));
+						totalBytesWritten += justWritten;
+					}
+				}
+				else
+				{
+					TElement[] array = enumerable.ToArray();
+					writer.WriteArrayHeader(array.Length);
+					Span<byte> span = writer.GetSpan(count * MsgPackBufferLengthFactor);
+					for (int i = 0; i < array.Length; i++)
+					{
+						Assumes.True(this.TryWrite(span[totalBytesWritten..], array[i], out int justWritten));
+						totalBytesWritten += justWritten;
+					}
+				}
+			}
+
+			writer.Advance(totalBytesWritten);
+		}
+
+		/// <inheritdoc/>
+		public override TEnumerable? Read(ref MessagePackReader reader, SerializationContext context)
+		{
+			if (reader.TryReadNil())
+			{
+				return default;
+			}
+
+			int count = reader.ReadArrayHeader();
+			if (count == 0)
+			{
+				return spanConstructor is null ? (TEnumerable)(object)Array.Empty<TElement>() : spanConstructor(default);
+			}
+
+			TElement[] elements = spanConstructor is null ? new TElement[count] : ArrayPool<TElement>.Shared.Rent(count);
+			try
+			{
+				// PERF: When the memory is contiguous, we could use MessagePackPrimitives and advance an offset manually
+				// to avoid calling some machinery within MessagePackReader to speed things up.
+				for (int i = 0; i < count; i++)
+				{
+					elements[i] = this.Read(ref reader);
+				}
+
+				return spanConstructor is null ? (TEnumerable)(object)elements : spanConstructor(elements.AsSpan(0, count));
+			}
+			finally
+			{
+				if (spanConstructor is not null)
+				{
+					ArrayPool<TElement>.Shared.Return(elements);
+				}
+			}
+		}
+
+		/// <summary>
+		/// When overridden by a derived class, invokes the appropriate <see cref="MessagePackPrimitives"/> <c>TryWrite</c> overload.
+		/// </summary>
+		/// <param name="destination">The buffer to write the msgpack-encoded value to.</param>
+		/// <param name="value">The value to encode.</param>
+		/// <param name="bytesWritten">Receives the number of actual bytes written to <paramref name="destination"/>, or that would have been written had there been sufficient space.</param>
+		/// <returns>A value indicating whether <paramref name="destination"/> was large enough to write out the value.</returns>>
+		protected abstract bool TryWrite(Span<byte> destination, TElement value, out int bytesWritten);
+
+		/// <summary>
+		/// Decodes a msgpack value.
+		/// </summary>
+		/// <param name="reader">The reader to use.</param>
+		/// <returns>The decoded value.</returns>
+		protected abstract TElement Read(ref MessagePackReader reader);
+
+		private static bool TryGetSpan(TEnumerable enumerable, out ReadOnlySpan<TElement> span)
+		{
+			switch (enumerable)
+			{
+				case TElement[] array:
+					span = array;
+					return true;
+				case List<TElement> list:
+					span = CollectionsMarshal.AsSpan(list);
+					return true;
+				case ReadOnlyMemory<TElement> rom:
+					span = rom.Span;
+					return true;
+				case Memory<TElement> mem:
+					span = mem.Span;
+					return true;
+			}
+
+			span = default;
+			return false;
+		}
+	}
+}

--- a/src/Nerdbank.MessagePack/Nerdbank.MessagePack.csproj
+++ b/src/Nerdbank.MessagePack/Nerdbank.MessagePack.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="System.IO.Pipelines" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="Converters\ArraysOfPrimitivesConverters.Generated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ArraysOfPrimitivesConverters.Generated.cs</LastGenOutput>
+    </None>
     <None Update="Converters\IntConverters.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>IntConverters.cs</LastGenOutput>
@@ -46,6 +50,11 @@
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="Converters\ArraysOfPrimitivesConverters.Generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ArraysOfPrimitivesConverters.Generated.tt</DependentUpon>
+    </Compile>
     <Compile Update="Converters\IntConverters.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -384,22 +384,34 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 
 		if (enumerableShape.Type.IsArray)
 		{
-			return enumerableShape.Rank > 1
-				? this.owner.MultiDimensionalArrayFormat switch
+			if (enumerableShape.Rank > 1)
+			{
+				return this.owner.MultiDimensionalArrayFormat switch
 				{
 					MultiDimensionalArrayFormat.Nested => new ArrayWithNestedDimensionsConverter<TEnumerable, TElement>(elementConverter, enumerableShape.Rank),
 					MultiDimensionalArrayFormat.Flat => new ArrayWithFlattenedDimensionsConverter<TEnumerable, TElement>(elementConverter),
 					_ => throw new NotSupportedException(),
-				}
-				: new ArrayConverter<TElement>(elementConverter);
+				};
+			}
+			else if (enumerableShape.ConstructionStrategy == CollectionConstructionStrategy.Span &&
+				ArraysOfPrimitivesConverters.TryGetConverter(enumerableShape.GetGetEnumerable(), enumerableShape.GetSpanConstructor(), out MessagePackConverter<TEnumerable>? converter))
+			{
+				return converter;
+			}
+			else
+			{
+				return new ArrayConverter<TElement>(elementConverter);
+			}
 		}
 
+		Func<TEnumerable, IEnumerable<TElement>> getEnumerable = enumerableShape.GetGetEnumerable();
 		return enumerableShape.ConstructionStrategy switch
 		{
-			CollectionConstructionStrategy.None => new EnumerableConverter<TEnumerable, TElement>(enumerableShape.GetGetEnumerable(), elementConverter),
-			CollectionConstructionStrategy.Mutable => new MutableEnumerableConverter<TEnumerable, TElement>(enumerableShape.GetGetEnumerable(), elementConverter, enumerableShape.GetAddElement(), enumerableShape.GetDefaultConstructor()),
-			CollectionConstructionStrategy.Span => new SpanEnumerableConverter<TEnumerable, TElement>(enumerableShape.GetGetEnumerable(), elementConverter, enumerableShape.GetSpanConstructor()),
-			CollectionConstructionStrategy.Enumerable => new EnumerableEnumerableConverter<TEnumerable, TElement>(enumerableShape.GetGetEnumerable(), elementConverter, enumerableShape.GetEnumerableConstructor()),
+			CollectionConstructionStrategy.None => new EnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter),
+			CollectionConstructionStrategy.Mutable => new MutableEnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter, enumerableShape.GetAddElement(), enumerableShape.GetDefaultConstructor()),
+			CollectionConstructionStrategy.Span when ArraysOfPrimitivesConverters.TryGetConverter(getEnumerable, enumerableShape.GetSpanConstructor(), out MessagePackConverter<TEnumerable>? converter) => converter,
+			CollectionConstructionStrategy.Span => new SpanEnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter, enumerableShape.GetSpanConstructor()),
+			CollectionConstructionStrategy.Enumerable => new EnumerableEnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter, enumerableShape.GetEnumerableConstructor()),
 			_ => throw new NotSupportedException($"Unrecognized enumerable pattern: {typeof(TEnumerable).Name}"),
 		};
 	}

--- a/test/Benchmarks/ArraysOfPrimitives.cs
+++ b/test/Benchmarks/ArraysOfPrimitives.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+[MemoryDiagnoser]
+public partial class ArraysOfPrimitives
+{
+	private const int Length = 10_000;
+	private static readonly bool[] BoolValues = GetRandomBools(Length);
+	private static readonly byte[] BoolValuesMsgPack = new MessagePackSerializer { SerializeDefaultValues = true }.Serialize<bool[], Witness>(BoolValues);
+	private static readonly sbyte[] Int8Values = GetRandomValues<sbyte>(Length);
+	private static readonly short[] Int16Values = GetRandomValues<short>(Length);
+	private static readonly int[] Int32Values = GetRandomValues<int>(Length);
+	private static readonly long[] Int64Values = GetRandomValues<long>(Length);
+	private static readonly ushort[] UInt16Values = GetRandomValues<ushort>(Length);
+	private static readonly uint[] UInt32Values = GetRandomValues<uint>(Length);
+	private static readonly ulong[] UInt64Values = GetRandomValues<ulong>(Length);
+	private static readonly float[] SingleValues = GetRandomFloats(Length);
+	private static readonly double[] DoubleValues = GetRandomDoubles(Length);
+	private readonly Sequence<byte> buffer = new();
+
+	public MessagePackSerializer Serializer { get; } = new() { SerializeDefaultValues = true };
+
+	[Benchmark]
+	[BenchmarkCategory("bool", "deserialize")]
+	public void Bool_Deserialize()
+	{
+		this.Serializer.Deserialize<bool[], Witness>(BoolValuesMsgPack);
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("bool", "serialize")]
+	public void Bool_Serialize()
+	{
+		this.Serializer.Serialize<bool[], Witness>(this.buffer, BoolValues);
+		this.buffer.Reset();
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("int8", "serialize")]
+	public void Int8_Serialize()
+	{
+		this.Serializer.Serialize<sbyte[], Witness>(this.buffer, Int8Values);
+		this.buffer.Reset();
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("int16", "serialize")]
+	public void Int16_Serialize()
+	{
+		this.Serializer.Serialize<short[], Witness>(this.buffer, Int16Values);
+		this.buffer.Reset();
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("int32", "serialize")]
+	public void Int32_Serialize()
+	{
+		this.Serializer.Serialize<int[], Witness>(this.buffer, Int32Values);
+		this.buffer.Reset();
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("int64", "serialize")]
+	public void Int64_Serialize()
+	{
+		this.Serializer.Serialize<long[], Witness>(this.buffer, Int64Values);
+		this.buffer.Reset();
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("uint16", "serialize")]
+	public void UInt16_Serialize()
+	{
+		this.Serializer.Serialize<ushort[], Witness>(this.buffer, UInt16Values);
+		this.buffer.Reset();
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("uint32", "serialize")]
+	public void UInt32_Serialize()
+	{
+		this.Serializer.Serialize<uint[], Witness>(this.buffer, UInt32Values);
+		this.buffer.Reset();
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("uint64", "serialize")]
+	public void UInt64_Serialize()
+	{
+		this.Serializer.Serialize<ulong[], Witness>(this.buffer, UInt64Values);
+		this.buffer.Reset();
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("float", "serialize")]
+	public void Single_Serialize()
+	{
+		this.Serializer.Serialize<float[], Witness>(this.buffer, SingleValues);
+		this.buffer.Reset();
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("double", "serialize")]
+	public void Double_Serialize()
+	{
+		this.Serializer.Serialize<double[], Witness>(this.buffer, DoubleValues);
+		this.buffer.Reset();
+	}
+
+	private static unsafe T[] GetRandomValues<T>(int length)
+		where T : unmanaged
+	{
+		byte[] random = new byte[length * sizeof(T)];
+		new Random(123).NextBytes(random); // use a fixed seed for reproducibility
+		T[] values = new T[length];
+		fixed (byte* pSource = random)
+		{
+			fixed (T* pTarget = values)
+			{
+				Buffer.MemoryCopy(pSource, pTarget, values.Length * sizeof(T), random.Length);
+			}
+		}
+
+		return values;
+	}
+
+	private static float[] GetRandomFloats(int length)
+	{
+		Random random = new Random(123); // use a fixed seed for reproducibility
+		float[] values = new float[length];
+		for (int i = 0; i < values.Length; i++)
+		{
+			values[i] = random.NextSingle();
+		}
+
+		return values;
+	}
+
+	private static double[] GetRandomDoubles(int length)
+	{
+		Random random = new Random(123); // use a fixed seed for reproducibility
+		double[] values = new double[length];
+		for (int i = 0; i < values.Length; i++)
+		{
+			values[i] = random.NextDouble();
+		}
+
+		return values;
+	}
+
+	private static bool[] GetRandomBools(int length)
+	{
+		byte[] random = new byte[length];
+		new Random(123).NextBytes(random); // use a fixed seed for reproducibility
+		bool[] values = random.Select(b => b % 2 == 0).ToArray();
+		return values;
+	}
+
+	[GenerateShape<bool[]>]
+	[GenerateShape<sbyte[]>]
+	[GenerateShape<sbyte[]>]
+	[GenerateShape<short[]>]
+	[GenerateShape<int[]>]
+	[GenerateShape<long[]>]
+	[GenerateShape<ushort[]>]
+	[GenerateShape<uint[]>]
+	[GenerateShape<ulong[]>]
+	[GenerateShape<float[]>]
+	[GenerateShape<double[]>]
+	private partial class Witness;
+}

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Nerdbank.MessagePack.Tests/ArraysOfPrimitivesTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ArraysOfPrimitivesTests.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Numerics;
+using System.Reflection;
+
+public partial class ArraysOfPrimitivesTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	[Theory, PairwiseData]
+	public void BoolArray([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(byte))] int length)
+	{
+		bool[]? values = null;
+		if (length >= 0)
+		{
+			byte[] random = new byte[length];
+			Random.Shared.NextBytes(random);
+			values = random.Select(b => b % 2 == 0).ToArray();
+		}
+
+		this.Roundtrip<bool[], Witness>(values);
+	}
+
+	[Theory, PairwiseData]
+	public void Boolean([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(byte))] int length)
+	{
+		bool[]? values = null;
+		if (length >= 0)
+		{
+			byte[]? random = new byte[length];
+			Random.Shared.NextBytes(random);
+			values = random.Select(b => b % 2 == 0).ToArray();
+		}
+
+		this.Roundtrip<Memory<bool>, Witness>(values);
+	}
+
+	[Theory, PairwiseData]
+	public void Int8([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(sbyte))] int length)
+		=> this.Roundtrip<Memory<sbyte>, Witness>(GetRandomValues<sbyte>(length));
+
+	[Theory, PairwiseData]
+	public void Int16([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(short))] int length)
+		=> this.Roundtrip<Memory<short>, Witness>(GetRandomValues<short>(length));
+
+	[Theory, PairwiseData]
+	public void Int32([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(int))] int length)
+		=> this.Roundtrip<Memory<int>, Witness>(GetRandomValues<int>(length));
+
+	[Theory, PairwiseData]
+	public void Int64([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(long))] int length)
+		=> this.Roundtrip<Memory<long>, Witness>(GetRandomValues<long>(length));
+
+	[Theory, PairwiseData]
+	public void UInt8([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(byte))] int length)
+		=> this.Roundtrip<Memory<byte>, Witness>(GetRandomValues<byte>(length));
+
+	[Theory, PairwiseData]
+	public void UInt16([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(ushort))] int length)
+		=> this.Roundtrip<Memory<ushort>, Witness>(GetRandomValues<ushort>(length));
+
+	[Theory, PairwiseData]
+	public void UInt32([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(uint))] int length)
+		=> this.Roundtrip<Memory<uint>, Witness>(GetRandomValues<uint>(length));
+
+	[Theory, PairwiseData]
+	public void UInt64([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(ulong))] int length)
+		=> this.Roundtrip<Memory<ulong>, Witness>(GetRandomValues<ulong>(length));
+
+	[Theory, PairwiseData]
+	public void Single([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(float))] int length)
+	{
+		float[]? values = null;
+		if (length >= 0)
+		{
+			values = new float[length];
+			for (int i = 0; i < values.Length; i++)
+			{
+				values[i] = Random.Shared.NextSingle();
+			}
+		}
+
+		this.Roundtrip<Memory<float>, Witness>(values);
+	}
+
+	[Theory, PairwiseData]
+	public void Double([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(double))] int length)
+	{
+		double[]? values = null;
+		if (length >= 0)
+		{
+			values = new double[length];
+			for (int i = 0; i < values.Length; i++)
+			{
+				values[i] = Random.Shared.NextDouble();
+			}
+		}
+
+		this.Roundtrip<Memory<double>, Witness>(values);
+	}
+
+	private static unsafe T[]? GetRandomValues<T>(int length)
+		where T : unmanaged
+	{
+		if (length < 0)
+		{
+			return null;
+		}
+
+		byte[] random = new byte[length * sizeof(T)];
+		Random.Shared.NextBytes(random);
+		T[] values = new T[length];
+		fixed (byte* pSource = random)
+		{
+			fixed (T* pTarget = values)
+			{
+				Buffer.MemoryCopy(pSource, pTarget, values.Length * sizeof(T), random.Length);
+			}
+		}
+
+		return values;
+	}
+
+	private static int[] GetInterestingLengths(Type type) => (int[])typeof(ArraysOfPrimitivesTests).GetMethod(nameof(GetInterestingLengthsHelper), BindingFlags.NonPublic | BindingFlags.Static)!.MakeGenericMethod(type).Invoke(null, null)!;
+
+	private static int[] GetInterestingLengthsHelper<T>() => [-1, 0, 4, Vector<T>.Count - 1, Vector<T>.Count, Vector<T>.Count + 1, (Vector<T>.Count * 2) + 2, 10_000];
+
+	[GenerateShape<bool[]>]
+	[GenerateShape<Memory<bool>>]
+	[GenerateShape<Memory<sbyte>>]
+	[GenerateShape<Memory<short>>]
+	[GenerateShape<Memory<int>>]
+	[GenerateShape<Memory<long>>]
+	[GenerateShape<Memory<byte>>]
+	[GenerateShape<Memory<ushort>>]
+	[GenerateShape<Memory<uint>>]
+	[GenerateShape<Memory<ulong>>]
+	[GenerateShape<Memory<float>>]
+	[GenerateShape<Memory<double>>]
+	private partial class Witness;
+}


### PR DESCRIPTION
Optimize serialization of arrays of primitives

These are super-small values of predictable max size. The largest perf cost to these previously had been the very many `MessagePackWriter.Advance(int)` calls. But we can reduce that from one per array element to just one per array, which makes such arrays dramatically faster.

## Before

| Method           | Mean     | Error     | StdDev   | Gen0   | Allocated |
|----------------- |---------:|----------:|---------:|-------:|----------:|
| Bool_Deserialize | 37.32 μs |  8.097 μs | 0.444 μs | 1.1597 |   10024 B |
| Bool_Serialize   | 38.50 μs |  7.784 μs | 0.427 μs |      - |         - |
| Double_Serialize | 41.46 μs |  7.525 μs | 0.412 μs |      - |         - |
| Single_Serialize | 43.66 μs | 50.927 μs | 2.791 μs |      - |         - |
| Int16_Serialize  | 73.34 μs |  5.794 μs | 0.318 μs |      - |         - |
| Int32_Serialize  | 79.60 μs |  5.485 μs | 0.301 μs |      - |         - |
| Int64_Serialize  | 92.66 μs | 33.140 μs | 1.816 μs |      - |         - |
| Int8_Serialize   | 66.61 μs |  7.251 μs | 0.397 μs |      - |         - |
| UInt16_Serialize | 32.16 μs |  7.697 μs | 0.422 μs |      - |         - |
| UInt32_Serialize | 41.43 μs |  0.443 μs | 0.024 μs |      - |         - |
| UInt64_Serialize | 47.61 μs |  5.934 μs | 0.325 μs |      - |         - |

## After

| Method           | Mean     | Error     | StdDev   | Gen0   | Allocated |
|----------------- |---------:|----------:|---------:|-------:|----------:|
| Bool_Deserialize | 33.98 us |  2.365 us | 0.130 us | 1.1597 |   10024 B |
| Bool_Serialize   | 34.47 us | 15.759 us | 0.864 us |      - |         - |
| Double_Serialize | 28.51 us |  4.251 us | 0.233 us |      - |         - |
| Single_Serialize | 20.30 us |  1.865 us | 0.102 us |      - |         - |
| Int16_Serialize  | 39.02 us | 10.901 us | 0.598 us |      - |         - |
| Int32_Serialize  | 41.60 us |  6.761 us | 0.371 us |      - |         - |
| Int64_Serialize  | 48.85 us |  5.687 us | 0.312 us |      - |         - |
| Int8_Serialize   | 45.08 us |  3.616 us | 0.198 us |      - |         - |
| UInt16_Serialize | 19.83 us |  0.839 us | 0.046 us |      - |         - |
| UInt32_Serialize | 21.71 us |  1.565 us | 0.086 us |      - |         - |
| UInt64_Serialize | 29.96 us |  9.823 us | 0.538 us |      - |         - |
