### PR TITLE
To-`RawMessagePack` conversion operators should be explicit

### DIFF
--- a/azure-pipelines/dotnet-test-cloud.ps1
+++ b/azure-pipelines/dotnet-test-cloud.ps1
@@ -50,7 +50,7 @@ if ($x86) {
     --filter "TestCategory!=FailsInCloudTest" `
     --collect "Code Coverage;Format=cobertura" `
     --settings "$PSScriptRoot/test.runsettings" `
-    --blame-hang-timeout 60s `
+    --blame-hang-timeout 120s `
     --blame-crash `
     -bl:"$ArtifactStagingFolder/build_logs/test.binlog" `
     --diag "$ArtifactStagingFolder/test_logs/diag.log;TraceLevel=info" `

--- a/src/Nerdbank.MessagePack/RawMessagePack.cs
+++ b/src/Nerdbank.MessagePack/RawMessagePack.cs
@@ -43,32 +43,32 @@ public struct RawMessagePack : IEquatable<RawMessagePack>
 	public bool IsOwned { get; internal set; }
 
 	/// <summary>
-	/// Implicitly converts a <see cref="ReadOnlySequence{T}"/> of bytes to a <see cref="RawMessagePack"/>.
+	/// Explicitly converts a <see cref="ReadOnlySequence{T}"/> of bytes to a <see cref="RawMessagePack"/>.
 	/// </summary>
 	/// <param name="msgpack">The sequence of MessagePack bytes.</param>
 	/// <returns>A new instance of <see cref="RawMessagePack"/> containing the provided bytes.</returns>
-	public static implicit operator RawMessagePack(ReadOnlySequence<byte> msgpack) => new(msgpack);
+	public static explicit operator RawMessagePack(ReadOnlySequence<byte> msgpack) => new(msgpack);
 
 	/// <summary>
-	/// Implicitly converts a <see cref="ReadOnlyMemory{T}"/> of bytes to a <see cref="RawMessagePack"/>.
+	/// Explicitly converts a <see cref="ReadOnlyMemory{T}"/> of bytes to a <see cref="RawMessagePack"/>.
 	/// </summary>
 	/// <param name="msgpack">The memory containing MessagePack bytes.</param>
 	/// <returns>A new instance of <see cref="RawMessagePack"/> containing the provided bytes.</returns>
-	public static implicit operator RawMessagePack(ReadOnlyMemory<byte> msgpack) => new(new ReadOnlySequence<byte>(msgpack));
+	public static explicit operator RawMessagePack(ReadOnlyMemory<byte> msgpack) => new(new ReadOnlySequence<byte>(msgpack));
 
 	/// <summary>
-	/// Implicitly converts a <see cref="Memory{T}"/> of bytes to a <see cref="RawMessagePack"/>.
+	/// Explicitly converts a <see cref="Memory{T}"/> of bytes to a <see cref="RawMessagePack"/>.
 	/// </summary>
 	/// <param name="msgpack">The memory containing MessagePack bytes.</param>
 	/// <returns>A new instance of <see cref="RawMessagePack"/> containing the provided bytes.</returns>
-	public static implicit operator RawMessagePack(Memory<byte> msgpack) => new(new ReadOnlySequence<byte>(msgpack));
+	public static explicit operator RawMessagePack(Memory<byte> msgpack) => new(new ReadOnlySequence<byte>(msgpack));
 
 	/// <summary>
-	/// Implicitly converts an array of bytes to a <see cref="RawMessagePack"/>.
+	/// Explicitly converts an array of bytes to a <see cref="RawMessagePack"/>.
 	/// </summary>
 	/// <param name="msgpack">The memory containing MessagePack bytes.</param>
 	/// <returns>A new instance of <see cref="RawMessagePack"/> containing the provided bytes.</returns>
-	public static implicit operator RawMessagePack(byte[] msgpack) => new(new ReadOnlySequence<byte>(msgpack));
+	public static explicit operator RawMessagePack(byte[] msgpack) => new(new ReadOnlySequence<byte>(msgpack));
 
 	/// <summary>
 	/// Implicitly converts a <see cref="RawMessagePack"/> to a <see cref="ReadOnlySequence{T}"/> of bytes.

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -468,10 +468,10 @@ static Nerdbank.MessagePack.MessagePackSerializer.ConvertToJson(ref Nerdbank.Mes
 static Nerdbank.MessagePack.MessagePackSerializer.ConvertToJson(System.ReadOnlyMemory<byte> msgpack) -> string!
 static Nerdbank.MessagePack.MessagePackWriter.GetEncodedLength(long value) -> int
 static Nerdbank.MessagePack.MessagePackWriter.GetEncodedLength(ulong value) -> int
-static Nerdbank.MessagePack.RawMessagePack.implicit operator Nerdbank.MessagePack.RawMessagePack(byte[]! msgpack) -> Nerdbank.MessagePack.RawMessagePack
-static Nerdbank.MessagePack.RawMessagePack.implicit operator Nerdbank.MessagePack.RawMessagePack(System.Buffers.ReadOnlySequence<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
-static Nerdbank.MessagePack.RawMessagePack.implicit operator Nerdbank.MessagePack.RawMessagePack(System.Memory<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
-static Nerdbank.MessagePack.RawMessagePack.implicit operator Nerdbank.MessagePack.RawMessagePack(System.ReadOnlyMemory<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
+static Nerdbank.MessagePack.RawMessagePack.explicit operator Nerdbank.MessagePack.RawMessagePack(byte[]! msgpack) -> Nerdbank.MessagePack.RawMessagePack
+static Nerdbank.MessagePack.RawMessagePack.explicit operator Nerdbank.MessagePack.RawMessagePack(System.Buffers.ReadOnlySequence<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
+static Nerdbank.MessagePack.RawMessagePack.explicit operator Nerdbank.MessagePack.RawMessagePack(System.Memory<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
+static Nerdbank.MessagePack.RawMessagePack.explicit operator Nerdbank.MessagePack.RawMessagePack(System.ReadOnlyMemory<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
 static Nerdbank.MessagePack.RawMessagePack.implicit operator System.Buffers.ReadOnlySequence<byte>(Nerdbank.MessagePack.RawMessagePack msgpack) -> System.Buffers.ReadOnlySequence<byte>
 static readonly Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.Default -> Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode!
 virtual Nerdbank.MessagePack.KnownSubTypeAttribute.Shape.get -> PolyType.Abstractions.ITypeShape?

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -427,10 +427,10 @@ static Nerdbank.MessagePack.MessagePackSerializer.ConvertToJson(ref Nerdbank.Mes
 static Nerdbank.MessagePack.MessagePackSerializer.ConvertToJson(System.ReadOnlyMemory<byte> msgpack) -> string!
 static Nerdbank.MessagePack.MessagePackWriter.GetEncodedLength(long value) -> int
 static Nerdbank.MessagePack.MessagePackWriter.GetEncodedLength(ulong value) -> int
-static Nerdbank.MessagePack.RawMessagePack.implicit operator Nerdbank.MessagePack.RawMessagePack(byte[]! msgpack) -> Nerdbank.MessagePack.RawMessagePack
-static Nerdbank.MessagePack.RawMessagePack.implicit operator Nerdbank.MessagePack.RawMessagePack(System.Buffers.ReadOnlySequence<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
-static Nerdbank.MessagePack.RawMessagePack.implicit operator Nerdbank.MessagePack.RawMessagePack(System.Memory<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
-static Nerdbank.MessagePack.RawMessagePack.implicit operator Nerdbank.MessagePack.RawMessagePack(System.ReadOnlyMemory<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
+static Nerdbank.MessagePack.RawMessagePack.explicit operator Nerdbank.MessagePack.RawMessagePack(byte[]! msgpack) -> Nerdbank.MessagePack.RawMessagePack
+static Nerdbank.MessagePack.RawMessagePack.explicit operator Nerdbank.MessagePack.RawMessagePack(System.Buffers.ReadOnlySequence<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
+static Nerdbank.MessagePack.RawMessagePack.explicit operator Nerdbank.MessagePack.RawMessagePack(System.Memory<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
+static Nerdbank.MessagePack.RawMessagePack.explicit operator Nerdbank.MessagePack.RawMessagePack(System.ReadOnlyMemory<byte> msgpack) -> Nerdbank.MessagePack.RawMessagePack
 static Nerdbank.MessagePack.RawMessagePack.implicit operator System.Buffers.ReadOnlySequence<byte>(Nerdbank.MessagePack.RawMessagePack msgpack) -> System.Buffers.ReadOnlySequence<byte>
 static readonly Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.Default -> Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode!
 virtual Nerdbank.MessagePack.KnownSubTypeAttribute.Shape.get -> PolyType.Abstractions.ITypeShape?

--- a/test/Nerdbank.MessagePack.Tests/RawMessagePackTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/RawMessagePackTests.cs
@@ -23,7 +23,7 @@ public partial class RawMessagePackTests(ITestOutputHelper logger) : MessagePack
 	public void DeferredSerialization()
 	{
 		DeferredData userData = new() { UserString = "Hello, World!" };
-		Envelope envelope = new() { Deferred = this.Serializer.Serialize(userData) };
+		Envelope envelope = new() { Deferred = (RawMessagePack)this.Serializer.Serialize(userData) };
 
 		Envelope? deserializedEnvelope = this.Roundtrip(envelope);
 
@@ -38,7 +38,7 @@ public partial class RawMessagePackTests(ITestOutputHelper logger) : MessagePack
 	public async Task DeferredSerializationAsync()
 	{
 		DeferredData userData = new() { UserString = "Hello, World!" };
-		Envelope envelope = new() { Deferred = this.Serializer.Serialize(userData) };
+		Envelope envelope = new() { Deferred = (RawMessagePack)this.Serializer.Serialize(userData) };
 
 		Envelope? deserializedEnvelope = await this.RoundtripAsync(envelope);
 
@@ -88,7 +88,7 @@ public partial class RawMessagePackTests(ITestOutputHelper logger) : MessagePack
 	public void ToOwned_NonEmpty()
 	{
 		// Verify that we consider an initial version to be borrowed.
-		RawMessagePack msgpack = new byte[] { 1, 2, 3 };
+		RawMessagePack msgpack = (RawMessagePack)new byte[] { 1, 2, 3 };
 		Assert.False(msgpack.IsOwned);
 		ReadOnlySequence<byte> borrowedSequence = msgpack.MsgPack;
 


### PR DESCRIPTION
"Downcasts" should be explicit while upcasts remain implicit.
