### PR TITLE
Decode strings incrementally during async deserialization

### DIFF
--- a/src/Nerdbank.MessagePack/BufferWriter.cs
+++ b/src/Nerdbank.MessagePack/BufferWriter.cs
@@ -43,9 +43,9 @@ internal ref struct BufferWriter
 	/// </summary>
 	private int buffered;
 
-	private SequencePool? sequencePool;
+	private SequencePool<byte>? sequencePool;
 
-	private SequencePool.Rental rental;
+	private SequencePool<byte>.Rental rental;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="BufferWriter"/> struct.
@@ -82,7 +82,7 @@ internal ref struct BufferWriter
 	/// <param name="sequencePool">The pool from which to draw an <see cref="IBufferWriter{T}"/> if required..</param>
 	/// <param name="array">An array to start with so we can avoid accessing the <paramref name="sequencePool"/> if possible.</param>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	internal BufferWriter(SequencePool sequencePool, byte[] array)
+	internal BufferWriter(SequencePool<byte> sequencePool, byte[] array)
 	{
 		this.sequencePool = sequencePool ?? throw new ArgumentNullException(nameof(sequencePool));
 
@@ -103,7 +103,7 @@ internal ref struct BufferWriter
 	/// <summary>
 	/// Gets the rental.
 	/// </summary>
-	internal SequencePool.Rental SequenceRental => this.rental;
+	internal SequencePool<byte>.Rental SequenceRental => this.rental;
 
 	/// <summary>
 	/// Gets the <see cref="BufferMemoryWriter"/> underlying this writer.

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.FriendlyOverloads.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.FriendlyOverloads.cs
@@ -30,7 +30,7 @@ public partial record MessagePackSerializer
 		(byte[] array, scratchArray) = (scratchArray ?? new byte[65536], null);
 		try
 		{
-			MessagePackWriter writer = new(SequencePool.Shared, array);
+			MessagePackWriter writer = new(SequencePool<byte>.Shared, array);
 			this.Serialize(ref writer, value, shape, cancellationToken);
 			return writer.FlushAndGetArray();
 		}
@@ -95,7 +95,7 @@ public partial record MessagePackSerializer
 		(byte[] array, scratchArray) = (scratchArray ?? new byte[65536], null);
 		try
 		{
-			MessagePackWriter writer = new(SequencePool.Shared, array);
+			MessagePackWriter writer = new(SequencePool<byte>.Shared, array);
 			this.Serialize(ref writer, value, provider, cancellationToken);
 			return writer.FlushAndGetArray();
 		}
@@ -187,7 +187,7 @@ public partial record MessagePackSerializer
 		else
 		{
 			// We don't have a streaming msgpack reader, so buffer it all into memory instead and read from there.
-			using SequencePool.Rental rental = SequencePool.Shared.Rent();
+			using SequencePool<byte>.Rental rental = SequencePool<byte>.Shared.Rent();
 			int bytesLastRead;
 			do
 			{
@@ -263,7 +263,7 @@ public partial record MessagePackSerializer
 		else
 		{
 			// We don't have a streaming msgpack reader, so buffer it all into memory instead and read from there.
-			using SequencePool.Rental rental = SequencePool.Shared.Rent();
+			using SequencePool<byte>.Rental rental = SequencePool<byte>.Shared.Rent();
 			int bytesLastRead;
 			do
 			{

--- a/src/Nerdbank.MessagePack/MessagePackWriter.cs
+++ b/src/Nerdbank.MessagePack/MessagePackWriter.cs
@@ -37,7 +37,7 @@ public ref struct MessagePackWriter
 	/// </summary>
 	/// <param name="sequencePool">The pool from which to draw an <see cref="IBufferWriter{T}"/> if required..</param>
 	/// <param name="array">An array to start with so we can avoid accessing the <paramref name="sequencePool"/> if possible.</param>
-	internal MessagePackWriter(SequencePool sequencePool, byte[] array)
+	internal MessagePackWriter(SequencePool<byte> sequencePool, byte[] array)
 		: this()
 	{
 		this.writer = new BufferWriter(sequencePool, array);

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -275,7 +275,7 @@ Nerdbank.MessagePack.MessagePackStreamingReader.BufferRefresh
 Nerdbank.MessagePack.MessagePackStreamingReader.BufferRefresh.BufferRefresh() -> void
 Nerdbank.MessagePack.MessagePackStreamingReader.CancellationToken.get -> System.Threading.CancellationToken
 Nerdbank.MessagePack.MessagePackStreamingReader.CancellationToken.init -> void
-Nerdbank.MessagePack.MessagePackStreamingReader.FetchMoreBytesAsync() -> System.Threading.Tasks.ValueTask<Nerdbank.MessagePack.MessagePackStreamingReader.BufferRefresh>
+Nerdbank.MessagePack.MessagePackStreamingReader.FetchMoreBytesAsync(uint minimumLength = 1) -> System.Threading.Tasks.ValueTask<Nerdbank.MessagePack.MessagePackStreamingReader.BufferRefresh>
 Nerdbank.MessagePack.MessagePackStreamingReader.GetExchangeInfo() -> Nerdbank.MessagePack.MessagePackStreamingReader.BufferRefresh
 Nerdbank.MessagePack.MessagePackStreamingReader.GetMoreBytesAsync
 Nerdbank.MessagePack.MessagePackStreamingReader.MessagePackStreamingReader() -> void

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -303,10 +303,12 @@ Nerdbank.MessagePack.MessagePackStreamingReader.TryRead(out ulong value) -> Nerd
 Nerdbank.MessagePack.MessagePackStreamingReader.TryRead(out ushort value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadArrayHeader(out int count) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadBinary(out System.Buffers.ReadOnlySequence<byte> value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
+Nerdbank.MessagePack.MessagePackStreamingReader.TryReadBinHeader(out uint length) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadMapHeader(out int count) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadNil() -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadNil(out bool isNil) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadRaw(long length, out System.Buffers.ReadOnlySequence<byte> rawMsgPack) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
+Nerdbank.MessagePack.MessagePackStreamingReader.TryReadStringHeader(out uint length) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadStringSequence(out System.Buffers.ReadOnlySequence<byte> value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadStringSpan(out bool contiguous, out System.ReadOnlySpan<byte> value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TrySkip(ref Nerdbank.MessagePack.SerializationContext context) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -269,10 +269,12 @@ Nerdbank.MessagePack.MessagePackStreamingReader.TryRead(out ulong value) -> Nerd
 Nerdbank.MessagePack.MessagePackStreamingReader.TryRead(out ushort value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadArrayHeader(out int count) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadBinary(out System.Buffers.ReadOnlySequence<byte> value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
+Nerdbank.MessagePack.MessagePackStreamingReader.TryReadBinHeader(out uint length) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadMapHeader(out int count) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadNil() -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadNil(out bool isNil) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadRaw(long length, out System.Buffers.ReadOnlySequence<byte> rawMsgPack) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
+Nerdbank.MessagePack.MessagePackStreamingReader.TryReadStringHeader(out uint length) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadStringSequence(out System.Buffers.ReadOnlySequence<byte> value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryReadStringSpan(out bool contiguous, out System.ReadOnlySpan<byte> value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TrySkip(ref Nerdbank.MessagePack.SerializationContext context) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -241,6 +241,7 @@ Nerdbank.MessagePack.MessagePackStreamingReader.BufferRefresh
 Nerdbank.MessagePack.MessagePackStreamingReader.BufferRefresh.BufferRefresh() -> void
 Nerdbank.MessagePack.MessagePackStreamingReader.CancellationToken.get -> System.Threading.CancellationToken
 Nerdbank.MessagePack.MessagePackStreamingReader.CancellationToken.init -> void
+Nerdbank.MessagePack.MessagePackStreamingReader.FetchMoreBytesAsync(uint minimumLength = 1) -> System.Threading.Tasks.ValueTask<Nerdbank.MessagePack.MessagePackStreamingReader.BufferRefresh>
 Nerdbank.MessagePack.MessagePackStreamingReader.GetExchangeInfo() -> Nerdbank.MessagePack.MessagePackStreamingReader.BufferRefresh
 Nerdbank.MessagePack.MessagePackStreamingReader.GetMoreBytesAsync
 Nerdbank.MessagePack.MessagePackStreamingReader.MessagePackStreamingReader() -> void
@@ -248,7 +249,6 @@ Nerdbank.MessagePack.MessagePackStreamingReader.MessagePackStreamingReader(scope
 Nerdbank.MessagePack.MessagePackStreamingReader.MessagePackStreamingReader(scoped in System.Buffers.ReadOnlySequence<byte> sequence) -> void
 Nerdbank.MessagePack.MessagePackStreamingReader.MessagePackStreamingReader(scoped in System.Buffers.ReadOnlySequence<byte> sequence, Nerdbank.MessagePack.MessagePackStreamingReader.GetMoreBytesAsync? additionalBytesSource, object? getMoreBytesState) -> void
 Nerdbank.MessagePack.MessagePackStreamingReader.Position.get -> System.SequencePosition
-Nerdbank.MessagePack.MessagePackStreamingReader.FetchMoreBytesAsync() -> System.Threading.Tasks.ValueTask<Nerdbank.MessagePack.MessagePackStreamingReader.BufferRefresh>
 Nerdbank.MessagePack.MessagePackStreamingReader.TryPeekNextCode(out byte code) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryPeekNextMessagePackType(out Nerdbank.MessagePack.MessagePackType type) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 Nerdbank.MessagePack.MessagePackStreamingReader.TryRead(Nerdbank.MessagePack.ExtensionHeader extensionHeader, out System.DateTime value) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult


### PR DESCRIPTION
This doesn't change how we work when _interning_ strings.
It also doesn't incrementally _encode_ strings during async serialization. But we could add that if needed.