### PR TITLE
Add `MessagePackSerializer.MaxAsyncBuffer` to speed up small async deserializations

### DIFF
--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -211,6 +211,8 @@ Nerdbank.MessagePack.MessagePackSerializer.InternStrings.get -> bool
 Nerdbank.MessagePack.MessagePackSerializer.InternStrings.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.LibraryExtensionTypeCodes.get -> Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode!
 Nerdbank.MessagePack.MessagePackSerializer.LibraryExtensionTypeCodes.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.MaxAsyncBuffer.get -> int
+Nerdbank.MessagePack.MessagePackSerializer.MaxAsyncBuffer.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.MultiDimensionalArrayFormat.get -> Nerdbank.MessagePack.MultiDimensionalArrayFormat
 Nerdbank.MessagePack.MessagePackSerializer.MultiDimensionalArrayFormat.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.PreserveReferences.get -> bool

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -195,6 +195,8 @@ Nerdbank.MessagePack.MessagePackSerializer.InternStrings.get -> bool
 Nerdbank.MessagePack.MessagePackSerializer.InternStrings.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.LibraryExtensionTypeCodes.get -> Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode!
 Nerdbank.MessagePack.MessagePackSerializer.LibraryExtensionTypeCodes.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.MaxAsyncBuffer.get -> int
+Nerdbank.MessagePack.MessagePackSerializer.MaxAsyncBuffer.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.PreserveReferences.get -> bool
 Nerdbank.MessagePack.MessagePackSerializer.PreserveReferences.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.PropertyNamingPolicy.get -> Nerdbank.MessagePack.MessagePackNamingPolicy?

--- a/test/Nerdbank.MessagePack.Tests/FragmentedPipeReader.cs
+++ b/test/Nerdbank.MessagePack.Tests/FragmentedPipeReader.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft;
+
+/// <summary>
+/// A <see cref="PipeReader"/> that is pre-buffered yet will only part with its data in chunks.
+/// </summary>
+internal class FragmentedPipeReader : PipeReader
+{
+	private readonly ReadOnlySequence<byte> buffer;
+	private readonly int chunkSize;
+	private SequencePosition consumed;
+	private SequencePosition examined;
+	private bool expectAdvance;
+
+	public FragmentedPipeReader(ReadOnlySequence<byte> buffer, int chunkSize = 1)
+	{
+		this.buffer = buffer;
+		this.chunkSize = chunkSize;
+		this.consumed = this.examined = buffer.Start;
+	}
+
+	public override void AdvanceTo(SequencePosition consumed) => this.AdvanceTo(consumed, consumed);
+
+	public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+	{
+		this.consumed = consumed;
+		this.examined = examined;
+		this.expectAdvance = false;
+	}
+
+	public override void CancelPendingRead() => throw new NotImplementedException();
+
+	public override void Complete(Exception? exception = null)
+	{
+	}
+
+	public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+	{
+		Verify.Operation(!this.expectAdvance, "Out of order operations. AdvanceTo call is missing.");
+		SequencePosition chunkEnd = this.buffer.GetPosition(this.chunkSize, this.examined);
+
+		ReadOnlySequence<byte> chunk = this.buffer.Slice(this.consumed, chunkEnd);
+		bool complete = chunk.End.Equals(this.buffer.End);
+		this.expectAdvance = true;
+		return new(new ReadResult(chunk, isCanceled: false, complete));
+	}
+
+	public override bool TryRead(out ReadResult result) => throw new NotImplementedException();
+}

--- a/test/Nerdbank.MessagePack.Tests/FragmentedPipeReader.cs
+++ b/test/Nerdbank.MessagePack.Tests/FragmentedPipeReader.cs
@@ -9,16 +9,29 @@ using Microsoft;
 internal class FragmentedPipeReader : PipeReader
 {
 	private readonly ReadOnlySequence<byte> buffer;
-	private readonly int chunkSize;
+
+	private readonly int? chunkSize;
+
+	private readonly SequencePosition[]? chunkPositions;
+
 	private SequencePosition consumed;
 	private SequencePosition examined;
 	private bool expectAdvance;
+	private SequencePosition? lastReadReturnedPosition;
 
 	public FragmentedPipeReader(ReadOnlySequence<byte> buffer, int chunkSize = 1)
 	{
 		this.buffer = buffer;
-		this.chunkSize = chunkSize;
 		this.consumed = this.examined = buffer.Start;
+		this.chunkSize = chunkSize;
+	}
+
+	public FragmentedPipeReader(ReadOnlySequence<byte> buffer, params SequencePosition[] chunkPositions)
+	{
+		Requires.Argument(chunkPositions.Length > 0, nameof(chunkPositions), "Must provide at least one chunk position.");
+		this.buffer = buffer;
+		this.consumed = this.examined = buffer.Start;
+		this.chunkPositions = chunkPositions;
 	}
 
 	public override void AdvanceTo(SequencePosition consumed) => this.AdvanceTo(consumed, consumed);
@@ -39,11 +52,33 @@ internal class FragmentedPipeReader : PipeReader
 	public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
 	{
 		Verify.Operation(!this.expectAdvance, "Out of order operations. AdvanceTo call is missing.");
-		SequencePosition chunkEnd = this.buffer.GetPosition(this.chunkSize, this.examined);
+		SequencePosition chunkEnd;
+		if (this.chunkSize.HasValue)
+		{
+			chunkEnd = this.buffer.GetPosition(this.chunkSize.Value, this.examined);
+		}
+		else
+		{
+			Assumes.NotNull(this.chunkPositions);
+			if (this.lastReadReturnedPosition.HasValue && this.examined.Equals(this.lastReadReturnedPosition.Value))
+			{
+				// The caller has examined everything we gave them. Give them more.
+				int lastChunkGivenIndex = Array.IndexOf(this.chunkPositions, this.examined);
+				Assumes.True(lastChunkGivenIndex >= 0);
+				chunkEnd = this.chunkPositions.Length > lastChunkGivenIndex + 1 ? this.chunkPositions[lastChunkGivenIndex + 1] : this.buffer.End;
+			}
+			else
+			{
+				// The caller hasn't finished processing the last chunk we gave them.
+				// Give them the same chunk again.
+				chunkEnd = this.lastReadReturnedPosition ?? this.chunkPositions[0];
+			}
+		}
 
 		ReadOnlySequence<byte> chunk = this.buffer.Slice(this.consumed, chunkEnd);
 		bool complete = chunk.End.Equals(this.buffer.End);
 		this.expectAdvance = true;
+		this.lastReadReturnedPosition = chunk.End;
 		return new(new ReadResult(chunk, isCanceled: false, complete));
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
@@ -259,15 +259,10 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 		sequence.Append(secondSegment);
 
 		// Deserialize, through a pipe that lets us control the buffer segments.
-		Pipe pipe = new();
+		FragmentedPipeReader pipeReader = new(sequence, sequence.AsReadOnlySequence.GetPosition(splitPosition));
 
-		ValueTask<FamilyWithAsyncProperties?> familyTask = this.Serializer.DeserializeAsync<FamilyWithAsyncProperties>(pipe.Reader);
+		FamilyWithAsyncProperties? family = await this.Serializer.DeserializeAsync<FamilyWithAsyncProperties>(pipeReader);
 
-		await pipe.Writer.WriteAsync(firstSegment);
-		await Task.Delay(AsyncDelay); // give the deserializer time to run.
-		await pipe.Writer.WriteAsync(secondSegment);
-
-		FamilyWithAsyncProperties? family = await familyTask;
 		Assert.Equal(expectedFamily, family);
 	}
 
@@ -310,15 +305,10 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 		sequence.Append(secondSegment);
 
 		// Deserialize, through a pipe that lets us control the buffer segments.
-		Pipe pipe = new();
+		FragmentedPipeReader pipeReader = new(sequence, sequence.AsReadOnlySequence.GetPosition(splitPosition));
 
-		ValueTask<FamilyWithAsyncPropertiesWithDefaultCtor?> familyTask = this.Serializer.DeserializeAsync<FamilyWithAsyncPropertiesWithDefaultCtor>(pipe.Reader);
+		FamilyWithAsyncPropertiesWithDefaultCtor? family = await this.Serializer.DeserializeAsync<FamilyWithAsyncPropertiesWithDefaultCtor>(pipeReader);
 
-		await pipe.Writer.WriteAsync(firstSegment);
-		await Task.Delay(AsyncDelay); // give the deserializer time to run.
-		await pipe.Writer.WriteAsync(secondSegment);
-
-		FamilyWithAsyncPropertiesWithDefaultCtor? family = await familyTask;
 		Assert.Equal(expectedFamily, family);
 	}
 


### PR DESCRIPTION
Since synchronous deserialization is substantially faster than async deserialization, we prefer sync. But sync requires that all msgpack data be pre-buffered. That's a reasonable trade-off, assuming the msgpack data is reasonably small. When it is large, the slower async path may be preferable to avoid unbounded memory consumption.

Closes #155

## Before

| Method            | Mean     | Error    | StdDev  | Ratio | RatioSD | Gen0    | Gen1   | Allocated | Alloc Ratio |
|------------------ |---------:|---------:|--------:|------:|--------:|--------:|-------:|----------:|------------:|
| Sync_Deserialize  | 111.4 us | 19.72 us | 1.08 us |  1.00 |    0.01 | 11.4746 | 1.9531 |  70.34 KB |        1.00 |
| Async_Deserialize | 327.0 us |  6.20 us | 0.34 us |  2.94 |    0.02 | 11.2305 | 1.9531 |  70.49 KB |        1.00 |

## After


Method | Categories | Mean | Error | StdDev | Ratio | Gen0 | Gen1 | Allocated | Alloc Ratio
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
Sync_Deserialize | map-init,Deserialize | 114.37 μs | 10.251 μs | 0.562 μs | 1.00 | 11.4746 | 1.9531 | 72024 B | 1.00
Async_Deserialize | map-init,Deserialize | 104.00 μs | 2.420 μs | 0.133 μs | 0.91 | 11.4746 | 1.9531 | 72080 B | 1.00

Not all benchmarks show 0 tax for async deserialization for small jobs. The above works because it's a reasonably _large_ array but still under the threshold for synchronous deserialization. But very tiny deserializations still pay a tax due to buffering overhead (even if it's already in memory) that sync deserialization APIs can avoid.