### PR TITLE
Add analyzer to flag missing `ref` modifier on ref struct typed parameters

### DIFF
--- a/docfx/analyzers/NBMsgPack050.md
+++ b/docfx/analyzers/NBMsgPack050.md
@@ -1,0 +1,22 @@
+# NBMsgPack050: Use ref parameters for ref structs
+
+It is critical for certain `ref struct` types defined in Nerdbank.MessagePack to be passed by `ref` when used as a parameter.
+Without this, a copy of the struct is made, and the buffers or position tracking fields that are modified by the callee will not apply back to the caller.
+
+These types fall into this category:
+
+- @Nerdbank.MessagePack.MessagePackReader
+- @Nerdbank.MessagePack.MessagePackStreamingReader
+- @Nerdbank.MessagePack.MessagePackWriter
+
+## Example violation
+
+The following method is declared with one of the above types as a parameter type, but without using the `ref` modifier:
+
+[!code-csharp[](../../samples/AnalyzerDocs/NBMsgPack050.cs#Defective)]
+
+## Resolution
+
+Add the `ref` modifier to the parameter (and all callers of the method):
+
+[!code-csharp[](../../samples/AnalyzerDocs/NBMsgPack050.cs#Fix)]

--- a/docfx/analyzers/index.md
+++ b/docfx/analyzers/index.md
@@ -23,6 +23,7 @@ Rule ID | Category | Severity | Notes
 [NBMsgPack035](NBMsgPack035.md) | Usage | Error | Async converters should return readers
 [NBMsgPack036](NBMsgPack036.md) | Usage | Error | Async converters should not reuse readers after returning them
 [NBMsgPack037](NBMsgPack037.md) | Usage | Warning | Async converters should override @Nerdbank.MessagePack.MessagePackConverter`1.PreferAsyncSerialization
+[NBMsgPack050](NBMsgPack050.md) | Usage | Warning | Use ref parameters for ref structs
 [NBMsgPack100](NBMsgPack100.md) | Migration | Info | Migrate MessagePack-CSharp formatter
 [NBMsgPack101](NBMsgPack101.md) | Migration | Info | Migrate to @Nerdbank.MessagePack.MessagePackConverterAttribute
 [NBMsgPack102](NBMsgPack102.md) | Migration | Info | Remove use of MessagePackObjectAttribute

--- a/docfx/analyzers/toc.yml
+++ b/docfx/analyzers/toc.yml
@@ -32,6 +32,8 @@
   href: NBMsgPack036.md
 - name: NBMsgPack037
   href: NBMsgPack037.md
+- name: NBMsgPack050
+  href: NBMsgPack050.md
 - name: NBMsgPack100
   href: NBMsgPack100.md
 - name: NBMsgPack101

--- a/samples/AnalyzerDocs/NBMsgPack050.cs
+++ b/samples/AnalyzerDocs/NBMsgPack050.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable NBMsgPackAsync
+
+namespace Samples.AnalyzerDocs.NBMsgPack050
+{
+    namespace Defective
+    {
+#pragma warning disable NBMsgPack050
+        internal class SomeClass
+        {
+            #region Defective
+            void SomeMethod(MessagePackReader reader)
+            {
+            }
+            #endregion
+        }
+#pragma warning restore NBMsgPack050
+    }
+
+    namespace Fixed
+    {
+        internal class SomeClass
+        {
+            #region Fix
+            void SomeMethod(ref MessagePackReader reader)
+            {
+            }
+            #endregion
+        }
+    }
+}

--- a/src/Nerdbank.MessagePack.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Nerdbank.MessagePack.Analyzers/AnalyzerReleases.Unshipped.md
@@ -22,6 +22,7 @@ NBMsgPack034 | Usage | Error | Async converters should not reuse MessagePackWrit
 NBMsgPack035 | Usage | Error | Async converters should return readers
 NBMsgPack036 | Usage | Error | Async converters should not reuse readers after returning them
 NBMsgPack037 | Usage | Warning | Async converters should override PreferAsyncSerialization
+NBMsgPack050 | Usage | Warning | Use ref parameters for ref structs
 NBMsgPack100 | Migration | Info | Migrate MessagePack-CSharp formatter
 NBMsgPack101 | Migration | Info | Migrate to MessagePackConverterAttribute
 NBMsgPack102 | Migration | Info | Remove use of MessagePackObjectAttribute

--- a/src/Nerdbank.MessagePack.Analyzers/RefParametersForRefStructsAnalyzer.cs
+++ b/src/Nerdbank.MessagePack.Analyzers/RefParametersForRefStructsAnalyzer.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Frozen;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Nerdbank.MessagePack.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RefParametersForRefStructsAnalyzer : DiagnosticAnalyzer
+{
+	public const string UseRefParametersForRefStructsDiagnosticId = "NBMsgPack050";
+
+	public static readonly DiagnosticDescriptor UseRefParametersForRefStructsDiagnostic = new(
+		id: UseRefParametersForRefStructsDiagnosticId,
+		title: Strings.NBMsgPack050_Title,
+		messageFormat: Strings.NBMsgPack050_MessageFormat,
+		category: "Usage",
+		defaultSeverity: DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		helpLinkUri: AnalyzerUtilities.GetHelpLink(UseRefParametersForRefStructsDiagnosticId));
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [
+		UseRefParametersForRefStructsDiagnostic,
+	];
+
+	public override void Initialize(AnalysisContext context)
+	{
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+		context.RegisterCompilationStartAction(
+			context =>
+			{
+				if (!ReferenceSymbols.TryCreate(context.Compilation, out ReferenceSymbols? referenceSymbols))
+				{
+					return;
+				}
+
+				FrozenSet<ISymbol> guardedRefStructs = new[]
+				{
+					referenceSymbols.MessagePackReader,
+					referenceSymbols.MessagePackStreamingReader,
+					referenceSymbols.MessagePackWriter,
+				}.ToFrozenSet<ISymbol>(SymbolEqualityComparer.Default);
+
+				context.RegisterSymbolAction(
+					context =>
+					{
+						IMethodSymbol method = (IMethodSymbol)context.Symbol;
+						foreach (IParameterSymbol parameter in method.Parameters)
+						{
+							if (parameter.RefKind == RefKind.None && guardedRefStructs.Contains(parameter.Type))
+							{
+								Location? location = ((ParameterSyntax?)parameter.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(context.CancellationToken))?.Type?.GetLocation()
+									?? parameter.Locations.FirstOrDefault();
+								if (location is not null)
+								{
+									context.ReportDiagnostic(Diagnostic.Create(UseRefParametersForRefStructsDiagnostic, location, parameter.Type.Name));
+								}
+							}
+						}
+					},
+					SymbolKind.Method);
+			});
+	}
+}

--- a/src/Nerdbank.MessagePack.Analyzers/ReferenceSymbols.cs
+++ b/src/Nerdbank.MessagePack.Analyzers/ReferenceSymbols.cs
@@ -10,6 +10,7 @@ public record ReferenceSymbols(
 	INamedTypeSymbol MessagePackConverter,
 	INamedTypeSymbol MessagePackConverterAttribute,
 	INamedTypeSymbol MessagePackReader,
+	INamedTypeSymbol MessagePackStreamingReader,
 	INamedTypeSymbol MessagePackWriter,
 	INamedTypeSymbol KeyAttribute,
 	INamedTypeSymbol KnownSubTypeAttribute,
@@ -60,6 +61,13 @@ public record ReferenceSymbols(
 
 		INamedTypeSymbol? messagePackReader = libraryAssembly.GetTypeByMetadataName("Nerdbank.MessagePack.MessagePackReader");
 		if (messagePackReader is null)
+		{
+			referenceSymbols = null;
+			return false;
+		}
+
+		INamedTypeSymbol? messagePackStreamingReader = libraryAssembly.GetTypeByMetadataName("Nerdbank.MessagePack.MessagePackStreamingReader");
+		if (messagePackStreamingReader is null)
 		{
 			referenceSymbols = null;
 			return false;
@@ -119,6 +127,7 @@ public record ReferenceSymbols(
 			messagePackConverter,
 			messagePackConverterAttribute,
 			messagePackReader,
+			messagePackStreamingReader,
 			messagePackWriter,
 			keyAttribute,
 			knownSubTypeAttribute,

--- a/src/Nerdbank.MessagePack.Analyzers/Strings.resx
+++ b/src/Nerdbank.MessagePack.Analyzers/Strings.resx
@@ -225,6 +225,12 @@
   <data name="NBMsgPack037_Title" xml:space="preserve">
     <value>Converters should override PreferAsyncSerialization</value>
   </data>
+  <data name="NBMsgPack050_MessageFormat" xml:space="preserve">
+    <value>The {0} type is stateful and should generally be passed by ref. Add the "ref" modifier to this parameter.</value>
+  </data>
+  <data name="NBMsgPack050_Title" xml:space="preserve">
+    <value>Use ref parameters for ref structs</value>
+  </data>
   <data name="NBMsgPack100_MessageFormat" xml:space="preserve">
     <value>This is a formatter for the MessagePack-CSharp library. You may want to migrate this to a converter for the newer Nerdbank.MessagePack library.</value>
   </data>

--- a/src/Nerdbank.MessagePack/Converters/ArrayWithNestedDimensionsConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayWithNestedDimensionsConverter`2.cs
@@ -149,7 +149,9 @@ internal class ArrayWithNestedDimensionsConverter<TArray, TElement>(MessagePackC
 	/// </summary>
 	/// <param name="reader">The reader. This is <em>not</em> a <see langword="ref" /> so as to not impact the caller's read position.</param>
 	/// <param name="dimensions">The dimensional array to initialize.</param>
+#pragma warning disable NBMsgPack050 // use "ref MessagePackReader" for parameter type
 	private void PeekDimensionsLength(MessagePackReader reader, int[] dimensions)
+#pragma warning restore NBMsgPack050 // use "ref MessagePackReader" for parameter type
 	{
 		for (int i = 0; i < dimensions.Length; i++)
 		{

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/RefParametersForRefStructsAnalyzerTests.cs
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/RefParametersForRefStructsAnalyzerTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = CodeFixVerifier<Nerdbank.MessagePack.Analyzers.RefParametersForRefStructsAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class RefParametersForRefStructsAnalyzerTests
+{
+	[Fact]
+	public async Task MethodWithRefParameters()
+	{
+		string testSource = /* lang=c#-test */ """
+			#pragma warning disable NBMsgPackAsync
+
+			using Nerdbank.MessagePack;
+
+			class Test
+			{
+				public void Method(ref MessagePackReader reader)
+				{
+				}
+
+				public void Method(ref MessagePackStreamingReader reader)
+				{
+				}
+
+				public void Method(ref MessagePackWriter writer)
+				{
+				}
+			}
+			""";
+
+		await VerifyCS.VerifyAnalyzerAsync(testSource);
+	}
+
+	[Fact]
+	public async Task MethodWithParameters_MissingRef()
+	{
+		string testSource = /* lang=c#-test */ """
+			#pragma warning disable NBMsgPackAsync
+
+			using Nerdbank.MessagePack;
+
+			class Test
+			{
+				public void Method({|NBMsgPack050:MessagePackReader|} reader)
+				{
+				}
+
+				public void Method({|NBMsgPack050:MessagePackStreamingReader|} reader)
+				{
+				}
+
+				public void Method({|NBMsgPack050:MessagePackWriter|} writer)
+				{
+				}
+			}
+			""";
+
+		await VerifyCS.VerifyAnalyzerAsync(testSource);
+	}
+}


### PR DESCRIPTION
Closes #88