### PR TITLE
Add friendlier `MessagePackWriter.Write(MessagePackString)` method

### DIFF
--- a/samples/CustomConverters.cs
+++ b/samples/CustomConverters.cs
@@ -445,10 +445,10 @@ namespace PerformanceConverters
             writer.WriteMapHeader(2);
 
             // Write the pre-encoded msgpack for the property names to avoid repeatedly paying encoding costs.
-            writer.WriteRaw(Message1.MsgPack.Span);
+            writer.Write(Message1);
             writer.Write(value.Message1);
 
-            writer.WriteRaw(Message2.MsgPack.Span);
+            writer.Write(Message2);
             writer.Write(value.Message2);
         }
     }

--- a/src/Nerdbank.MessagePack/MessagePackWriter.cs
+++ b/src/Nerdbank.MessagePack/MessagePackWriter.cs
@@ -674,6 +674,12 @@ public ref struct MessagePackWriter
 	}
 
 	/// <summary>
+	/// Writes a pre-encoded msgpack string.
+	/// </summary>
+	/// <param name="value">The string to write.</param>
+	public void Write(MessagePackString value) => this.WriteRaw(Requires.NotNull(value).MsgPack.Span);
+
+	/// <summary>
 	/// Writes the extension format header, using the smallest one of these codes:
 	/// <see cref="MessagePackCode.FixExt1"/>,
 	/// <see cref="MessagePackCode.FixExt2"/>,

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -351,6 +351,7 @@ Nerdbank.MessagePack.MessagePackWriter.Write(int value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(long value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(Nerdbank.MessagePack.Extension extensionData) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(Nerdbank.MessagePack.ExtensionHeader extensionHeader) -> void
+Nerdbank.MessagePack.MessagePackWriter.Write(Nerdbank.MessagePack.MessagePackString! value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(sbyte value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(short value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(string? value) -> void

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -317,6 +317,7 @@ Nerdbank.MessagePack.MessagePackWriter.Write(int value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(long value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(Nerdbank.MessagePack.Extension extensionData) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(Nerdbank.MessagePack.ExtensionHeader extensionHeader) -> void
+Nerdbank.MessagePack.MessagePackWriter.Write(Nerdbank.MessagePack.MessagePackString! value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(sbyte value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(short value) -> void
 Nerdbank.MessagePack.MessagePackWriter.Write(string? value) -> void

--- a/test/Nerdbank.MessagePack.Tests/MessagePackWriterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackWriterTests.cs
@@ -112,6 +112,19 @@ public class MessagePackWriterTests
 	}
 
 	[Fact]
+	public void Write_MessagePackString()
+	{
+		MessagePackString msgpackString = new("abc");
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.Write(msgpackString);
+		writer.Flush();
+
+		MessagePackReader reader = new(seq);
+		Assert.Equal("abc", reader.ReadString());
+	}
+
+	[Fact]
 	public void WriteBinHeader()
 	{
 		var sequence = new Sequence<byte>();


### PR DESCRIPTION
Hopefully reduce the need for the analyzer requested in #198.