### PR TITLE
Add option to serialize enums by name

### DIFF
--- a/src/Nerdbank.MessagePack/Converters/EnumAsOrdinalConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/EnumAsOrdinalConverter`2.cs
@@ -9,13 +9,14 @@ namespace Nerdbank.MessagePack.Converters;
 /// <typeparam name="TEnum">The enum type.</typeparam>
 /// <typeparam name="TUnderlyingType">The underlying integer type.</typeparam>
 internal class EnumAsOrdinalConverter<TEnum, TUnderlyingType>(MessagePackConverter<TUnderlyingType> primitiveConverter) : MessagePackConverter<TEnum>
+	where TEnum : struct, Enum
 {
 	/// <inheritdoc/>
-	public override TEnum? Read(ref MessagePackReader reader, SerializationContext context) => (TEnum?)(object?)primitiveConverter.Read(ref reader, context);
+	public override TEnum Read(ref MessagePackReader reader, SerializationContext context) => (TEnum)(object)primitiveConverter.Read(ref reader, context)!;
 
 	/// <inheritdoc/>
-	public override void Write(ref MessagePackWriter writer, in TEnum? value, SerializationContext context)
+	public override void Write(ref MessagePackWriter writer, in TEnum value, SerializationContext context)
 	{
-		primitiveConverter.Write(ref writer, (TUnderlyingType?)(object?)value, context);
+		primitiveConverter.Write(ref writer, (TUnderlyingType)(object)value, context);
 	}
 }

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -50,6 +50,21 @@ public partial record MessagePackSerializer
 	public MessagePackNamingPolicy? PropertyNamingPolicy { get; init; }
 
 	/// <summary>
+	/// Gets a value indicating whether enum values will be serialized by name rather than by their numeric value.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Serializing by name is a best effort.
+	/// Most enums do not define a name for every possible value, and flags enums may have complicated string representations when multiple named enum elements are combined to form a value.
+	/// When a simple string cannot be constructed for a given value, the numeric form is used.
+	/// </para>
+	/// <para>
+	/// When deserializing enums by name, name matching is case <em>insensitive</em> unless the enum type defines multiple values with names that are only distinguished by case.
+	/// </para>
+	/// </remarks>
+	public bool SerializeEnumValuesByName { get; init; }
+
+	/// <summary>
 	/// Gets a value indicating whether to serialize properties that are set to their default values.
 	/// </summary>
 	/// <value>The default value is <see langword="false" />.</value>

--- a/src/Nerdbank.MessagePack/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/PublicAPI.Unshipped.txt
@@ -222,6 +222,8 @@ Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Stream! s
 Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Stream! stream, T? value, PolyType.Abstractions.ITypeShape<T>! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues.get -> bool
 Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.SerializeEnumValuesByName.get -> bool
+Nerdbank.MessagePack.MessagePackSerializer.SerializeEnumValuesByName.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.StartingContext.get -> Nerdbank.MessagePack.SerializationContext
 Nerdbank.MessagePack.MessagePackSerializer.StartingContext.init -> void
 Nerdbank.MessagePack.MessagePackType

--- a/src/Nerdbank.MessagePack/StringEncoding.cs
+++ b/src/Nerdbank.MessagePack/StringEncoding.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text;
+using Microsoft;
 
 namespace Nerdbank.MessagePack;
 
@@ -14,4 +15,23 @@ internal static class StringEncoding
 	/// UTF-8 encoding without a byte order mark.
 	/// </summary>
 	internal static readonly Encoding UTF8 = new UTF8Encoding(false);
+
+	/// <summary>
+	/// Gets the messagepack encoding for a given string.
+	/// </summary>
+	/// <param name="value">The string to encode.</param>
+	/// <param name="utf8Bytes">The UTF-8 encoded string.</param>
+	/// <param name="msgpackEncoded">The msgpack-encoded string.</param>
+	/// <remarks>
+	/// Because msgpack encodes with UTF-8 bytes, the two output parameter share most of the memory.
+	/// </remarks>
+	internal static void GetEncodedStringBytes(string value, out ReadOnlyMemory<byte> utf8Bytes, out ReadOnlyMemory<byte> msgpackEncoded)
+	{
+		int byteCount = StringEncoding.UTF8.GetByteCount(value);
+		Memory<byte> bytes = new byte[byteCount + 5];
+		Assumes.True(MessagePackPrimitives.TryWriteStringHeader(bytes.Span, (uint)byteCount, out int msgpackHeaderLength));
+		StringEncoding.UTF8.GetBytes(value, bytes.Span[msgpackHeaderLength..]);
+		utf8Bytes = bytes.Slice(msgpackHeaderLength, byteCount);
+		msgpackEncoded = bytes.Slice(0, byteCount + msgpackHeaderLength);
+	}
 }

--- a/test/Nerdbank.MessagePack.Tests/EnumTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/EnumTests.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public abstract partial class EnumTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	public enum Simple
+	{
+		One,
+		Two,
+		Three,
+	}
+
+	public enum CaseInsensitiveCollisions
+	{
+		One,
+		OnE,
+	}
+
+	[Flags]
+	public enum FlagsEnum
+	{
+		None = 0,
+		One = 1,
+		Two = 2,
+		Four = 4,
+	}
+
+	public enum EnumWithNonUniqueNames
+	{
+		One = 1,
+		AnotherOne = 1,
+		Two = 2,
+	}
+
+	public MessagePackType ExpectedType { get; set; }
+
+	[Fact]
+	public void SimpleEnum()
+	{
+		this.AssertEnum<Simple, Witness>(Simple.Two);
+	}
+
+	[Fact]
+	public void Enum_WithCaseInsensitiveCollisions()
+	{
+		this.AssertEnum<CaseInsensitiveCollisions, Witness>(CaseInsensitiveCollisions.OnE);
+		this.AssertEnum<CaseInsensitiveCollisions, Witness>(CaseInsensitiveCollisions.One);
+	}
+
+	[Fact]
+	public void NonExistentValue_NonFlags()
+	{
+		this.ExpectedType = MessagePackType.Integer;
+		this.AssertEnum<Simple, Witness>((Simple)15);
+	}
+
+	[Fact]
+	public void NonExistentValue_Flags()
+	{
+		this.ExpectedType = MessagePackType.Integer;
+		this.AssertEnum<FlagsEnum, Witness>((FlagsEnum)15);
+	}
+
+	[Fact]
+	public void OneValueFromFlags()
+	{
+		this.AssertEnum<FlagsEnum, Witness>(FlagsEnum.One);
+	}
+
+	[Fact]
+	public void MultipleFlags()
+	{
+		this.ExpectedType = MessagePackType.Integer;
+		this.AssertEnum<FlagsEnum, Witness>(FlagsEnum.One | FlagsEnum.Two);
+	}
+
+	[Fact]
+	public void NonUniqueNamesInEnum_Roundtrip()
+	{
+		this.AssertEnum<EnumWithNonUniqueNames, Witness>(EnumWithNonUniqueNames.AnotherOne);
+		this.AssertEnum<EnumWithNonUniqueNames, Witness>(EnumWithNonUniqueNames.One);
+	}
+
+	private static ReadOnlySequence<byte> SerializeEnumName(string name)
+	{
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.Write(name);
+		writer.Flush();
+		return seq;
+	}
+
+	private void AssertEnum<T, TWitness>(T value)
+		where T : struct, Enum
+		where TWitness : IShapeable<T>
+	{
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip<T, TWitness>(value);
+		this.AssertType(msgpack, this.ExpectedType);
+		this.Logger.WriteLine(value.ToString());
+	}
+
+	private void AssertType(ReadOnlySequence<byte> msgpack, MessagePackType expectedType)
+	{
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(expectedType, reader.NextMessagePackType);
+	}
+
+	public class EnumAsStringTests : EnumTests
+	{
+		public EnumAsStringTests(ITestOutputHelper logger)
+			: base(logger)
+		{
+			this.Serializer = this.Serializer with { SerializeEnumValuesByName = true };
+			this.ExpectedType = MessagePackType.String;
+		}
+
+		[Fact]
+		public void CaseInsensitiveByDefault()
+		{
+			Assert.Equal(Simple.One, this.Serializer.Deserialize<Simple, Witness>(SerializeEnumName("ONE")));
+		}
+
+		[Fact]
+		public void UnrecognizedName()
+		{
+			MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Deserialize<Simple, Witness>(SerializeEnumName("FOO")));
+			this.Logger.WriteLine(ex.Message);
+		}
+
+		[Fact]
+		public void NonUniqueNamesInEnum_ParseEitherName()
+		{
+			Assert.Equal(EnumWithNonUniqueNames.One, this.Serializer.Deserialize<EnumWithNonUniqueNames, Witness>(SerializeEnumName(nameof(EnumWithNonUniqueNames.One))));
+			Assert.Equal(EnumWithNonUniqueNames.AnotherOne, this.Serializer.Deserialize<EnumWithNonUniqueNames, Witness>(SerializeEnumName(nameof(EnumWithNonUniqueNames.AnotherOne))));
+		}
+	}
+
+	public class EnumAsOrdinalTests : EnumTests
+	{
+		public EnumAsOrdinalTests(ITestOutputHelper logger)
+			: base(logger)
+		{
+			this.Serializer = this.Serializer with { SerializeEnumValuesByName = false };
+			this.ExpectedType = MessagePackType.Integer;
+		}
+	}
+
+	[GenerateShape<Simple>]
+	[GenerateShape<CaseInsensitiveCollisions>]
+	[GenerateShape<FlagsEnum>]
+	[GenerateShape<EnumWithNonUniqueNames>]
+	private partial class Witness;
+}


### PR DESCRIPTION
Prior to this, enums would only serialize as their underlying integer type.

Closes #132