### PR TITLE
Improve known sub-type support

### DIFF
--- a/docfx/docs/migrating.md
+++ b/docfx/docs/migrating.md
@@ -16,7 +16,7 @@ Feature                   | Nerdbank.MessagePack | MessagePack-CSharp  |
 Optimized for high performance | [✅](performance.md) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#performance) |
 Contractless data types   | [✅](getting-started.md)[^1] | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#object-serialization) |
 Attributed data types     | [✅](customizing-serialization.md) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#object-serialization) |
-Polymorphic serialization | [✅](unions.md) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#union) |
+Polymorphic serialization | [✅](unions.md) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#union)[^4] |
 Skip serializing default values | [✅](xref:Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues) | [❌](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/678) |
 Dynamically use maps or arrays for most compact format | [✅](customizing-serialization.md#array-or-map) | [❌](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/1953) |
 Typeless serialization    | ❌ | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#typeless) |
@@ -41,6 +41,7 @@ Security is a complex subject, and an area where Nerdbank.MessagePack is activel
 [^1]: Nerdbank.MessagePack's approach is more likely to be correct by default and more flexible to fixing when it is not.
 [^2]: Although MessagePack-CSharp does not support .NET 8 flavor NativeAOT, it has long-supported Unity's il2cpp runtime, but it requires careful avoidance of dynamic features.
 [^3]: This hasn't been tested, and even if it works, the level of active support may be limited as the maintainers of Nerdbank.MessagePack do not use Unity. We may accept outside contributions to support it if it isn't onerous to maintain.
+[^4]: MessagePack-CSharp is limited to derived types that can be attributed on the base type, whereas Nerdbank.MessagePack allows for dynamically identifying derived types at runtime.
 
 ## Migration process
 
@@ -114,8 +115,8 @@ Nerdbank.MessagePack supports this same use case via its @Nerdbank.MessagePack.K
 ```diff
 -[Union(0, typeof(MyType1))]
 -[Union(1, typeof(MyType2))]
-+[KnownSubType(0, typeof(MyType1))]
-+[KnownSubType(1, typeof(MyType2))]
++[KnownSubType(typeof(MyType1), 0)]
++[KnownSubType(typeof(MyType2), 1)]
  public interface IMyType
  {
  }

--- a/docfx/docs/unions.md
+++ b/docfx/docs/unions.md
@@ -83,8 +83,10 @@ To fix this, you would need to add @Nerdbank.MessagePack.KnownSubTypeAttribute`1
 
 ### Alias types
 
-An alias may also be a string.
+An alias may be an integer or a string.
 String aliases are case sensitive.
+
+Aliases may also be inferred from the @System.Type.FullName?displayProperty=nameWithType of the sub-type, in which case they are treated as strings.
 
 The following example shows using strings:
 
@@ -109,6 +111,21 @@ Mixing alias types for a given base type is allowed, as shown here:
 [!code-csharp[](../../samples/Unions.cs#MixedAliasTypesNETFX)]
 
 ---
+
+Following is an example of string alias inferrence:
+
+# [.NET](#tab/net)
+
+[!code-csharp[](../../samples/Unions.cs#InferredAliasTypesNET)]
+
+# [.NET Standard](#tab/netfx)
+
+[!code-csharp[](../../samples/Unions.cs#InferredAliasTypesNETFX)]
+
+---
+
+Note that while inferrence is the simplest syntax, it results in the serialized schema including the full name of the type, which can make the serialized form more fragile in the face of refactoring changes.
+It can also result in a poorer experience if the data is exchanged with non-.NET programs.
 
 ### Nested sub-types
 

--- a/docfx/docs/unions.md
+++ b/docfx/docs/unions.md
@@ -79,6 +79,15 @@ The `Animal` class only knows about `Horse` as a subtype and designates `2` as t
 As such, serializing your `Farm` would drop any details about horse breeds and deserializing would produce `Horse` objects, not `QuarterHorse` or `Thoroughbred`.
 To fix this, you would need to add @Nerdbank.MessagePack.KnownSubTypeAttribute`1 to the `Animal` class for `QuarterHorse` and `Thoroughbred` that assigns type aliases for each of them.
 
+### Nested sub-types
+
+Suppose you had the following type hierarchy:
+
+Animal <- Horse <- Quarterback
+
+The `Animal` class _must_ have the whole set of transitive derived types listed as known sub-types directly on itself.
+It will not do for `Animal` to merely mention `Horse` and for `Horse` to listed `Quarterback` as a sub-type, as this is not currently supported.
+
 ### Generic sub-types
 
 Sub-types may be generic types, but they must be *closed* generic types (i.e. all the generic type arguments must be specified).

--- a/docfx/docs/unions.md
+++ b/docfx/docs/unions.md
@@ -30,6 +30,7 @@ This changes the schema of the serialized data to include a tag that indicates t
 ```
 
 But with the `KnownSubTypeAttribute`, it serializes like this:
+
 ```json
 [null, { "Name": "Bessie" }]
 ```
@@ -69,6 +70,7 @@ Now suppose you have different breeds of horses that each had their own subtype:
 ---
 
 At this point your `HorsePen` *would* serialize with the union schema around each horse:
+
 ```json
 { "Horses": [[1, { "Name": "Bessie" }], [2, { "Name", "Lightfoot" }]] }
 ```
@@ -78,6 +80,35 @@ The `Animal` class only knows about `Horse` as a subtype and designates `2` as t
 `Animal` has no designation for `QuarterHorse` or `Thoroughbred`.
 As such, serializing your `Farm` would drop any details about horse breeds and deserializing would produce `Horse` objects, not `QuarterHorse` or `Thoroughbred`.
 To fix this, you would need to add @Nerdbank.MessagePack.KnownSubTypeAttribute`1 to the `Animal` class for `QuarterHorse` and `Thoroughbred` that assigns type aliases for each of them.
+
+### Alias types
+
+An alias may also be a string.
+String aliases are case sensitive.
+
+The following example shows using strings:
+
+# [.NET](#tab/net)
+
+[!code-csharp[](../../samples/Unions.cs#StringAliasTypesNET)]
+
+# [.NET Standard](#tab/netfx)
+
+[!code-csharp[](../../samples/Unions.cs#StringAliasTypesNETFX)]
+
+---
+
+Mixing alias types for a given base type is allowed, as shown here:
+
+# [.NET](#tab/net)
+
+[!code-csharp[](../../samples/Unions.cs#MixedAliasTypesNET)]
+
+# [.NET Standard](#tab/netfx)
+
+[!code-csharp[](../../samples/Unions.cs#MixedAliasTypesNETFX)]
+
+---
 
 ### Nested sub-types
 

--- a/docfx/docs/unions.md
+++ b/docfx/docs/unions.md
@@ -98,3 +98,25 @@ For example:
 [!code-csharp[](../../samples/Unions.cs#ClosedGenericSubTypesNETFX)]
 
 ---
+
+### Runtime subtype registration
+
+Static registration via attributes is not always possible.
+For instance, you may want to serialize types from a third-party library that you cannot modify.
+Or you may have an extensible plugin system where new types are added at runtime.
+Or most simply, the derived types may not be declared in the same assembly as the base type.
+
+In such cases, runtime registration of subtypes is possible to allow you to run any custom logic you may require to discover and register subtypes.
+Your code is still responsible to ensure unique aliases are assigned to each subtype.
+
+Consider the following example where a type hierarchy is registered without using the attribute approach:
+
+# [.NET](#tab/net)
+
+[!code-csharp[](../../samples/Unions.cs#RuntimeSubTypesNET)]
+
+# [.NET Standard](#tab/netfx)
+
+[!code-csharp[](../../samples/Unions.cs#RuntimeSubTypesNETFX)]
+
+---

--- a/samples/Unions.cs
+++ b/samples/Unions.cs
@@ -128,3 +128,62 @@ namespace GenericSubTypes
     #endregion
 #endif
 }
+
+namespace RuntimeSubTypes
+{
+#if NET
+    #region RuntimeSubTypesNET
+    class Animal
+    {
+        public string? Name { get; set; }
+    }
+
+    [GenerateShape]
+    partial class Horse : Animal { }
+
+    [GenerateShape]
+    partial class Cow : Animal { }
+
+    class SerializationConfigurator
+    {
+        internal void ConfigureAnimalsMapping(MessagePackSerializer serializer)
+        {
+            KnownSubTypeMapping<Animal> mapping = new();
+            mapping.Add<Horse>(1);
+            mapping.Add<Cow>(2);
+
+            serializer.RegisterKnownSubTypes(mapping);
+        }
+    }
+    #endregion
+#else
+    #region RuntimeSubTypesNETFX
+    class Animal
+    {
+        public string? Name { get; set; }
+    }
+
+    [GenerateShape]
+    partial class Horse : Animal { }
+
+    [GenerateShape]
+    partial class Cow : Animal { }
+
+    [GenerateShape<Horse>]
+    [GenerateShape<Cow>]
+    partial class Witness;
+
+    class SerializationConfigurator
+    {
+        internal void ConfigureAnimalsMapping(MessagePackSerializer serializer)
+        {
+            KnownSubTypeMapping<Animal> mapping = new();
+            mapping.Add<Horse>(1, Witness.ShapeProvider);
+            mapping.Add<Cow>(2, Witness.ShapeProvider);
+
+            serializer.RegisterKnownSubTypes(mapping);
+        }
+    }
+    #endregion
+#endif
+}

--- a/samples/Unions.cs
+++ b/samples/Unions.cs
@@ -29,9 +29,9 @@ namespace Sample1
     #endregion
 #else
     #region FarmAnimalsNETFX
-    [KnownSubType(1, typeof(Cow))]
-    [KnownSubType(2, typeof(Horse))]
-    [KnownSubType(3, typeof(Dog))]
+    [KnownSubType(typeof(Cow), 1)]
+    [KnownSubType(typeof(Horse), 2)]
+    [KnownSubType(typeof(Dog), 3)]
     public class Animal
     {
         public string? Name { get; set; }
@@ -66,8 +66,8 @@ namespace Sample1
     #endregion
 #else
     #region HorseBreedsNETFX
-    [KnownSubType(1, typeof(QuarterHorse))]
-    [KnownSubType(2, typeof(Thoroughbred))]
+    [KnownSubType(typeof(QuarterHorse), 1)]
+    [KnownSubType(typeof(Thoroughbred), 2)]
     public partial class Horse : Animal { }
 
     [GenerateShape]
@@ -105,9 +105,9 @@ namespace GenericSubTypes
     #endregion
 #else
     #region ClosedGenericSubTypesNETFX
-    [KnownSubType(1, typeof(Horse))]
-    [KnownSubType(2, typeof(Cow<SolidHoof>))]
-    [KnownSubType(3, typeof(Cow<ClovenHoof>))]
+    [KnownSubType(typeof(Horse), 1)]
+    [KnownSubType(typeof(Cow<SolidHoof>), 2)]
+    [KnownSubType(typeof(Cow<ClovenHoof>), 3)]
     class Animal
     {
         public string? Name { get; set; }
@@ -150,8 +150,8 @@ namespace StringAliasTypes
 #else
     #region StringAliasTypesNETFX
     [GenerateShape]
-    [KnownSubType("Horse", typeof(Horse))]
-    [KnownSubType("Cow", typeof(Cow))]
+    [KnownSubType(typeof(Horse), "Horse")]
+    [KnownSubType(typeof(Cow), "Cow")]
     partial class Animal
     {
         public string? Name { get; set; }
@@ -187,8 +187,45 @@ namespace MixedAliasTypes
 #else
     #region MixedAliasTypesNETFX
     [GenerateShape]
-    [KnownSubType(1, typeof(Horse))]
-    [KnownSubType("Cow", typeof(Cow))]
+    [KnownSubType(typeof(Horse), 1)]
+    [KnownSubType(typeof(Cow), "Cow")]
+    partial class Animal
+    {
+        public string? Name { get; set; }
+    }
+
+    [GenerateShape]
+    partial class Horse : Animal { }
+
+    [GenerateShape]
+    partial class Cow : Animal { }
+    #endregion
+#endif
+}
+
+namespace InferredAliasTypes
+{
+#if NET
+    #region InferredAliasTypesNET
+    [GenerateShape]
+    [KnownSubType<Horse>]
+    [KnownSubType<Cow>]
+    partial class Animal
+    {
+        public string? Name { get; set; }
+    }
+
+    [GenerateShape]
+    partial class Horse : Animal { }
+
+    [GenerateShape]
+    partial class Cow : Animal { }
+    #endregion
+#else
+    #region InferredAliasTypesNETFX
+    [GenerateShape]
+    [KnownSubType(typeof(Horse))]
+    [KnownSubType(typeof(Cow))]
     partial class Animal
     {
         public string? Name { get; set; }

--- a/samples/Unions.cs
+++ b/samples/Unions.cs
@@ -129,6 +129,80 @@ namespace GenericSubTypes
 #endif
 }
 
+namespace StringAliasTypes
+{
+#if NET
+    #region StringAliasTypesNET
+    [GenerateShape]
+    [KnownSubType<Horse>("Horse")]
+    [KnownSubType<Cow>("Cow")]
+    partial class Animal
+    {
+        public string? Name { get; set; }
+    }
+
+    [GenerateShape]
+    partial class Horse : Animal { }
+
+    [GenerateShape]
+    partial class Cow : Animal { }
+    #endregion
+#else
+    #region StringAliasTypesNETFX
+    [GenerateShape]
+    [KnownSubType("Horse", typeof(Horse))]
+    [KnownSubType("Cow", typeof(Cow))]
+    partial class Animal
+    {
+        public string? Name { get; set; }
+    }
+
+    [GenerateShape]
+    partial class Horse : Animal { }
+
+    [GenerateShape]
+    partial class Cow : Animal { }
+    #endregion
+#endif
+}
+
+namespace MixedAliasTypes
+{
+#if NET
+    #region MixedAliasTypesNET
+    [GenerateShape]
+    [KnownSubType<Horse>(1)]
+    [KnownSubType<Cow>("Cow")]
+    partial class Animal
+    {
+        public string? Name { get; set; }
+    }
+
+    [GenerateShape]
+    partial class Horse : Animal { }
+
+    [GenerateShape]
+    partial class Cow : Animal { }
+    #endregion
+#else
+    #region MixedAliasTypesNETFX
+    [GenerateShape]
+    [KnownSubType(1, typeof(Horse))]
+    [KnownSubType("Cow", typeof(Cow))]
+    partial class Animal
+    {
+        public string? Name { get; set; }
+    }
+
+    [GenerateShape]
+    partial class Horse : Animal { }
+
+    [GenerateShape]
+    partial class Cow : Animal { }
+    #endregion
+#endif
+}
+
 namespace RuntimeSubTypes
 {
 #if NET

--- a/src/Nerdbank.MessagePack.Analyzers/AnalyzerUtilities.cs
+++ b/src/Nerdbank.MessagePack.Analyzers/AnalyzerUtilities.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Nerdbank.MessagePack.Analyzers;
@@ -135,6 +136,25 @@ public static class AnalyzerUtilities
 		=> att.ApplicationSyntaxReference?.GetSyntax(cancellationToken) is AttributeSyntax { Name: GenericNameSyntax { TypeArgumentList.Arguments: { } a } } && a.Count > typeArgumentIndex
 			? a[typeArgumentIndex].GetLocation()
 			: null;
+
+	public static string GetFullName(this INamedTypeSymbol symbol)
+	{
+		var sb = new StringBuilder();
+
+		if (symbol.ContainingType is not null)
+		{
+			sb.Append(GetFullName(symbol.ContainingType));
+			sb.Append('.');
+		}
+		else if (!symbol.ContainingNamespace.IsGlobalNamespace)
+		{
+			sb.Append(symbol.ContainingNamespace.MetadataName);
+			sb.Append('.');
+		}
+
+		sb.Append(symbol.MetadataName);
+		return sb.ToString();
+	}
 
 	internal static string GetHelpLink(string diagnosticId) => $"https://aarnott.github.io/Nerdbank.MessagePack/analyzers/{diagnosticId}.html";
 }

--- a/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
+++ b/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
@@ -135,12 +135,17 @@ internal record ArrayConstructorVisitorInputs<TDeclaringType>(List<(string Name,
 internal record SubTypes
 {
 	/// <summary>
-	/// Gets the converters to use to deserialize a subtype, keyed by their alias.
+	/// Gets the converters to use to deserialize a subtype, keyed by its integer alias.
 	/// </summary>
-	internal required FrozenDictionary<int, IMessagePackConverter> Deserializers { get; init; }
+	internal required FrozenDictionary<int, IMessagePackConverter> DeserializersByIntAlias { get; init; }
+
+	/// <summary>
+	/// Gets the converter to use to deserialize a subtype, keyed by its UTF-8 encoded string alias.
+	/// </summary>
+	internal required SpanDictionary<byte, IMessagePackConverter> DeserializersByStringAlias { get; init; }
 
 	/// <summary>
 	/// Gets the converter and alias to use for a subtype, keyed by their <see cref="Type"/>.
 	/// </summary>
-	internal required FrozenDictionary<Type, (int Alias, IMessagePackConverter Converter, ITypeShape Shape)> Serializers { get; init; }
+	internal required FrozenDictionary<Type, (SubTypeAlias Alias, IMessagePackConverter Converter, ITypeShape Shape)> Serializers { get; init; }
 }

--- a/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
@@ -38,7 +38,7 @@ internal class ObjectMapWithNonDefaultCtorConverter<TDeclaringType, TArgumentSta
 			int count = reader.ReadMapHeader();
 			for (int i = 0; i < count; i++)
 			{
-				ReadOnlySpan<byte> propertyName = ReadStringSpan(ref reader);
+				ReadOnlySpan<byte> propertyName = StringEncoding.ReadStringSpan(ref reader);
 				if (parameters.Readers.TryGetValue(propertyName, out DeserializableProperty<TArgumentState> deserializeArg))
 				{
 					deserializeArg.Read(ref argState, ref reader, context);
@@ -104,7 +104,7 @@ internal class ObjectMapWithNonDefaultCtorConverter<TDeclaringType, TArgumentSta
 				int bufferedEntries = bufferedStructures / 2;
 				for (int i = 0; i < bufferedEntries; i++)
 				{
-					ReadOnlySpan<byte> propertyName = ReadStringSpan(ref syncReader);
+					ReadOnlySpan<byte> propertyName = StringEncoding.ReadStringSpan(ref syncReader);
 					if (parameters.Readers.TryGetValue(propertyName, out DeserializableProperty<TArgumentState> propertyReader))
 					{
 						propertyReader.Read(ref argState, ref syncReader, context);
@@ -124,7 +124,7 @@ internal class ObjectMapWithNonDefaultCtorConverter<TDeclaringType, TArgumentSta
 					if (bufferedStructures % 2 == 1)
 					{
 						// The property name has already been buffered.
-						ReadOnlySpan<byte> propertyName = ReadStringSpan(ref syncReader);
+						ReadOnlySpan<byte> propertyName = StringEncoding.ReadStringSpan(ref syncReader);
 						if (parameters.Readers.TryGetValue(propertyName, out DeserializableProperty<TArgumentState> propertyReader) && propertyReader.PreferAsyncSerialization)
 						{
 							// The next property value is async, so turn in our sync reader and read it asynchronously.

--- a/src/Nerdbank.MessagePack/IKnownSubTypeMapping.cs
+++ b/src/Nerdbank.MessagePack/IKnownSubTypeMapping.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Frozen;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// A non-generic accessor for <see cref="KnownSubTypeMapping{TBase}"/>
+/// so that multiple such mappings can be stored in a collection and retrieved later.
+/// </summary>
+internal interface IKnownSubTypeMapping
+{
+	/// <summary>
+	/// Constructs a read-only dictionary of sub-types, keyed by their aliases.
+	/// </summary>
+	/// <returns>A collection of sub-types and aliases.</returns>
+	/// <remarks>
+	/// It is not strictly required that the implementation guarantee that each type is unique,
+	/// because the requirement for uniqueness is enforced later when the known sub-type converter is initialized.
+	/// </remarks>
+	FrozenDictionary<int, ITypeShape> CreateSubTypesMapping();
+}

--- a/src/Nerdbank.MessagePack/IKnownSubTypeMapping.cs
+++ b/src/Nerdbank.MessagePack/IKnownSubTypeMapping.cs
@@ -19,5 +19,5 @@ internal interface IKnownSubTypeMapping
 	/// It is not strictly required that the implementation guarantee that each type is unique,
 	/// because the requirement for uniqueness is enforced later when the known sub-type converter is initialized.
 	/// </remarks>
-	FrozenDictionary<int, ITypeShape> CreateSubTypesMapping();
+	FrozenDictionary<SubTypeAlias, ITypeShape> CreateSubTypesMapping();
 }

--- a/src/Nerdbank.MessagePack/KnownSubTypeAttribute.cs
+++ b/src/Nerdbank.MessagePack/KnownSubTypeAttribute.cs
@@ -17,7 +17,6 @@ namespace Nerdbank.MessagePack;
 /// </summary>
 /// <typeparam name="TSubType">A class derived from the one to which this attribute is affixed.</typeparam>
 /// <typeparam name="TShapeProvider">The class that serves as the shape provider for <typeparamref name="TSubType"/>.</typeparam>
-/// <param name="alias">A value that identifies the subtype in the serialized data. Must be unique among all the attributes applied to the same class.</param>
 /// <remarks>
 /// <para>
 /// A type with one or more of these attributes applied serializes to a different schema than the same type
@@ -30,11 +29,28 @@ namespace Nerdbank.MessagePack;
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = true)]
 [DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
-#pragma warning disable CS0618 // Type or member is obsolete
-public class KnownSubTypeAttribute<TSubType, TShapeProvider>(int alias) : KnownSubTypeAttribute(alias, typeof(TSubType))
-#pragma warning restore CS0618 // Type or member is obsolete
+public class KnownSubTypeAttribute<TSubType, TShapeProvider> : KnownSubTypeAttribute
 	where TShapeProvider : IShapeable<TSubType>
 {
+	/// <summary>
+	/// Initializes a new instance of the <see cref="KnownSubTypeAttribute{TSubType, TShapeProvider}"/> class.
+	/// </summary>
+	/// <param name="alias"><inheritdoc cref="KnownSubTypeAttribute(int, Type)" path="/param[@name='alias']" /></param>
+	public KnownSubTypeAttribute(int alias)
+#pragma warning disable CS0618 // Type or member is obsolete
+		: base(alias, typeof(TSubType))
+#pragma warning restore CS0618 // Type or member is obsolete
+	{
+	}
+
+	/// <inheritdoc cref="KnownSubTypeAttribute{TSubType, TShapeProvider}.KnownSubTypeAttribute(int)" />
+	public KnownSubTypeAttribute(string alias)
+#pragma warning disable CS0618 // Type or member is obsolete
+		: base(alias, typeof(TSubType))
+#pragma warning restore CS0618 // Type or member is obsolete
+	{
+	}
+
 	/// <inheritdoc/>
 	public override ITypeShape? Shape => TShapeProvider.GetShape();
 
@@ -47,9 +63,23 @@ public class KnownSubTypeAttribute<TSubType, TShapeProvider>(int alias) : KnownS
 /// <inheritdoc cref="KnownSubTypeAttribute{TSubType, TShapeProvider}"/>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = true)]
 [DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
-public class KnownSubTypeAttribute<TSubType>(int alias) : KnownSubTypeAttribute<TSubType, TSubType>(alias)
+public class KnownSubTypeAttribute<TSubType> : KnownSubTypeAttribute<TSubType, TSubType>
 	where TSubType : IShapeable<TSubType>
 {
+	/// <summary>
+	/// Initializes a new instance of the <see cref="KnownSubTypeAttribute{TSubType}"/> class.
+	/// </summary>
+	/// <param name="alias"><inheritdoc cref="KnownSubTypeAttribute(int, Type)" path="/param[@name='alias']" /></param>
+	public KnownSubTypeAttribute(int alias)
+		: base(alias)
+	{
+	}
+
+	/// <inheritdoc cref="KnownSubTypeAttribute{TSubType}.KnownSubTypeAttribute(int)" />
+	public KnownSubTypeAttribute(string alias)
+		: base(alias)
+	{
+	}
 }
 
 #endif
@@ -91,10 +121,15 @@ public class KnownSubTypeAttribute : Attribute
 		this.SubType = subType;
 	}
 
-	/// <summary>
-	/// Gets a value that identifies the subtype in the serialized data. Must be unique among all the attributes applied to the same class.
-	/// </summary>
-	public int Alias { get; }
+	/// <inheritdoc cref="KnownSubTypeAttribute(int, Type)" />
+#if NET
+	[Obsolete("Use the generic version of this attribute instead.")]
+#endif
+	public KnownSubTypeAttribute(string alias, Type subType)
+	{
+		this.Alias = alias;
+		this.SubType = subType;
+	}
 
 	/// <summary>
 	/// Gets the sub-type.
@@ -105,4 +140,9 @@ public class KnownSubTypeAttribute : Attribute
 	/// Gets the shape that describes the subtype.
 	/// </summary>
 	public virtual ITypeShape? Shape => null;
+
+	/// <summary>
+	/// Gets a value that identifies the subtype in the serialized data. Must be unique among all the attributes applied to the same class.
+	/// </summary>
+	internal SubTypeAlias Alias { get; }
 }

--- a/src/Nerdbank.MessagePack/KnownSubTypeMapping`1.cs
+++ b/src/Nerdbank.MessagePack/KnownSubTypeMapping`1.cs
@@ -12,7 +12,7 @@ namespace Nerdbank.MessagePack;
 /// <typeparam name="TBase">The base type or interface that all sub-types derive from or implement.</typeparam>
 public class KnownSubTypeMapping<TBase> : IKnownSubTypeMapping
 {
-	private readonly Dictionary<int, ITypeShape> map = new();
+	private readonly Dictionary<SubTypeAlias, ITypeShape> map = new();
 	private readonly HashSet<Type> addedTypes = new();
 
 	/// <summary>
@@ -65,5 +65,5 @@ public class KnownSubTypeMapping<TBase> : IKnownSubTypeMapping
 #endif
 
 	/// <inheritdoc />
-	FrozenDictionary<int, ITypeShape> IKnownSubTypeMapping.CreateSubTypesMapping() => this.map.ToFrozenDictionary();
+	FrozenDictionary<SubTypeAlias, ITypeShape> IKnownSubTypeMapping.CreateSubTypesMapping() => this.map.ToFrozenDictionary();
 }

--- a/src/Nerdbank.MessagePack/KnownSubTypeMapping`1.cs
+++ b/src/Nerdbank.MessagePack/KnownSubTypeMapping`1.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Frozen;
+using Microsoft;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// Describes a mapping between a base type and its known sub-types, along with the aliases that identify them.
+/// </summary>
+/// <typeparam name="TBase">The base type or interface that all sub-types derive from or implement.</typeparam>
+public class KnownSubTypeMapping<TBase> : IKnownSubTypeMapping
+{
+	private readonly Dictionary<int, ITypeShape> map = new();
+	private readonly HashSet<Type> addedTypes = new();
+
+	/// <summary>
+	/// Adds a known sub-type to the mapping.
+	/// </summary>
+	/// <typeparam name="TDerived">The sub-type.</typeparam>
+	/// <param name="alias">The alias for the sub-type.</param>
+	/// <param name="typeShape">The shape of the sub-type.</param>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="alias"/> or the <see cref="Type"/> described by <paramref name="typeShape"/> have already been added to this mapping.</exception>
+	public void Add<TDerived>(int alias, ITypeShape<TDerived> typeShape)
+		where TDerived : TBase
+	{
+		Requires.NotNull(typeShape);
+		this.map.Add(alias, typeShape);
+		if (!this.addedTypes.Add(typeof(TDerived)))
+		{
+			this.map.Remove(alias);
+			throw new ArgumentException($"The type {typeof(TDerived)} has already been added to the mapping.", nameof(alias));
+		}
+	}
+
+	/// <inheritdoc cref="Add{TDerived}(int, ITypeShape{TDerived})" path="/summary" />
+	/// <inheritdoc cref="Add{TDerived}(int, ITypeShape{TDerived})" path="/exception" />
+	/// <param name="alias"><inheritdoc cref="Add{TDerived}(int, ITypeShape{TDerived})" path="/param[@name='alias']" /></param>
+	/// <param name="provider"><inheritdoc cref="MessagePackSerializer.Deserialize{T}(ref MessagePackReader, ITypeShapeProvider, CancellationToken)" path="/param[@name='provider']"/></param>
+	public void Add<TDerived>(int alias, ITypeShapeProvider provider)
+		where TDerived : TBase
+	{
+		Requires.NotNull(provider);
+
+		ITypeShape<TDerived>? shape = (ITypeShape<TDerived>?)provider.GetShape(typeof(TDerived));
+		Requires.Argument(shape is not null, nameof(provider), "The provider did not provide a shape for the given type.");
+		this.Add(alias, shape);
+	}
+
+#if NET
+	/// <inheritdoc cref="Add{TDerived}(int, ITypeShape{TDerived})" />
+	public void Add<TDerived>(int alias)
+		where TDerived : TBase, IShapeable<TDerived> => this.Add(alias, TDerived.GetShape());
+
+	/// <inheritdoc cref="Add{TDerived}(int, ITypeShape{TDerived})" path="/summary" />
+	/// <inheritdoc cref="Add{TDerived}(int, ITypeShape{TDerived})" path="/exception" />
+	/// <param name="alias"><inheritdoc cref="Add{TDerived}(int, ITypeShape{TDerived})" path="/param[@name='alias']" /></param>
+	/// <typeparam name="TDerived"><inheritdoc cref="Add{TDerived}(int, ITypeShape{TDerived})" path="/typeparam[@name='TDerived']"/></typeparam>
+	/// <typeparam name="TProvider">The witness class that provides a type shape for <typeparamref name="TDerived"/>.</typeparam>
+	public void Add<TDerived, TProvider>(int alias)
+		where TDerived : TBase
+		where TProvider : IShapeable<TDerived>
+		=> this.Add(alias, TProvider.GetShape());
+#endif
+
+	/// <inheritdoc />
+	FrozenDictionary<int, ITypeShape> IKnownSubTypeMapping.CreateSubTypesMapping() => this.map.ToFrozenDictionary();
+}

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -655,7 +655,7 @@ public partial record MessagePackSerializer
 	/// <param name="baseType">The base type.</param>
 	/// <param name="subTypes">If sub-types are registered, receives the mapping of those sub-types to their aliases.</param>
 	/// <returns><see langword="true" /> if sub-types are registered; <see langword="false" /> otherwise.</returns>
-	internal bool TryGetDynamicSubTypes(Type baseType, [NotNullWhen(true)] out IReadOnlyDictionary<int, ITypeShape>? subTypes)
+	internal bool TryGetDynamicSubTypes(Type baseType, [NotNullWhen(true)] out IReadOnlyDictionary<SubTypeAlias, ITypeShape>? subTypes)
 	{
 		if (this.userProvidedKnownSubTypes.TryGetValue(baseType, out IKnownSubTypeMapping? mapping))
 		{

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -521,22 +521,39 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	/// <exception cref="InvalidOperationException">Thrown if <paramref name="objectShape"/> has any <see cref="KnownSubTypeAttribute"/> that violates rules.</exception>
 	private SubTypes? DiscoverUnionTypes(IObjectTypeShape objectShape)
 	{
-		KnownSubTypeAttribute[]? unionAttributes = objectShape.AttributeProvider?.GetCustomAttributes(typeof(KnownSubTypeAttribute), false).Cast<KnownSubTypeAttribute>().ToArray();
-		if (unionAttributes is null or { Length: 0 })
+		IReadOnlyDictionary<int, ITypeShape>? mapping;
+		if (!this.owner.TryGetDynamicSubTypes(objectShape.Type, out mapping))
 		{
-			return null;
+			KnownSubTypeAttribute[]? unionAttributes = objectShape.AttributeProvider?.GetCustomAttributes(typeof(KnownSubTypeAttribute), false).Cast<KnownSubTypeAttribute>().ToArray();
+			if (unionAttributes is null or { Length: 0 })
+			{
+				return null;
+			}
+
+			Dictionary<int, ITypeShape> mutableMapping = new();
+			foreach (KnownSubTypeAttribute unionAttribute in unionAttributes)
+			{
+				ITypeShape subtypeShape = unionAttribute.Shape ?? objectShape.Provider.GetShapeOrThrow(unionAttribute.SubType);
+				Verify.Operation(objectShape.Type.IsAssignableFrom(subtypeShape.Type), $"The type {objectShape.Type.FullName} has a {KnownSubTypeAttribute.TypeName} that references non-derived {subtypeShape.Type.FullName}.");
+				Verify.Operation(mutableMapping.TryAdd(unionAttribute.Alias, subtypeShape), $"The type {objectShape.Type.FullName} has more than one {KnownSubTypeAttribute.TypeName} with a duplicate alias: {unionAttribute.Alias}.");
+			}
+
+			mapping = mutableMapping;
 		}
 
 		Dictionary<int, IMessagePackConverter> deserializerData = new();
 		Dictionary<Type, (int Alias, IMessagePackConverter Converter, ITypeShape Shape)> serializerData = new();
-		foreach (KnownSubTypeAttribute unionAttribute in unionAttributes)
+		foreach (KeyValuePair<int, ITypeShape> pair in mapping)
 		{
-			ITypeShape subtypeShape = unionAttribute.Shape ?? objectShape.Provider.GetShapeOrThrow(unionAttribute.SubType);
-			Verify.Operation(objectShape.Type.IsAssignableFrom(subtypeShape.Type), $"The type {objectShape.Type.FullName} has a {KnownSubTypeAttribute.TypeName} that references non-derived {subtypeShape.Type.FullName}.");
+			int alias = pair.Key;
+			ITypeShape shape = pair.Value;
 
-			IMessagePackConverter converter = this.GetConverter(subtypeShape);
-			Verify.Operation(deserializerData.TryAdd(unionAttribute.Alias, converter), $"The type {objectShape.Type.FullName} has more than one {KnownSubTypeAttribute.TypeName} with a duplicate alias: {unionAttribute.Alias}.");
-			Verify.Operation(serializerData.TryAdd(subtypeShape.Type, (unionAttribute.Alias, converter, subtypeShape)), $"The type {objectShape.Type.FullName} has more than one subtype with a duplicate alias: {unionAttribute.Alias}.");
+			// We don't want a reference-preserving converter here because that layer has already run
+			// by the time our subtype converter is invoked.
+			// And doubling up on it means values get serialized incorrectly.
+			IMessagePackConverter converter = this.GetConverter(shape).UnwrapReferencePreservation();
+			deserializerData.Add(alias, converter);
+			Verify.Operation(serializerData.TryAdd(shape.Type, (alias, converter, shape)), $"The type {objectShape.Type.FullName} has more than one subtype with a duplicate alias: {alias}.");
 		}
 
 		return new SubTypes

--- a/src/Nerdbank.MessagePack/StringEncoding.cs
+++ b/src/Nerdbank.MessagePack/StringEncoding.cs
@@ -34,4 +34,31 @@ internal static class StringEncoding
 		utf8Bytes = bytes.Slice(msgpackHeaderLength, byteCount);
 		msgpackEncoded = bytes.Slice(0, byteCount + msgpackHeaderLength);
 	}
+
+	/// <summary>
+	/// Reads a string as a contiguous span of UTF-8 encoded characters.
+	/// An array may be allocated if the string is not already contiguous in memory.
+	/// </summary>
+	/// <param name="reader">The reader to use.</param>
+	/// <returns>The span of UTF-8 encoded characters.</returns>
+	internal static ReadOnlySpan<byte> ReadStringSpan(scoped ref MessagePackReader reader)
+	{
+		if (!reader.TryReadStringSpan(out ReadOnlySpan<byte> result))
+		{
+			ReadOnlySequence<byte>? sequence = reader.ReadStringSequence();
+			if (sequence.HasValue)
+			{
+				if (sequence.Value.IsSingleSegment)
+				{
+					return sequence.Value.First.Span;
+				}
+
+				return sequence.Value.ToArray();
+			}
+
+			return default;
+		}
+
+		return result;
+	}
 }

--- a/src/Nerdbank.MessagePack/SubTypeAlias.cs
+++ b/src/Nerdbank.MessagePack/SubTypeAlias.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// Acts as a type union between a <see cref="string"/> and an <see cref="int"/>, which are the allowed types for sub-type aliases.
+/// </summary>
+internal struct SubTypeAlias : IEquatable<SubTypeAlias>
+{
+	private string? stringAlias;
+	private ReadOnlyMemory<byte> utfAlias;
+	private ReadOnlyMemory<byte> msgpackAlias;
+	private int? intAlias;
+
+	/// <inheritdoc cref="SubTypeAlias(string)"/>
+	internal SubTypeAlias(int alias)
+	{
+		this.intAlias = alias;
+		byte[] msgpack = new byte[5]; // maximum possible value can be encoded in this buffer.
+		Assumes.True(MessagePackPrimitives.TryWrite(msgpack, alias, out int bytesWritten));
+		this.msgpackAlias = msgpack.AsMemory(0, bytesWritten);
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SubTypeAlias"/> struct.
+	/// </summary>
+	/// <param name="alias">The alias.</param>
+	internal SubTypeAlias(string alias)
+	{
+		this.stringAlias = alias;
+		StringEncoding.GetEncodedStringBytes(alias, out this.utfAlias, out this.msgpackAlias);
+	}
+
+	/// <summary>
+	/// The types of values that are allowed for use as aliases.
+	/// </summary>
+	internal enum AliasType
+	{
+		/// <summary>
+		/// The struct is uninitialized. This constitutes an internal error.
+		/// </summary>
+		None,
+
+		/// <summary>
+		/// The alias is an <see cref="int"/>.
+		/// </summary>
+		Integer,
+
+		/// <summary>
+		/// The alias is a <see cref="string"/>.
+		/// </summary>
+		String,
+	}
+
+	/// <summary>
+	/// Gets the type of this alias.
+	/// </summary>
+	public AliasType Type => this.stringAlias is not null ? AliasType.String : this.intAlias is not null ? AliasType.Integer : AliasType.None;
+
+	/// <summary>
+	/// Gets the <see cref="string"/> alias.
+	/// </summary>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="Type"/> is not <see cref="AliasType.String"/>.</exception>
+	public string StringAlias => this.stringAlias ?? throw new InvalidOperationException();
+
+	/// <summary>
+	/// Gets the <see cref="int"/> alias.
+	/// </summary>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="Type"/> is not <see cref="AliasType.Integer"/>.</exception>
+	public int IntAlias => this.intAlias ?? throw new InvalidOperationException();
+
+	/// <summary>
+	/// Gets the msgpack encoding of the alias.
+	/// </summary>
+	public ReadOnlyMemory<byte> MsgPackAlias => this.msgpackAlias;
+
+	/// <summary>
+	/// Gets the UTF-8 encoding of the <see cref="string"/> alias.
+	/// </summary>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="Type"/> is not <see cref="AliasType.String"/>.</exception>
+	public ReadOnlyMemory<byte> Utf8Alias => this.stringAlias is not null ? this.utfAlias : throw new InvalidOperationException();
+
+	public static implicit operator SubTypeAlias(string alias) => new(alias);
+
+	public static implicit operator SubTypeAlias(int alias) => new(alias);
+
+	/// <inheritdoc/>
+	public bool Equals(SubTypeAlias other) => this.stringAlias == other.stringAlias && this.intAlias == other.intAlias;
+
+	/// <inheritdoc/>
+	public override bool Equals([NotNullWhen(true)] object? obj) => obj is SubTypeAlias other && this.Equals(other);
+
+	/// <inheritdoc/>
+	public override int GetHashCode() => this.stringAlias?.GetHashCode() ?? this.intAlias?.GetHashCode() ?? 0;
+}

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -75,13 +75,16 @@ Nerdbank.MessagePack.KeyAttribute
 Nerdbank.MessagePack.KeyAttribute.Index.get -> int
 Nerdbank.MessagePack.KeyAttribute.KeyAttribute(int index) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute
-Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(int alias, System.Type! subType) -> void
-Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(string! alias, System.Type! subType) -> void
+Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(System.Type! subType) -> void
+Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(System.Type! subType, int alias) -> void
+Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(System.Type! subType, string! alias) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute.SubType.get -> System.Type!
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType, TShapeProvider>
+Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType, TShapeProvider>.KnownSubTypeAttribute() -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType, TShapeProvider>.KnownSubTypeAttribute(int alias) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType, TShapeProvider>.KnownSubTypeAttribute(string! alias) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType>
+Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType>.KnownSubTypeAttribute() -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType>.KnownSubTypeAttribute(int alias) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType>.KnownSubTypeAttribute(string! alias) -> void
 Nerdbank.MessagePack.KnownSubTypeMapping<TBase>

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -75,13 +75,15 @@ Nerdbank.MessagePack.KeyAttribute
 Nerdbank.MessagePack.KeyAttribute.Index.get -> int
 Nerdbank.MessagePack.KeyAttribute.KeyAttribute(int index) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute
-Nerdbank.MessagePack.KnownSubTypeAttribute.Alias.get -> int
 Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(int alias, System.Type! subType) -> void
+Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(string! alias, System.Type! subType) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute.SubType.get -> System.Type!
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType, TShapeProvider>
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType, TShapeProvider>.KnownSubTypeAttribute(int alias) -> void
+Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType, TShapeProvider>.KnownSubTypeAttribute(string! alias) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType>
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType>.KnownSubTypeAttribute(int alias) -> void
+Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType>.KnownSubTypeAttribute(string! alias) -> void
 Nerdbank.MessagePack.KnownSubTypeMapping<TBase>
 Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.Add<TDerived, TProvider>(int alias) -> void
 Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.Add<TDerived>(int alias) -> void

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -82,6 +82,12 @@ Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType, TShapeProvider>
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType, TShapeProvider>.KnownSubTypeAttribute(int alias) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType>
 Nerdbank.MessagePack.KnownSubTypeAttribute<TSubType>.KnownSubTypeAttribute(int alias) -> void
+Nerdbank.MessagePack.KnownSubTypeMapping<TBase>
+Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.Add<TDerived, TProvider>(int alias) -> void
+Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.Add<TDerived>(int alias) -> void
+Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.Add<TDerived>(int alias, PolyType.Abstractions.ITypeShape<TDerived>! typeShape) -> void
+Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.Add<TDerived>(int alias, PolyType.ITypeShapeProvider! provider) -> void
+Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.KnownSubTypeMapping() -> void
 Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode
 Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.ObjectReference.get -> sbyte
 Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.ObjectReference.init -> void
@@ -220,6 +226,7 @@ Nerdbank.MessagePack.MessagePackSerializer.PreserveReferences.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.PropertyNamingPolicy.get -> Nerdbank.MessagePack.MessagePackNamingPolicy?
 Nerdbank.MessagePack.MessagePackSerializer.PropertyNamingPolicy.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.RegisterConverter<T>(Nerdbank.MessagePack.MessagePackConverter<T>! converter) -> void
+Nerdbank.MessagePack.MessagePackSerializer.RegisterKnownSubTypes<TBase>(Nerdbank.MessagePack.KnownSubTypeMapping<TBase>! mapping) -> void
 Nerdbank.MessagePack.MessagePackSerializer.Serialize<T, TProvider>(in T? value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
 Nerdbank.MessagePack.MessagePackSerializer.Serialize<T, TProvider>(System.Buffers.IBufferWriter<byte>! writer, in T? value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 Nerdbank.MessagePack.MessagePackSerializer.Serialize<T, TProvider>(System.IO.Stream! stream, in T? value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -75,8 +75,8 @@ Nerdbank.MessagePack.KeyAttribute
 Nerdbank.MessagePack.KeyAttribute.Index.get -> int
 Nerdbank.MessagePack.KeyAttribute.KeyAttribute(int index) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute
-Nerdbank.MessagePack.KnownSubTypeAttribute.Alias.get -> int
 Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(int alias, System.Type! subType) -> void
+Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(string! alias, System.Type! subType) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute.SubType.get -> System.Type!
 Nerdbank.MessagePack.KnownSubTypeMapping<TBase>
 Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.Add<TDerived>(int alias, PolyType.Abstractions.ITypeShape<TDerived>! typeShape) -> void

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -78,6 +78,10 @@ Nerdbank.MessagePack.KnownSubTypeAttribute
 Nerdbank.MessagePack.KnownSubTypeAttribute.Alias.get -> int
 Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(int alias, System.Type! subType) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute.SubType.get -> System.Type!
+Nerdbank.MessagePack.KnownSubTypeMapping<TBase>
+Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.Add<TDerived>(int alias, PolyType.Abstractions.ITypeShape<TDerived>! typeShape) -> void
+Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.Add<TDerived>(int alias, PolyType.ITypeShapeProvider! provider) -> void
+Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.KnownSubTypeMapping() -> void
 Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode
 Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.ObjectReference.get -> sbyte
 Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.ObjectReference.init -> void
@@ -202,6 +206,7 @@ Nerdbank.MessagePack.MessagePackSerializer.PreserveReferences.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.PropertyNamingPolicy.get -> Nerdbank.MessagePack.MessagePackNamingPolicy?
 Nerdbank.MessagePack.MessagePackSerializer.PropertyNamingPolicy.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.RegisterConverter<T>(Nerdbank.MessagePack.MessagePackConverter<T>! converter) -> void
+Nerdbank.MessagePack.MessagePackSerializer.RegisterKnownSubTypes<TBase>(Nerdbank.MessagePack.KnownSubTypeMapping<TBase>! mapping) -> void
 Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(in T? value, PolyType.Abstractions.ITypeShape<T>! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
 Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(in T? value, PolyType.ITypeShapeProvider! provider, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]!
 Nerdbank.MessagePack.MessagePackSerializer.Serialize<T>(ref Nerdbank.MessagePack.MessagePackWriter writer, in T? value, PolyType.Abstractions.ITypeShape<T>! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -75,8 +75,9 @@ Nerdbank.MessagePack.KeyAttribute
 Nerdbank.MessagePack.KeyAttribute.Index.get -> int
 Nerdbank.MessagePack.KeyAttribute.KeyAttribute(int index) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute
-Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(int alias, System.Type! subType) -> void
-Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(string! alias, System.Type! subType) -> void
+Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(System.Type! subType) -> void
+Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(System.Type! subType, int alias) -> void
+Nerdbank.MessagePack.KnownSubTypeAttribute.KnownSubTypeAttribute(System.Type! subType, string! alias) -> void
 Nerdbank.MessagePack.KnownSubTypeAttribute.SubType.get -> System.Type!
 Nerdbank.MessagePack.KnownSubTypeMapping<TBase>
 Nerdbank.MessagePack.KnownSubTypeMapping<TBase>.Add<TDerived>(int alias, PolyType.Abstractions.ITypeShape<TDerived>! typeShape) -> void

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/KnownSubTypeAnalyzersTests.cs
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/KnownSubTypeAnalyzersTests.cs
@@ -40,7 +40,7 @@ public class KnownSubTypeAnalyzersTests
 	}
 
 	[Fact]
-	public async Task NoIssues_Subclass()
+	public async Task NoIssues_Subclass_Int()
 	{
 #if NET
 		string source = /* lang=c#-test */ """
@@ -61,6 +61,87 @@ public class KnownSubTypeAnalyzersTests
 			using Nerdbank.MessagePack;
 
 			[KnownSubType(1, typeof(DerivedType))]
+			public class MyType
+			{
+			}
+
+			public class DerivedType : MyType
+			{
+			}
+			""";
+#endif
+
+		await VerifyCS.VerifyAnalyzerAsync(source);
+	}
+
+	[Fact]
+	public async Task NoIssues_Subclass_Mixed()
+	{
+#if NET
+		string source = /* lang=c#-test */ """
+			using Nerdbank.MessagePack;
+
+			[KnownSubType<DerivedType1>(1)]
+			[KnownSubType<DerivedTypeA>("A")]
+			public class MyType
+			{
+			}
+
+			public class DerivedType1 : MyType, PolyType.IShapeable<DerivedType1>
+			{
+				static PolyType.Abstractions.ITypeShape<DerivedType1> PolyType.IShapeable<DerivedType1>.GetShape() => throw new System.NotImplementedException();
+			}
+
+			public class DerivedTypeA : MyType, PolyType.IShapeable<DerivedTypeA>
+			{
+				static PolyType.Abstractions.ITypeShape<DerivedTypeA> PolyType.IShapeable<DerivedTypeA>.GetShape() => throw new System.NotImplementedException();
+			}
+			""";
+#else
+		string source = /* lang=c#-test */ """
+			using Nerdbank.MessagePack;
+
+			[KnownSubType(1, typeof(DerivedType1))]
+			[KnownSubType("A", typeof(DerivedTypeA))]
+			public class MyType
+			{
+			}
+
+			public class DerivedType1 : MyType
+			{
+			}
+
+			public class DerivedTypeA : MyType
+			{
+			}
+			""";
+#endif
+
+		await VerifyCS.VerifyAnalyzerAsync(source);
+	}
+
+	[Fact]
+	public async Task NoIssues_Subclass_String()
+	{
+#if NET
+		string source = /* lang=c#-test */ """
+			using Nerdbank.MessagePack;
+
+			[KnownSubType<DerivedType>("A")]
+			public class MyType
+			{
+			}
+
+			public class DerivedType : MyType, PolyType.IShapeable<DerivedType>
+			{
+				static PolyType.Abstractions.ITypeShape<DerivedType> PolyType.IShapeable<DerivedType>.GetShape() => throw new System.NotImplementedException();
+			}
+			""";
+#else
+		string source = /* lang=c#-test */ """
+			using Nerdbank.MessagePack;
+
+			[KnownSubType("A", typeof(DerivedType))]
 			public class MyType
 			{
 			}
@@ -164,7 +245,7 @@ public class KnownSubTypeAnalyzersTests
 	}
 
 	[Fact]
-	public async Task NonUniqueAlias()
+	public async Task NonUniqueAlias_Int()
 	{
 #if NET
 		string source = /* lang=c#-test */ """
@@ -201,6 +282,120 @@ public class KnownSubTypeAnalyzersTests
 			}
 
 			public class DerivedType2 : MyType
+			{
+			}
+			""";
+#endif
+
+		await VerifyCS.VerifyAnalyzerAsync(source);
+	}
+
+	[Fact]
+	public async Task NonUniqueAlias_String()
+	{
+#if NET
+		string source = /* lang=c#-test */ """
+			using Nerdbank.MessagePack;
+
+			[KnownSubType<DerivedType1>("A")]
+			[KnownSubType<DerivedType2>({|NBMsgPack011:"A"|})]
+			public class MyType
+			{
+			}
+
+			public class DerivedType1 : MyType, PolyType.IShapeable<DerivedType1>
+			{
+				static PolyType.Abstractions.ITypeShape<DerivedType1> PolyType.IShapeable<DerivedType1>.GetShape() => throw new System.NotImplementedException();
+			}
+
+			public class DerivedType2 : MyType, PolyType.IShapeable<DerivedType2>
+			{
+				static PolyType.Abstractions.ITypeShape<DerivedType2> PolyType.IShapeable<DerivedType2>.GetShape() => throw new System.NotImplementedException();
+			}
+			""";
+#else
+		string source = /* lang=c#-test */ """
+			using Nerdbank.MessagePack;
+
+			[KnownSubType("A", typeof(DerivedType1))]
+			[KnownSubType({|NBMsgPack011:"A"|}, typeof(DerivedType2))]
+			public class MyType
+			{
+			}
+
+			public class DerivedType1 : MyType
+			{
+			}
+
+			public class DerivedType2 : MyType
+			{
+			}
+			""";
+#endif
+
+		await VerifyCS.VerifyAnalyzerAsync(source);
+	}
+
+	[Fact]
+	public async Task NonUniqueAlias_Mixed()
+	{
+#if NET
+		string source = /* lang=c#-test */ """
+			using Nerdbank.MessagePack;
+
+			[KnownSubType<DerivedTypeA>("A")]
+			[KnownSubType<DerivedTypeB>({|NBMsgPack011:"A"|})]
+			[KnownSubType<DerivedTypeC>(1)]
+			[KnownSubType<DerivedTypeD>({|NBMsgPack011:1|})]
+			public class MyType
+			{
+			}
+
+			public class DerivedTypeA : MyType, PolyType.IShapeable<DerivedTypeA>
+			{
+				static PolyType.Abstractions.ITypeShape<DerivedTypeA> PolyType.IShapeable<DerivedTypeA>.GetShape() => throw new System.NotImplementedException();
+			}
+
+			public class DerivedTypeB : MyType, PolyType.IShapeable<DerivedTypeB>
+			{
+				static PolyType.Abstractions.ITypeShape<DerivedTypeB> PolyType.IShapeable<DerivedTypeB>.GetShape() => throw new System.NotImplementedException();
+			}
+
+			public class DerivedTypeC : MyType, PolyType.IShapeable<DerivedTypeC>
+			{
+				static PolyType.Abstractions.ITypeShape<DerivedTypeC> PolyType.IShapeable<DerivedTypeC>.GetShape() => throw new System.NotImplementedException();
+			}
+
+			public class DerivedTypeD : MyType, PolyType.IShapeable<DerivedTypeD>
+			{
+				static PolyType.Abstractions.ITypeShape<DerivedTypeD> PolyType.IShapeable<DerivedTypeD>.GetShape() => throw new System.NotImplementedException();
+			}
+			""";
+#else
+		string source = /* lang=c#-test */ """
+			using Nerdbank.MessagePack;
+
+			[KnownSubType("A", typeof(DerivedType1))]
+			[KnownSubType({|NBMsgPack011:"A"|}, typeof(DerivedType2))]
+			[KnownSubType(1, typeof(DerivedType3))]
+			[KnownSubType({|NBMsgPack011:1|}, typeof(DerivedType4))]
+			public class MyType
+			{
+			}
+
+			public class DerivedType1 : MyType
+			{
+			}
+
+			public class DerivedType2 : MyType
+			{
+			}
+
+			public class DerivedType3 : MyType
+			{
+			}
+
+			public class DerivedType4 : MyType
 			{
 			}
 			""";

--- a/test/Nerdbank.MessagePack.Tests/KnownSubTypeMappingTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/KnownSubTypeMappingTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public partial class KnownSubTypeMappingTests(ITestOutputHelper logger)
+{
+	[Fact]
+	public void NonUniqueAliasesRejected()
+	{
+		KnownSubTypeMapping<MyBase> mapping = new();
+#if NET
+		mapping.Add<MyDerivedA>(1);
+		ArgumentException ex = Assert.Throws<ArgumentException>(() => mapping.Add<MyDerivedB>(1));
+#else
+		mapping.Add<MyDerivedA>(1, Witness.ShapeProvider);
+		ArgumentException ex = Assert.Throws<ArgumentException>(() => mapping.Add<MyDerivedB>(1, Witness.ShapeProvider));
+#endif
+		logger.WriteLine(ex.Message);
+	}
+
+	[Fact]
+	public void NonUniqueTypesRejected()
+	{
+		KnownSubTypeMapping<MyBase> mapping = new();
+#if NET
+		mapping.Add<MyDerivedA>(1);
+		ArgumentException ex = Assert.Throws<ArgumentException>(() => mapping.Add<MyDerivedA>(2));
+#else
+		mapping.Add<MyDerivedA>(1, Witness.ShapeProvider);
+		ArgumentException ex = Assert.Throws<ArgumentException>(() => mapping.Add<MyDerivedA>(2, Witness.ShapeProvider));
+#endif
+		logger.WriteLine(ex.Message);
+	}
+
+	[Fact]
+	public void NonUniquePairsRejected()
+	{
+		KnownSubTypeMapping<MyBase> mapping = new();
+#if NET
+		mapping.Add<MyDerivedA>(1);
+		ArgumentException ex = Assert.Throws<ArgumentException>(() => mapping.Add<MyDerivedA>(1));
+#else
+		mapping.Add<MyDerivedA>(1, Witness.ShapeProvider);
+		ArgumentException ex = Assert.Throws<ArgumentException>(() => mapping.Add<MyDerivedA>(1, Witness.ShapeProvider));
+#endif
+		logger.WriteLine(ex.Message);
+	}
+
+	[GenerateShape]
+	internal partial class MyBase;
+
+	[GenerateShape]
+	internal partial class MyDerivedA : MyBase;
+
+	[GenerateShape]
+	internal partial class MyDerivedB : MyBase;
+
+	[GenerateShape<MyBase>]
+	[GenerateShape<MyDerivedA>]
+	[GenerateShape<MyDerivedB>]
+	private partial class Witness;
+}

--- a/test/Nerdbank.MessagePack.Tests/KnownSubTypeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/KnownSubTypeTests.cs
@@ -107,6 +107,15 @@ public partial class KnownSubTypeTests(ITestOutputHelper logger) : MessagePackSe
 	}
 
 	[Fact]
+	public void ImpliedAlias()
+	{
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip<ImpliedAliasBase>(new ImpliedAliasDerived());
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(2, reader.ReadArrayHeader());
+		Assert.Equal(typeof(ImpliedAliasDerived).FullName, reader.ReadString());
+	}
+
+	[Fact]
 	public void RecursiveSubTypes()
 	{
 		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Serialize<RecursiveBase>(new RecursiveDerivedDerived()));
@@ -192,11 +201,11 @@ public partial class KnownSubTypeTests(ITestOutputHelper logger) : MessagePackSe
 	[KnownSubType<EnumerableDerived>(4)]
 	[KnownSubType<DerivedGeneric<int>, Witness>(5)]
 #else
-	[KnownSubType(1, typeof(DerivedA))]
-	[KnownSubType(2, typeof(DerivedAA))]
-	[KnownSubType(3, typeof(DerivedB))]
-	[KnownSubType(4, typeof(EnumerableDerived))]
-	[KnownSubType(5, typeof(DerivedGeneric<int>))]
+	[KnownSubType(typeof(DerivedA), 1)]
+	[KnownSubType(typeof(DerivedAA), 2)]
+	[KnownSubType(typeof(DerivedB), 3)]
+	[KnownSubType(typeof(EnumerableDerived), 4)]
+	[KnownSubType(typeof(DerivedGeneric<int>), 5)]
 #endif
 	public partial record BaseClass
 	{
@@ -239,8 +248,8 @@ public partial class KnownSubTypeTests(ITestOutputHelper logger) : MessagePackSe
 	[KnownSubType<MixedAliasDerivedA>("A")]
 	[KnownSubType<MixedAliasDerived1>(1)]
 #else
-	[KnownSubType("A", typeof(MixedAliasDerivedA))]
-	[KnownSubType(1, typeof(MixedAliasDerived1))]
+	[KnownSubType(typeof(MixedAliasDerivedA), "A")]
+	[KnownSubType(typeof(MixedAliasDerived1), 1)]
 #endif
 	public partial record MixedAliasBase;
 
@@ -249,6 +258,17 @@ public partial class KnownSubTypeTests(ITestOutputHelper logger) : MessagePackSe
 
 	[GenerateShape]
 	public partial record MixedAliasDerived1 : MixedAliasBase;
+
+	[GenerateShape]
+#if NET
+	[KnownSubType<ImpliedAliasDerived>]
+#else
+	[KnownSubType(typeof(ImpliedAliasDerived))]
+#endif
+	public partial record ImpliedAliasBase;
+
+	[GenerateShape]
+	public partial record ImpliedAliasDerived : ImpliedAliasBase;
 
 	[GenerateShape]
 	public partial record DynamicallyRegisteredBase;
@@ -263,7 +283,7 @@ public partial class KnownSubTypeTests(ITestOutputHelper logger) : MessagePackSe
 #if NET
 	[KnownSubType<RecursiveDerived>(1)]
 #else
-	[KnownSubType(1, typeof(RecursiveDerived))]
+	[KnownSubType(typeof(RecursiveDerived), 1)]
 #endif
 	public partial record RecursiveBase;
 
@@ -271,7 +291,7 @@ public partial class KnownSubTypeTests(ITestOutputHelper logger) : MessagePackSe
 #if NET
 	[KnownSubType<RecursiveDerivedDerived>(13)]
 #else
-	[KnownSubType(13, typeof(RecursiveDerivedDerived))]
+	[KnownSubType(typeof(RecursiveDerivedDerived), 13)]
 #endif
 	public partial record RecursiveDerived : RecursiveBase;
 

--- a/test/Nerdbank.MessagePack.Tests/KnownSubTypeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/KnownSubTypeTests.cs
@@ -93,6 +93,20 @@ public partial class KnownSubTypeTests(ITestOutputHelper logger) : MessagePackSe
 	}
 
 	[Fact]
+	public void MixedAliasTypes()
+	{
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip<MixedAliasBase>(new MixedAliasDerivedA());
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(2, reader.ReadArrayHeader());
+		Assert.Equal("A", reader.ReadString());
+
+		msgpack = this.AssertRoundtrip<MixedAliasBase>(new MixedAliasDerived1());
+		reader = new(msgpack);
+		Assert.Equal(2, reader.ReadArrayHeader());
+		Assert.Equal(1, reader.ReadInt32());
+	}
+
+	[Fact]
 	public void RecursiveSubTypes()
 	{
 		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Serialize<RecursiveBase>(new RecursiveDerivedDerived()));
@@ -219,6 +233,22 @@ public partial class KnownSubTypeTests(ITestOutputHelper logger) : MessagePackSe
 
 	[GenerateShape]
 	public partial record UnknownDerived : BaseClass;
+
+	[GenerateShape]
+#if NET
+	[KnownSubType<MixedAliasDerivedA>("A")]
+	[KnownSubType<MixedAliasDerived1>(1)]
+#else
+	[KnownSubType("A", typeof(MixedAliasDerivedA))]
+	[KnownSubType(1, typeof(MixedAliasDerived1))]
+#endif
+	public partial record MixedAliasBase;
+
+	[GenerateShape]
+	public partial record MixedAliasDerivedA : MixedAliasBase;
+
+	[GenerateShape]
+	public partial record MixedAliasDerived1 : MixedAliasBase;
 
 	[GenerateShape]
 	public partial record DynamicallyRegisteredBase;

--- a/test/Nerdbank.MessagePack.Tests/ReferencePreservationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ReferencePreservationTests.cs
@@ -240,7 +240,7 @@ public partial class ReferencePreservationTests : MessagePackSerializerTestBase
 #if NET
 	[KnownSubType<DerivedRecordA>(1)]
 #else
-	[KnownSubType(1, typeof(DerivedRecordA))]
+	[KnownSubType(typeof(DerivedRecordA), 1)]
 #endif
 	public partial record BaseRecord;
 

--- a/test/Nerdbank.MessagePack.Tests/ReferencePreservationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ReferencePreservationTests.cs
@@ -182,6 +182,42 @@ public partial class ReferencePreservationTests : MessagePackSerializerTestBase
 		Assert.Same(deserializedRoot.Value1, deserializedRoot.Value2);
 	}
 
+	[Fact]
+	public void KnownSubTypes_StaticRegistration()
+	{
+		BaseRecord baseInstance = new BaseRecord();
+		BaseRecord derivedInstance = new DerivedRecordA();
+		BaseRecord[] array = [baseInstance, baseInstance, derivedInstance, derivedInstance];
+
+		BaseRecord[]? deserialized = this.Roundtrip<BaseRecord[], Witness>(array);
+
+		Assert.NotNull(deserialized);
+		Assert.IsType<BaseRecord>(deserialized[0]);
+		Assert.IsType<DerivedRecordA>(deserialized[2]);
+		Assert.Same(deserialized[0], deserialized[1]);
+		Assert.Same(deserialized[2], deserialized[3]);
+	}
+
+	[Fact]
+	public void KnownSubTypes_DynamicRegistration()
+	{
+		KnownSubTypeMapping<BaseRecord> mapping = new();
+		mapping.Add<DerivedRecordB>(1, Witness.ShapeProvider);
+		this.Serializer.RegisterKnownSubTypes(mapping);
+
+		BaseRecord baseInstance = new BaseRecord();
+		BaseRecord derivedInstance = new DerivedRecordB();
+		BaseRecord[] array = [baseInstance, baseInstance, derivedInstance, derivedInstance];
+
+		BaseRecord[]? deserialized = this.Roundtrip<BaseRecord[], Witness>(array);
+
+		Assert.NotNull(deserialized);
+		Assert.IsType<BaseRecord>(deserialized[0]);
+		Assert.IsType<DerivedRecordB>(deserialized[2]);
+		Assert.Same(deserialized[0], deserialized[1]);
+		Assert.Same(deserialized[2], deserialized[3]);
+	}
+
 	[GenerateShape]
 	public partial record RecordWithStrings
 	{
@@ -199,6 +235,20 @@ public partial class ReferencePreservationTests : MessagePackSerializerTestBase
 
 		public object? Value3 { get; init; }
 	}
+
+	[GenerateShape]
+#if NET
+	[KnownSubType<DerivedRecordA>(1)]
+#else
+	[KnownSubType(1, typeof(DerivedRecordA))]
+#endif
+	public partial record BaseRecord;
+
+	[GenerateShape]
+	public partial record DerivedRecordA : BaseRecord;
+
+	[GenerateShape]
+	public partial record DerivedRecordB : BaseRecord;
 
 	[GenerateShape]
 	public partial record CustomType
@@ -285,5 +335,6 @@ public partial class ReferencePreservationTests : MessagePackSerializerTestBase
 	[GenerateShape<CustomTypeWrapper[]>]
 	[GenerateShape<CustomType[]>]
 	[GenerateShape<string[]>]
+	[GenerateShape<BaseRecord[]>]
 	private partial class Witness;
 }

--- a/test/Nerdbank.MessagePack.Tests/SchemaTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/SchemaTests.cs
@@ -339,7 +339,7 @@ public partial class SchemaTests(ITestOutputHelper logger) : MessagePackSerializ
 #if NET
 	[KnownSubType<SubType>(1)]
 #else
-	[KnownSubType(1, typeof(SubType))]
+	[KnownSubType(typeof(SubType), 1)]
 #endif
 	internal partial class BaseType
 	{


### PR DESCRIPTION
- Add support for dynamic registration of sub-types.
- Add support for `string` aliases for known sub-types.
- Add support for inferring a string alias for subtypes using `Type.FullName`.

Closes #36