### PR TITLE
Implement stateful, incremental skip

### DIFF
--- a/samples/CustomConverters.cs
+++ b/samples/CustomConverters.cs
@@ -364,7 +364,7 @@ namespace AsyncConverters
 
             for (int i = 0; i < count; i++)
             {
-                while (streamingReader.TrySkip(context).NeedsMoreBytes())
+                while (streamingReader.TrySkip(ref context).NeedsMoreBytes())
                 {
                     streamingReader = new(await streamingReader.FetchMoreBytesAsync());
                 }

--- a/src/Nerdbank.MessagePack/Converters/ObjectMapConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapConverter`1.cs
@@ -270,7 +270,7 @@ internal class ObjectMapConverter<T>(MapSerializableProperties<T> serializable, 
 		else
 		{
 			// We have nothing to read into, so just skip any data in the object.
-			while (streamingReader.TrySkip(context).NeedsMoreBytes())
+			while (streamingReader.TrySkip(ref context).NeedsMoreBytes())
 			{
 				streamingReader = new(await streamingReader.FetchMoreBytesAsync());
 			}

--- a/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
@@ -151,7 +151,7 @@ internal class ObjectMapWithNonDefaultCtorConverter<TDeclaringType, TArgumentSta
 		else
 		{
 			// We have nothing to read into, so just skip any data in the object.
-			while (streamingReader.TrySkip(context).NeedsMoreBytes())
+			while (streamingReader.TrySkip(ref context).NeedsMoreBytes())
 			{
 				streamingReader = new(await streamingReader.FetchMoreBytesAsync());
 			}

--- a/src/Nerdbank.MessagePack/MessagePackAsyncReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackAsyncReader.cs
@@ -65,7 +65,7 @@ public class MessagePackAsyncReader(PipeReader pipeReader)
 			skipCount = 0;
 			for (; skipCount < countUpTo; skipCount++)
 			{
-				if (reader.TrySkip(context) is MessagePackPrimitives.DecodeResult.InsufficientBuffer or MessagePackPrimitives.DecodeResult.EmptyBuffer)
+				if (reader.TrySkip(ref context) is MessagePackPrimitives.DecodeResult.InsufficientBuffer or MessagePackPrimitives.DecodeResult.EmptyBuffer)
 				{
 					if (skipCount >= minimumDesiredBufferedStructures)
 					{

--- a/src/Nerdbank.MessagePack/MessagePackReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackReader.cs
@@ -679,7 +679,7 @@ public ref partial struct MessagePackReader
 	/// </remarks>
 	internal bool TrySkip(SerializationContext context)
 	{
-		switch (this.streamingReader.TrySkip(context))
+		switch (this.streamingReader.TrySkip(ref context))
 		{
 			case MessagePackPrimitives.DecodeResult.Success:
 				return true;

--- a/src/Nerdbank.MessagePack/MessagePackReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackReader.cs
@@ -676,7 +676,6 @@ public ref partial struct MessagePackReader
 	/// <remarks>
 	/// The entire structure is skipped, including content of maps or arrays, or any other type with payloads.
 	/// To get the raw MessagePack sequence that was skipped, use <see cref="ReadRaw(SerializationContext)"/> instead.
-	/// WARNING: when false is returned, the position of the reader is undefined.
 	/// </remarks>
 	internal bool TrySkip(SerializationContext context)
 	{

--- a/src/Nerdbank.MessagePack/SerializationContext.cs
+++ b/src/Nerdbank.MessagePack/SerializationContext.cs
@@ -66,6 +66,12 @@ public record struct SerializationContext
 	internal ReferenceEqualityTracker? ReferenceEqualityTracker { get; private init; }
 
 	/// <summary>
+	/// Gets or sets the number of elements that must still be skipped to complete a skip operation.
+	/// </summary>
+	/// <value>0 when no skip operation was suspended and is still incomplete.</value>
+	internal int MidSkipRemainingCount { get; set; }
+
+	/// <summary>
 	/// Decrements the depth remaining and checks the cancellation token.
 	/// </summary>
 	/// <remarks>

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -285,7 +285,7 @@ Nerdbank.MessagePack.MessagePackStreamingReader.TryReadNil(out bool isNil) -> Ne
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadRaw(long length, out System.Buffers.ReadOnlySequence<byte> rawMsgPack) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadStringSequence(out System.Buffers.ReadOnlySequence<byte> value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadStringSpan(out bool contiguous, out System.ReadOnlySpan<byte> value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
-Nerdbank.MessagePack.MessagePackStreamingReader.TrySkip(Nerdbank.MessagePack.SerializationContext context) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
+Nerdbank.MessagePack.MessagePackStreamingReader.TrySkip(ref Nerdbank.MessagePack.SerializationContext context) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackType
 Nerdbank.MessagePack.MessagePackType.Array = 7 -> Nerdbank.MessagePack.MessagePackType
 Nerdbank.MessagePack.MessagePackType.Binary = 6 -> Nerdbank.MessagePack.MessagePackType

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -257,7 +257,7 @@ Nerdbank.MessagePack.MessagePackStreamingReader.TryReadNil(out bool isNil) -> Ne
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadRaw(long length, out System.Buffers.ReadOnlySequence<byte> rawMsgPack) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadStringSequence(out System.Buffers.ReadOnlySequence<byte> value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadStringSpan(out bool contiguous, out System.ReadOnlySpan<byte> value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
-Nerdbank.MessagePack.MessagePackStreamingReader.TrySkip(Nerdbank.MessagePack.SerializationContext context) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
+Nerdbank.MessagePack.MessagePackStreamingReader.TrySkip(ref Nerdbank.MessagePack.SerializationContext context) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackType
 Nerdbank.MessagePack.MessagePackType.Array = 7 -> Nerdbank.MessagePack.MessagePackType
 Nerdbank.MessagePack.MessagePackType.Binary = 6 -> Nerdbank.MessagePack.MessagePackType


### PR DESCRIPTION
This is a perf optimization for streaming scenarios where a converter needs to skip a structure but the buffer may not have the entire structure in memory. This optimization records how much of the structure has been skipped already so that the reader can advance, freeing memory, and resume skipping when we get more bytes to decode.

In particular, this avoids the previous behavior that skipping had to be restarted from the beginning of the structure each time new bytes are brought in until the whole structure was in memory together.

While this is theoretically a memory use improvement (for skipping scenarios only), this is mostly about avoiding CPU work to parse partial structures repeatedly until we get the whole thing in memory. With this change, at most one msgpack *token* (rather than whole structure) will be decoded more than once, and that limited to only once per fetch of new bytes.

Closes https://github.com/AArnott/Nerdbank.MessagePack/issues/154