### PR TITLE
Reference .NET 8 era packages for .NET Standard

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,9 +33,12 @@
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)'!='.NETCoreApp'">
+    <!-- The versions specified here should be the latest ones supported by the OLDEST .NET runtime version that is still supported
+         so that as someone references the .NET Standard version and then runs against the .NET build, they don't get an older
+         dependency than they were expecting or needlessly bring in a 9.0 assembly to an 8.0 runtime. -->
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsAnalyzerProject)'=='true'">
     <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />

--- a/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
+++ b/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
@@ -26,6 +26,8 @@
     <PackageReference Include="Nerdbank.Streams" />
     <PackageReference Include="Newtonsoft.Json.Schema" />
     <PackageReference Include="PolyType.TestCases" />
+    <!-- Override S.T.J. version just until we get a PolyType update that includes https://github.com/eiriktsarpalis/PolyType/pull/90 -->
+    <PackageReference Include="System.Text.Json" VersionOverride="9.0.0" />
     <PackageReference Include="Xunit.Combinatorial" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
That way, we don't bring in .NET 9 packages for .NET 8 apps that include libraries that compiled against .NET Standard 2.0 and referenced _this_ package.