### PR TITLE
Fix handling of getter-only properties on `[Key]` types

### DIFF
--- a/src/Nerdbank.MessagePack.Analyzers.CodeFixes/MigrationCodeFix.cs
+++ b/src/Nerdbank.MessagePack.Analyzers.CodeFixes/MigrationCodeFix.cs
@@ -369,7 +369,8 @@ public class MigrationCodeFix : CodeFixProvider
 			}
 			else
 			{
-				return (SyntaxNode?)node;
+				// look for nested types that need to be marked with [GenerateShape]
+				return base.VisitClassDeclaration(node);
 			}
 		}
 

--- a/src/Nerdbank.MessagePack.Analyzers/KeyAttributeUseAnalyzer.cs
+++ b/src/Nerdbank.MessagePack.Analyzers/KeyAttributeUseAnalyzer.cs
@@ -94,7 +94,13 @@ public class KeyAttributeUseAnalyzer : DiagnosticAnalyzer
 					}
 					else if (keyAttributeApplied != keyAttribute is not null)
 					{
-						context.ReportDiagnostic(Diagnostic.Create(InconsistentUseDescriptor, memberSymbol.Locations.First()));
+						Location? location = memberSymbol.Locations.FirstOrDefault(l => l.SourceTree is not null) ??
+							typeSymbol.Locations.FirstOrDefault(l => l.SourceTree is not null);
+						context.ReportDiagnostic(
+							Diagnostic.Create(
+								InconsistentUseDescriptor,
+								location,
+								$"{typeSymbol.Name}.{memberSymbol.Name}"));
 					}
 
 					if (keyAttribute is not null)

--- a/src/Nerdbank.MessagePack.Analyzers/ReferenceSymbols.cs
+++ b/src/Nerdbank.MessagePack.Analyzers/ReferenceSymbols.cs
@@ -14,7 +14,8 @@ public record ReferenceSymbols(
 	INamedTypeSymbol KeyAttribute,
 	INamedTypeSymbol IKnownSubTypeAttribute,
 	INamedTypeSymbol GenerateShapeAttribute,
-	INamedTypeSymbol PropertyShapeAttribute)
+	INamedTypeSymbol PropertyShapeAttribute,
+	INamedTypeSymbol ConstructorShapeAttribute)
 {
 	public INamedTypeSymbol MessagePackConverterUnbound { get; } = MessagePackConverter.ConstructUnboundGenericType();
 
@@ -97,6 +98,13 @@ public record ReferenceSymbols(
 			return false;
 		}
 
+		INamedTypeSymbol? constructorShapeAttribute = polytypeAssembly.GetTypeByMetadataName("PolyType.ConstructorShapeAttribute");
+		if (constructorShapeAttribute is null)
+		{
+			referenceSymbols = null;
+			return false;
+		}
+
 		referenceSymbols = new ReferenceSymbols(
 			messagePackSerializer,
 			messagePackConverter,
@@ -106,7 +114,8 @@ public record ReferenceSymbols(
 			keyAttribute,
 			iknownSubTypeAttribute,
 			generateShapeAttribute,
-			propertyShapeAttribute);
+			propertyShapeAttribute,
+			constructorShapeAttribute);
 		return true;
 	}
 }

--- a/src/Nerdbank.MessagePack.Analyzers/Strings.resx
+++ b/src/Nerdbank.MessagePack.Analyzers/Strings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NBMsgPack001_MessageFormat" xml:space="preserve">
-    <value>Use [Key] on all serialized members or none of them. Application must be consistent across base and derived types as well.</value>
+    <value>Use [Key] on all serialized members or none of them. Application must be consistent across base and derived types as well. The member {0} is not consistent with others.</value>
   </data>
   <data name="NBMsgPack001_Title" xml:space="preserve">
     <value>Apply [Key] consistently across members</value>

--- a/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
+++ b/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
@@ -65,10 +65,9 @@ internal record struct MapSerializableProperties<TDeclaringType>(ReadOnlyMemory<
 /// <param name="RawPropertyNameString">The entire msgpack encoding of the property name, including the string header.</param>
 /// <param name="Write">A delegate that synchronously serializes the value of the property.</param>
 /// <param name="WriteAsync">A delegate that asynchonously serializes the value of the property.</param>
-/// <param name="SuppressIfNoConstructorParameter">A value indicating whether this property should <em>not</em> be serialized if no matching constructor parameter is discovered such that the value could be deserialized.</param>
 /// <param name="PreferAsyncSerialization"><inheritdoc cref="MessagePackConverter{T}.PreferAsyncSerialization"/></param>
 /// <param name="ShouldSerialize"><inheritdoc cref="PropertyAccessors{TDeclaringType}.ShouldSerialize"/></param>
-internal record struct SerializableProperty<TDeclaringType>(string Name, ReadOnlyMemory<byte> RawPropertyNameString, SerializeProperty<TDeclaringType> Write, SerializePropertyAsync<TDeclaringType> WriteAsync, bool SuppressIfNoConstructorParameter, bool PreferAsyncSerialization, Func<TDeclaringType, bool>? ShouldSerialize);
+internal record struct SerializableProperty<TDeclaringType>(string Name, ReadOnlyMemory<byte> RawPropertyNameString, SerializeProperty<TDeclaringType> Write, SerializePropertyAsync<TDeclaringType> WriteAsync, bool PreferAsyncSerialization, Func<TDeclaringType, bool>? ShouldSerialize);
 
 /// <summary>
 /// A map of deserializable properties.
@@ -94,13 +93,11 @@ internal record struct DeserializableProperty<TDeclaringType>(string Name, ReadO
 /// <typeparam name="TDeclaringType">The data type that declares the property that these accessors can serialize and deserialize values for.</typeparam>
 /// <param name="MsgPackWriters">Delegates that can serialize the value of a property.</param>
 /// <param name="MsgPackReaders">Delegates that can initialize the property with a value deserialized from msgpack.</param>
-/// <param name="SuppressIfNoConstructorParameter">A value indicating whether this property should <em>not</em> be serialized if no matching constructor parameter is discovered such that the value could be deserialized.</param>
 /// <param name="PreferAsyncSerialization"><inheritdoc cref="MessagePackConverter{T}.PreferAsyncSerialization"/></param>
 /// <param name="ShouldSerialize">An optional func that determines whether a property should be serialized. When <see langword="null"/> the property should always be serialized.</param>
 internal record struct PropertyAccessors<TDeclaringType>(
 	(SerializeProperty<TDeclaringType> Serialize, SerializePropertyAsync<TDeclaringType> SerializeAsync)? MsgPackWriters,
 	(DeserializeProperty<TDeclaringType> Deserialize, DeserializePropertyAsync<TDeclaringType> DeserializeAsync)? MsgPackReaders,
-	bool SuppressIfNoConstructorParameter,
 	bool PreferAsyncSerialization,
 	Func<TDeclaringType, bool>? ShouldSerialize);
 

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -341,7 +341,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 						return new ObjectArrayConverter<TDeclaringType>(inputs.GetJustAccessors(), constructorShape.GetDefaultConstructor(), !this.owner.SerializeDefaultValues);
 					}
 
-					Dictionary<string, int> propertyIndexesByName = new(StringComparer.Ordinal);
+					Dictionary<string, int> propertyIndexesByName = new(StringComparer.OrdinalIgnoreCase);
 					for (int i = 0; i < inputs.Properties.Count; i++)
 					{
 						if (inputs.Properties[i] is { } property)

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/KeyAttributeUseAnalyzerTests.cs
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/KeyAttributeUseAnalyzerTests.cs
@@ -160,4 +160,46 @@ public class KeyAttributeUseAnalyzerTests
 
 		await VerifyCS.VerifyAnalyzerAsync(source);
 	}
+
+	[Fact]
+	public async Task KeyNotOnPropertyWithOnlyGetter()
+	{
+		string source = /* lang=c#-test */ """
+			using PolyType;
+			using Nerdbank.MessagePack;
+			
+			[GenerateShape]
+			public partial record ClassWithUnserializedPropertyGetters
+			{
+				public string PropertyChanged => throw new System.NotImplementedException();
+
+				[Key(0)]
+				public bool Value { get; set; }
+			}
+			""";
+
+		await VerifyCS.VerifyAnalyzerAsync(source);
+	}
+
+	[Fact]
+	public async Task KeyNotOnPropertyWithOnlyGetterButAlsoHasCtorParam()
+	{
+		string source = /* lang=c#-test */ """
+			using PolyType;
+			using Nerdbank.MessagePack;
+			
+			[GenerateShape]
+			public partial record ClassWithUnserializedPropertyGetters
+			{
+				public ClassWithUnserializedPropertyGetters(string propertyChanged) => this.PropertyChanged = propertyChanged;
+
+				public string PropertyChanged { get; }
+
+				[Key(0)]
+				public bool {|NBMsgPack001:Value|} { get; set; }
+			}
+			""";
+
+		await VerifyCS.VerifyAnalyzerAsync(source);
+	}
 }

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -19,53 +19,53 @@ public class MigrationAnalyzerTests
 			public class MyType
 			{
 				public string? Name { get; set; }
-			}
 
-			public class {|NBMsgPack100:MyTypeFormatter|} : IMessagePackFormatter<MyType?>
-			{
-				public MyType? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+				private class {|NBMsgPack100:MyTypeFormatter|} : IMessagePackFormatter<MyType?>
 				{
-					if (reader.TryReadNil())
+					public MyType? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
 					{
-						return null;
-					}
-
-					string? name = null;
-					options.Security.DepthStep(ref reader);
-					try
-					{
-						int count = reader.ReadArrayHeader();
-						for (int i = 0; i < count; i++)
+						if (reader.TryReadNil())
 						{
-							switch (i)
-							{
-								case 0:
-									name = options.Resolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
-									break;
-								default:
-									reader.Skip();
-									break;
-								}
+							return null;
 						}
 
-						return new MyType { Name = name };
-					}
-					finally
-					{
-						reader.Depth--;
-					}
-				}
+						string? name = null;
+						options.Security.DepthStep(ref reader);
+						try
+						{
+							int count = reader.ReadArrayHeader();
+							for (int i = 0; i < count; i++)
+							{
+								switch (i)
+								{
+									case 0:
+										name = options.Resolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+										break;
+									default:
+										reader.Skip();
+										break;
+									}
+							}
 
-				public void Serialize(ref MessagePackWriter writer, MyType? value, MessagePackSerializerOptions options)
-				{
-					if (value is null)
-					{
-						writer.WriteNil();
-						return;
+							return new MyType { Name = name };
+						}
+						finally
+						{
+							reader.Depth--;
+						}
 					}
 
-					writer.WriteArrayHeader(1);
-					options.Resolver.GetFormatterWithVerify<string?>().Serialize(ref writer, value.Name, options);
+					public void Serialize(ref MessagePackWriter writer, MyType? value, MessagePackSerializerOptions options)
+					{
+						if (value is null)
+						{
+							writer.WriteNil();
+							return;
+						}
+
+						writer.WriteArrayHeader(1);
+						options.Resolver.GetFormatterWithVerify<string?>().Serialize(ref writer, value.Name, options);
+					}
 				}
 			}
 			""";
@@ -82,47 +82,47 @@ public class MigrationAnalyzerTests
 			public class MyType
 			{
 				public string? Name { get; set; }
-			}
 
-			[GenerateShape<string>]
-			public partial class MyTypeFormatter : MessagePackConverter<MyType>
-			{
-				public override MyType? Read(ref Nerdbank.MessagePack.MessagePackReader reader, SerializationContext context)
+				[GenerateShape<string>]
+				private partial class MyTypeFormatter : MessagePackConverter<MyType>
 				{
-					if (reader.TryReadNil())
+					public override MyType? Read(ref Nerdbank.MessagePack.MessagePackReader reader, SerializationContext context)
 					{
-						return null;
-					}
-
-					string? name = null;
-					context.DepthStep();
-					int count = reader.ReadArrayHeader();
-					for (int i = 0; i < count; i++)
-					{
-						switch (i)
+						if (reader.TryReadNil())
 						{
-							case 0:
-								name = context.GetConverter<string, MyTypeFormatter>().Read(ref reader, context);
-								break;
-							default:
-								reader.Skip(context);
-								break;
+							return null;
 						}
+
+						string? name = null;
+						context.DepthStep();
+						int count = reader.ReadArrayHeader();
+						for (int i = 0; i < count; i++)
+						{
+							switch (i)
+							{
+								case 0:
+									name = context.GetConverter<string, MyTypeFormatter>().Read(ref reader, context);
+									break;
+								default:
+									reader.Skip(context);
+									break;
+							}
+						}
+
+						return new MyType { Name = name };
 					}
 
-					return new MyType { Name = name };
-				}
-
-				public override void Write(ref Nerdbank.MessagePack.MessagePackWriter writer, in MyType? value, SerializationContext context)
-				{
-					if (value is null)
+					public override void Write(ref Nerdbank.MessagePack.MessagePackWriter writer, in MyType? value, SerializationContext context)
 					{
-						writer.WriteNil();
-						return;
-					}
+						if (value is null)
+						{
+							writer.WriteNil();
+							return;
+						}
 
-					writer.WriteArrayHeader(1);
-					context.GetConverter<string, MyTypeFormatter>().Write(ref writer, value.Name, context);
+						writer.WriteArrayHeader(1);
+						context.GetConverter<string, MyTypeFormatter>().Write(ref writer, value.Name, context);
+					}
 				}
 			}
 			""";

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/MigrationAnalyzerTests.cs
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/MigrationAnalyzerTests.cs
@@ -137,9 +137,13 @@ public class MigrationAnalyzerTests
 			using MessagePack;
 			using MessagePack.Formatters;
 
+			/// <summary>
+			/// Doc comment
+			/// </summary>
 			[{|NBMsgPack102:MessagePackObject|}]
 			public class MyType
 			{
+				/// <summary>doc comment</summary>
 				[{|NBMsgPack103:Key(0)|}]
 				public string Name { get; set; }
 			}
@@ -149,8 +153,12 @@ public class MigrationAnalyzerTests
 			using MessagePack;
 			using MessagePack.Formatters;
 
+			/// <summary>
+			/// Doc comment
+			/// </summary>
 			public class MyType
 			{
+				/// <summary>doc comment</summary>
 				[Nerdbank.MessagePack.Key(0)]
 				public string Name { get; set; }
 			}
@@ -242,6 +250,9 @@ public class MigrationAnalyzerTests
 			using MessagePack;
 			using MessagePack.Formatters;
 
+			/// <summary>
+			/// Doc comment
+			/// </summary>
 			[{|NBMsgPack102:MessagePackObject(true)|}]
 			public class MyType
 			{
@@ -262,6 +273,9 @@ public class MigrationAnalyzerTests
 			using MessagePack.Formatters;
 			using PolyType;
 
+			/// <summary>
+			/// Doc comment
+			/// </summary>
 			[GenerateShape]
 			public partial class MyType
 			{

--- a/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
@@ -332,13 +332,20 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 	}
 
 	[Fact]
-	public void PropertyGetterWithCtorParam()
+	public void PropertyGetterWithCtorParamAndMissingKey()
 	{
-		ClassWithPropertyGettersWithCtorParam obj = new("hi") { Value = true };
+		ClassWithPropertyGettersWithCtorParamAndMissingKey obj = new("hi") { Value = true };
 
 		// We expect this to throw because a qualified property is not attributed with KeyAttribute.
 		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Serialize(obj));
 		this.Logger.WriteLine(ex.Message);
+	}
+
+	[Fact]
+	public void PropertyGetterWithCtorParam()
+	{
+		ClassWithPropertyGettersWithCtorParam obj = new(true);
+		this.AssertRoundtrip(obj);
 	}
 
 	private static ITypeShape<T> GetShape<T>()
@@ -420,9 +427,9 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 	}
 
 	[GenerateShape]
-	public partial record ClassWithPropertyGettersWithCtorParam
+	public partial record ClassWithPropertyGettersWithCtorParamAndMissingKey
 	{
-		public ClassWithPropertyGettersWithCtorParam(string propertyChanged) => this.PropertyChanged = propertyChanged;
+		public ClassWithPropertyGettersWithCtorParamAndMissingKey(string propertyChanged) => this.PropertyChanged = propertyChanged;
 
 		public string PropertyChanged { get; }
 
@@ -430,5 +437,14 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 #pragma warning disable NBMsgPack001 // We WANT this to verify runtime failure.
 		public bool Value { get; set; }
 #pragma warning restore NBMsgPack001
+	}
+
+	[GenerateShape]
+	public partial record ClassWithPropertyGettersWithCtorParam
+	{
+		public ClassWithPropertyGettersWithCtorParam(bool value) => this.Value = value;
+
+		[Key(0)]
+		public bool Value { get; set; }
 	}
 }

--- a/test/Nerdbank.MessagePack.Tests/ObjectsAsMapTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ObjectsAsMapTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 public partial class ObjectsAsMapTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
 {
 	[Fact]
@@ -24,6 +26,15 @@ public partial class ObjectsAsMapTests(ITestOutputHelper logger) : MessagePackSe
 	[Fact]
 	public void PropertyAndConstructorNameCaseMismatch() => this.AssertRoundtrip(new ClassWithConstructorParameterNameMatchTest("Andrew"));
 
+	[Fact]
+	public void PropertyGettersIgnored()
+	{
+		ClassWithUnserializedPropertyGetters obj = new() { Value = true };
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip(obj);
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(1, reader.ReadMapHeader());
+	}
+
 	[GenerateShape]
 	public partial record Person
 	{
@@ -42,5 +53,13 @@ public partial class ObjectsAsMapTests(ITestOutputHelper logger) : MessagePackSe
 		public string Name { get; set; }
 
 		public bool Equals(ClassWithConstructorParameterNameMatchTest? other) => other is not null && this.Name == other.Name;
+	}
+
+	[GenerateShape]
+	public partial record ClassWithUnserializedPropertyGetters
+	{
+		public IObservable<PropertyChangedEventArgs> PropertyChanged => throw new NotImplementedException();
+
+		public bool Value { get; set; }
 	}
 }


### PR DESCRIPTION
Also fix several issues found during migration.

- [Improve NBMsgPack001 when there is no syntax for the member](https://github.com/AArnott/Nerdbank.MessagePack/commit/cb91ec144193a8613cdb8b550ec57c4c99d9d29c)
- [Fix ignoring of getter-only properties in [Key] mode](https://github.com/AArnott/Nerdbank.MessagePack/commit/cd07d409061f84f1bccdcc4ecf532f30625af0f7)
- [Fix trivia preservation around changed/removed attributes](https://github.com/AArnott/Nerdbank.MessagePack/commit/320087a890797ab8caae902cd036923bf1e13f90)
- [Fix migration of nested converters](https://github.com/AArnott/Nerdbank.MessagePack/commit/5f7f6254c69de3fd0078f64f8b38bdf5a33b69dc)