### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,21 +1,25 @@
 {
   "name": "Dev space",
   "dockerFile": "Dockerfile",
-  "settings": {
-    "terminal.integrated.shell.linux": "/usr/bin/pwsh"
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/usr/bin/pwsh"
+      },
+      "extensions": [
+        "ms-azure-devops.azure-pipelines",
+        "ms-dotnettools.csharp",
+        "k--kato.docomment",
+        "editorconfig.editorconfig",
+        "esbenp.prettier-vscode",
+        "pflannery.vscode-versionlens",
+        "davidanson.vscode-markdownlint",
+        "dotjoshjohnson.xml",
+        "ms-vscode-remote.remote-containers",
+        "ms-azuretools.vscode-docker",
+        "tintoy.msbuild-project-tools"
+      ]
+    }
   },
-  "postCreateCommand": "./init.ps1 -InstallLocality machine",
-  "extensions": [
-    "ms-azure-devops.azure-pipelines",
-    "ms-dotnettools.csharp",
-    "k--kato.docomment",
-    "editorconfig.editorconfig",
-    "esbenp.prettier-vscode",
-    "pflannery.vscode-versionlens",
-    "davidanson.vscode-markdownlint",
-    "dotjoshjohnson.xml",
-    "ms-vscode-remote.remote-containers",
-    "ms-azuretools.vscode-docker",
-    "tintoy.msbuild-project-tools"
-  ]
+  "postCreateCommand": "./init.ps1 -InstallLocality machine"
 }

--- a/.github/.editorconfig
+++ b/.github/.editorconfig
@@ -1,0 +1,2 @@
+[renovate.json*]
+indent_style = tab

--- a/.github/actions/publish-artifacts/action.yaml
+++ b/.github/actions/publish-artifacts/action.yaml
@@ -32,13 +32,6 @@ runs:
       name: build_logs-${{ runner.os }}
       path: ${{ runner.temp }}/_artifacts/build_logs
     continue-on-error: true
-  - name: 📢 Upload test_logs
-    if: always()
-    uses: actions/upload-artifact@v4
-    with:
-      name: test_logs-${{ runner.os }}
-      path: ${{ runner.temp }}/_artifacts/test_logs
-    continue-on-error: true
   - name: 📢 Upload testResults
     if: always()
     uses: actions/upload-artifact@v4

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,8 +42,8 @@
   </ItemGroup>
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageVersion Include="xunit.v3" Version="1.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="xunit.v3" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="3.11.0-beta1.24527.2" />

--- a/tools/Get-ArtifactsStagingDirectory.ps1
+++ b/tools/Get-ArtifactsStagingDirectory.ps1
@@ -4,7 +4,7 @@ Param(
 if ($env:BUILD_ARTIFACTSTAGINGDIRECTORY) {
     $ArtifactStagingFolder = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 } elseif ($env:RUNNER_TEMP) {
-    $ArtifactStagingFolder = "$env:RUNNER_TEMP\_artifacts"
+    $ArtifactStagingFolder = Join-Path $env:RUNNER_TEMP _artifacts
 } else {
     $ArtifactStagingFolder = [System.IO.Path]::GetFullPath("$PSScriptRoot/../obj/_artifacts")
     if ($CleanIfLocal -and (Test-Path $ArtifactStagingFolder)) {

--- a/tools/artifacts/_stage_all.ps1
+++ b/tools/artifacts/_stage_all.ps1
@@ -11,7 +11,7 @@ param (
     [switch]$AvoidSymbolicLinks
 )
 
-$ArtifactStagingFolder = & "$PSScriptRoot/../../tools/Get-ArtifactsStagingDirectory.ps1" -CleanIfLocal
+$ArtifactStagingFolder = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1" -CleanIfLocal
 
 function Create-SymbolicLink {
     param (

--- a/tools/artifacts/build_logs.ps1
+++ b/tools/artifacts/build_logs.ps1
@@ -1,4 +1,4 @@
-$ArtifactStagingFolder = & "$PSScriptRoot/../../tools/Get-ArtifactsStagingDirectory.ps1"
+$ArtifactStagingFolder = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1"
 
 if (!(Test-Path $ArtifactStagingFolder/build_logs)) { return }
 

--- a/tools/artifacts/testResults.ps1
+++ b/tools/artifacts/testResults.ps1
@@ -7,9 +7,10 @@ $result = @{}
 $testRoot = Resolve-Path "$PSScriptRoot\..\..\test"
 $result[$testRoot] = (Get-ChildItem "$testRoot\TestResults" -Recurse -Directory | Get-ChildItem -Recurse -File)
 
-$testlogsPath = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY\test_logs"
+$artifactStaging = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1"
+$testlogsPath = Join-Path $artifactStaging "test_logs"
 if (Test-Path $testlogsPath) {
-    $result[$testlogsPath] = Get-ChildItem "$testlogsPath\*";
+    $result[$testlogsPath] = Get-ChildItem $testlogsPath -Recurse;
 }
 
 $result

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -44,6 +44,9 @@ if ($x86) {
   }
 }
 
+$testBinLog = Join-Path $ArtifactStagingFolder (Join-Path build_logs test.binlog)
+$testDiagLog = Join-Path $ArtifactStagingFolder (Join-Path test_logs diag.log)
+
 & $dotnet test $RepoRoot `
     --no-build `
     -c $Configuration `
@@ -52,8 +55,8 @@ if ($x86) {
     --settings "$PSScriptRoot/test.runsettings" `
     --blame-hang-timeout 120s `
     --blame-crash `
-    -bl:"$ArtifactStagingFolder/build_logs/test.binlog" `
-    --diag "$ArtifactStagingFolder/test_logs/diag.log;TraceLevel=info" `
+    -bl:"$testBinLog" `
+    --diag "$testDiagLog;TraceLevel=info" `
     --logger trx `
 
 $unknownCounter = 0
@@ -65,7 +68,7 @@ Get-ChildItem -Recurse -Path $RepoRoot\test\*.trx |% {
     $runTitle = $null
     if ($x.TestRun.TestDefinitions -and $x.TestRun.TestDefinitions.GetElementsByTagName('UnitTest')) {
       $storage = $x.TestRun.TestDefinitions.GetElementsByTagName('UnitTest')[0].storage -replace '\\','/'
-      if ($storage -match '/(?<tfm>net[^/]+)/(?:(?<rid>[^/]+)/)?(?<lib>[^/]+)\.dll$') {
+      if ($storage -match '/(?<tfm>net[^/]+)/(?:(?<rid>[^/]+)/)?(?<lib>[^/]+)\.(dll|exe)$') {
         if ($matches.rid) {
           $runTitle = "$($matches.lib) ($($matches.tfm), $($matches.rid), $Agent)"
         } else {


### PR DESCRIPTION
- Drop renovate PR hourly limit back to default
- Use JSON5 for renovate configuration
- Update devcontainer schema
- Rename renovate config back to .json
- Fix test logs collection
- Take care to use proper slashes per OS for testing
- Match test assemblies that are built as exe's
- Ensure Expand-Template uses UTF-8 when replacing placeholders.
- Simplify certain ps1 script paths
- Update xunit (#336)
