### PR TITLE
Implement support for surrogates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <RoslynVersion>4.12.0</RoslynVersion>
     <RoslynVersionForAnalyzers>4.11.0</RoslynVersionForAnalyzers>
     <CodeAnalysisAnalyzerVersion>3.11.0-beta1.24605.2</CodeAnalysisAnalyzerVersion>
-    <PolyTypeVersion>0.24.1</PolyTypeVersion>
+    <PolyTypeVersion>0.25.1</PolyTypeVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />

--- a/docfx/docs/byvalue-equality.md
+++ b/docfx/docs/byvalue-equality.md
@@ -8,7 +8,7 @@ Even when types override these methods, they are often not implemented for _deep
 This is particularly true when a type contains collection members, since testing a collection's contents for by-value equality of each element can be difficult.
 
 Nerdbank.MessagePack alleviates these difficulties somewhat by providing deep, by-value equality testing and hashing for arbitrary types, using the same @PolyType.GenerateShapeAttribute technology that it uses for serialization.
-It does this via the @Nerdbank.MessagePack.ByValueEqualityComparer.GetDefault\*?displayProperty=nameWithType method, which returns an instance of @System.Collections.Generic.IEqualityComparer`1 for the specified type that provides deep, by-value checking and hashing.
+It does this via the @"Nerdbank.MessagePack.ByValueEqualityComparer.GetDefault*?displayProperty=nameWithType" method, which returns an instance of @System.Collections.Generic.IEqualityComparer`1 for the specified type that provides deep, by-value checking and hashing.
 
 Here is an example of using this for by-value equality checking for a user-defined type that does not implement it itself:
 

--- a/docfx/docs/custom-converters.md
+++ b/docfx/docs/custom-converters.md
@@ -1,7 +1,10 @@
 # Custom converters
 
-While using the [`GenerateShapeAttribute`](xref:PolyType.GenerateShapeAttribute) is by far the simplest way to make an entire type graph serializable, some types may not be compatible with automatic serialization.
+While using the @PolyType.GenerateShapeAttribute is by far the simplest way to make an entire type graph serializable, some types may not be compatible with automatic serialization.
 In such cases, you can define and register your own custom converter for the incompatible type.
+
+Before writing your own converter for a custom type, consider writing a [surrogate type](surrogate-types.md) instead.
+Surrogate types are simpler and utilize efficient, tested converters that are automatically generated.
 
 ## Define your own converter
 

--- a/docfx/docs/migrating.md
+++ b/docfx/docs/migrating.md
@@ -20,6 +20,7 @@ Polymorphic serialization | [✅](unions.md) | [✅](https://github.com/MessageP
 Skip serializing default values | [✅](xref:Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues) | [❌](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/678) |
 Dynamically use maps or arrays for most compact format | [✅](customizing-serialization.md#array-or-map) | [❌](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/1953) |
 Typeless serialization    | ❌ | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#typeless) |
+Surrogate types for automatic serialization of unserializable types | [✅](surrogate-types.md) | ❌ |
 Custom converters         | [✅](custom-converters.md) | ✅ |
 Stateful converters       | [✅](custom-converters.md#stateful-converters) | ❌ |
 Deserialization callback  | ❌ | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#serialization-callback) |

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -7,6 +7,7 @@ items:
   href: unions.md
 - name: Customizing serialization
   href: customizing-serialization.md
+- href: surrogate-types.md
 - name: Custom converters
   href: custom-converters.md
 - name: Performance

--- a/samples/SurrogateTypes.cs
+++ b/samples/SurrogateTypes.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OnlyOriginalType
+{
+    #region OnlyOriginalType
+    [GenerateShape]
+    public partial class OriginalType
+    {
+        private int a;
+        private int b;
+
+        public OriginalType(int a, int b)
+        {
+            this.a = a;
+            this.b = b;
+        }
+
+        public int Sum => this.a + this.b;
+    }
+    #endregion
+}
+
+namespace FocusOnAddedTypes
+{
+    [GenerateShape]
+    [TypeShape(Marshaller = typeof(MyTypeMarshaller))]
+    public partial class OriginalType
+    {
+        private int a;
+        private int b;
+
+        public OriginalType(int a, int b)
+        {
+            this.a = a;
+            this.b = b;
+        }
+
+        public int Sum => this.a + this.b;
+
+        #region SurrogateType
+        internal record struct MarshaledType(int A, int B);
+        #endregion
+
+        #region Marshaler
+        internal class MyTypeMarshaller : IMarshaller<OriginalType, MarshaledType?>
+        {
+            public MarshaledType? ToSurrogate(OriginalType? value)
+                => value is null ? null : new(value.a, value.b);
+
+            public OriginalType? FromSurrogate(MarshaledType? surrogate)
+                => surrogate.HasValue ? new(surrogate.Value.A, surrogate.Value.B) : null;
+        }
+        #endregion
+    }
+}
+
+namespace CompleteSample
+{
+    #region CompleteSample
+    [GenerateShape]
+    [TypeShape(Marshaller = typeof(MyTypeMarshaller))]
+    public partial class OriginalType
+    {
+        private int a;
+        private int b;
+
+        public OriginalType(int a, int b)
+        {
+            this.a = a;
+            this.b = b;
+        }
+
+        public int Sum => this.a + this.b;
+
+        internal record struct MarshaledType(int A, int B);
+
+        internal class MyTypeMarshaller : IMarshaller<OriginalType, MarshaledType?>
+        {
+            public MarshaledType? ToSurrogate(OriginalType? value)
+                => value is null ? null : new(value.a, value.b);
+
+            public OriginalType? FromSurrogate(MarshaledType? surrogate)
+                => surrogate.HasValue ? new(surrogate.Value.A, surrogate.Value.B) : null;
+        }
+    }
+    #endregion
+}

--- a/src/Nerdbank.MessagePack/ByValueEqualityComparer.cs
+++ b/src/Nerdbank.MessagePack/ByValueEqualityComparer.cs
@@ -37,6 +37,8 @@ namespace Nerdbank.MessagePack;
 /// But if the type is referenced in a type reference graph such that is used for by-value comparison,
 /// implementing <see cref="IDeepSecureEqualityComparer{T}"/> on that type will allow the type to take control
 /// of just its contribution to the hash code and equality comparison.
+/// <see cref="TypeShapeAttribute.Marshaller">Type surrogates</see> may alternatively be used for a
+/// simpler way to guide the comparison of a type.
 /// </para>
 /// <para>
 /// Types that define no (public or opted in) properties and do not implement <see cref="IDeepSecureEqualityComparer{T}"/> will throw a <see cref="NotSupportedException"/> when attempting to create an equality comparer.

--- a/src/Nerdbank.MessagePack/Converters/SurrogateConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/SurrogateConverter`2.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
+
+namespace Nerdbank.MessagePack.Converters;
+
+/// <summary>
+/// A converter that uses a surrogate type to serialize and deserialize a type.
+/// </summary>
+/// <typeparam name="T">The type to be serialized.</typeparam>
+/// <typeparam name="TSurrogate">the type of surrogate to be used.</typeparam>
+/// <param name="shape">The shape of the type with a surrogate.</param>
+/// <param name="surrogateConverter">The surrogate converter.</param>
+internal class SurrogateConverter<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> shape, MessagePackConverter<TSurrogate> surrogateConverter)
+	: MessagePackConverter<T>
+{
+	/// <inheritdoc/>
+	public override bool PreferAsyncSerialization => surrogateConverter.PreferAsyncSerialization;
+
+	/// <inheritdoc/>
+	public override T? Read(ref MessagePackReader reader, SerializationContext context)
+		=> shape.Marshaller.FromSurrogate(surrogateConverter.Read(ref reader, context));
+
+	/// <inheritdoc/>
+	public override void Write(ref MessagePackWriter writer, in T? value, SerializationContext context)
+		=> surrogateConverter.Write(ref writer, shape.Marshaller.ToSurrogate(value), context);
+
+	/// <inheritdoc/>
+	[Experimental("NBMsgPackAsync")]
+	public override async ValueTask<T?> ReadAsync(MessagePackAsyncReader reader, SerializationContext context)
+		=> shape.Marshaller.FromSurrogate(await surrogateConverter.ReadAsync(reader, context).ConfigureAwait(false));
+
+	/// <inheritdoc/>
+	[Experimental("NBMsgPackAsync")]
+	public override ValueTask WriteAsync(MessagePackAsyncWriter writer, T? value, SerializationContext context)
+		=> surrogateConverter.WriteAsync(writer, shape.Marshaller.ToSurrogate(value), context);
+
+	/// <inheritdoc/>
+	public override JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape)
+		=> surrogateConverter.GetJsonSchema(context, shape.SurrogateType);
+}

--- a/src/Nerdbank.MessagePack/ReferencePreservingVisitor.cs
+++ b/src/Nerdbank.MessagePack/ReferencePreservingVisitor.cs
@@ -28,4 +28,8 @@ internal class ReferencePreservingVisitor(ITypeShapeVisitor inner) : TypeShapeVi
 	/// <inheritdoc/>
 	public override object? VisitObject<T>(IObjectTypeShape<T> objectShape, object? state = null)
 		=> ((IMessagePackConverterInternal)inner.VisitObject(objectShape, state)!).WrapWithReferencePreservation();
+
+	/// <inheritdoc/>
+	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
+		=> ((IMessagePackConverterInternal)inner.VisitSurrogate(surrogateShape, state)!).WrapWithReferencePreservation();
 }

--- a/src/Nerdbank.MessagePack/SecureHash/ByValueVisitor.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/ByValueVisitor.cs
@@ -67,6 +67,10 @@ internal class ByValueVisitor(TypeGenerationContext context) : TypeShapeVisitor,
 	public override object? VisitNullable<T>(INullableTypeShape<T> nullableShape, object? state = null)
 		=> new ByValueNullableEqualityComparer<T>(this.GetEqualityComparer(nullableShape.ElementType));
 
+	/// <inheritdoc/>
+	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
+		=> new SurrogateEqualityComparer<T, TSurrogate>(surrogateShape.Marshaller, this.GetEqualityComparer(surrogateShape.SurrogateType, state));
+
 	/// <summary>
 	/// Gets or creates an equality comparer for the given type shape.
 	/// </summary>

--- a/src/Nerdbank.MessagePack/SecureHash/SecureVisitor.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecureVisitor.cs
@@ -116,6 +116,10 @@ internal class SecureVisitor(TypeGenerationContext context) : TypeShapeVisitor, 
 	public override object? VisitNullable<T>(INullableTypeShape<T> nullableShape, object? state = null)
 		=> new SecureNullableEqualityComparer<T>(this.GetEqualityComparer(nullableShape.ElementType));
 
+	/// <inheritdoc/>
+	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
+		=> new SurrogateSecureEqualityComparer<T, TSurrogate>(surrogateShape.Marshaller, this.GetEqualityComparer(surrogateShape.SurrogateType, state));
+
 	/// <summary>
 	/// Gets or creates an equality comparer for the given type shape.
 	/// </summary>

--- a/src/Nerdbank.MessagePack/SecureHash/SurrogateEqualityComparer`2.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SurrogateEqualityComparer`2.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETSTANDARD
+#pragma warning disable CS8604 // Possible null reference argument.
+#pragma warning disable CS8767 // Nullability of type of parameter doesn't match overridden member (possibly because of nullability attributes).
+#endif
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// An <see cref="IEqualityComparer{T}"/> that operates on values through their surrogates.
+/// </summary>
+/// <typeparam name="T">The type of value to be compared.</typeparam>
+/// <typeparam name="TSurrogate">The type of surrogate to use instead of the value directly.</typeparam>
+/// <param name="marshaller">The means to convert between a value and its surrogate.</param>
+/// <param name="surrogateComparer">The comparer that operates directly on the surrogate.</param>
+internal class SurrogateEqualityComparer<T, TSurrogate>(IMarshaller<T, TSurrogate> marshaller, IEqualityComparer<TSurrogate> surrogateComparer)
+	: IEqualityComparer<T>
+{
+	/// <inheritdoc/>
+	public bool Equals(T? x, T? y)
+		=> surrogateComparer.Equals(marshaller.ToSurrogate(x), marshaller.ToSurrogate(y));
+
+	/// <inheritdoc/>
+	public int GetHashCode([DisallowNull] T obj)
+		=> marshaller.ToSurrogate(obj) is TSurrogate surrogate ? surrogateComparer.GetHashCode(surrogate) : 0;
+}

--- a/src/Nerdbank.MessagePack/SecureHash/SurrogateSecureEqualityComparer`2.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SurrogateSecureEqualityComparer`2.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.SecureHash;
+
+/// <summary>
+/// A <see cref="SecureEqualityComparer{T}"/> that operates on values through their surrogates.
+/// </summary>
+/// <typeparam name="T">The type of value to be compared.</typeparam>
+/// <typeparam name="TSurrogate">The type of surrogate to use instead of the value directly.</typeparam>
+/// <param name="marshaller">The means to convert between a value and its surrogate.</param>
+/// <param name="surrogateComparer">The comparer that operates directly on the surrogate.</param>
+internal class SurrogateSecureEqualityComparer<T, TSurrogate>(IMarshaller<T, TSurrogate> marshaller, SecureEqualityComparer<TSurrogate> surrogateComparer)
+	: SecureEqualityComparer<T>
+{
+	/// <inheritdoc/>
+	public override bool Equals(T? x, T? y)
+		=> surrogateComparer.Equals(marshaller.ToSurrogate(x), marshaller.ToSurrogate(y));
+
+	/// <inheritdoc/>
+	public override long GetSecureHashCode([DisallowNull] T obj)
+		=> marshaller.ToSurrogate(obj) is TSurrogate surrogate ? surrogateComparer.GetSecureHashCode(surrogate) : 0;
+}

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -462,6 +462,10 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			? new EnumAsStringConverter<TEnum, TUnderlying>(this.GetConverter(enumShape.UnderlyingType))
 			: new EnumAsOrdinalConverter<TEnum, TUnderlying>(this.GetConverter(enumShape.UnderlyingType));
 
+	/// <inheritdoc/>
+	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
+		=> new SurrogateConverter<T, TSurrogate>(surrogateShape, this.GetConverter(surrogateShape.SurrogateType, state));
+
 	/// <summary>
 	/// Gets or creates a converter for the given type shape.
 	/// </summary>

--- a/test/Nerdbank.MessagePack.Tests/ReferencePreservationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ReferencePreservationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+[Trait("ReferencePreservation", "true")]
 public partial class ReferencePreservationTests : MessagePackSerializerTestBase
 {
 	public ReferencePreservationTests(ITestOutputHelper logger)
@@ -109,6 +110,15 @@ public partial class ReferencePreservationTests : MessagePackSerializerTestBase
 
 		// Verify that reference equality is also satisfied within the deserialized tree.
 		Assert.Same(deserializedRoot.City, deserializedRoot.State);
+	}
+
+	[Fact]
+	public void DictionaryReferencePreservation()
+	{
+		Dictionary<string, int> dict = new() { ["a"] = 1, ["b"] = 2 };
+		Dictionary<string, int>[]? deserializedArray = this.Roundtrip<Dictionary<string, int>[], Witness>([dict, dict]);
+		Assert.NotNull(deserializedArray);
+		Assert.Same(deserializedArray[0], deserializedArray[1]);
 	}
 
 	[Theory, PairwiseData]
@@ -336,5 +346,6 @@ public partial class ReferencePreservationTests : MessagePackSerializerTestBase
 	[GenerateShape<CustomType[]>]
 	[GenerateShape<string[]>]
 	[GenerateShape<BaseRecord[]>]
+	[GenerateShape<Dictionary<string, int>[]>]
 	private partial class Witness;
 }

--- a/test/Nerdbank.MessagePack.Tests/Resources/KnownGoodSchemas/Surrogates.schema.json
+++ b/test/Nerdbank.MessagePack.Tests/Resources/KnownGoodSchemas/Surrogates.schema.json
@@ -1,0 +1,35 @@
+﻿{
+  "oneOf": [
+    {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/SurrogateTests\u002BOriginalType\u002BMarshaledType"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    {
+      "type": "null"
+    }
+  ],
+  "definitions": {
+    "SurrogateTests\u002BOriginalType\u002BMarshaledType": {
+      "type": "object",
+      "properties": {
+        "A": {
+          "type": "integer"
+        },
+        "B": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "A",
+        "B"
+      ]
+    }
+  },
+  "$schema": "http://json-schema.org/draft-04/schema"
+}

--- a/test/Nerdbank.MessagePack.Tests/SchemaTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/SchemaTests.cs
@@ -23,6 +23,7 @@ using Microsoft;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
 
+[Trait("JsonSchema", "true")]
 public partial class SchemaTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
 {
 	private const bool RecordMode =
@@ -91,6 +92,13 @@ public partial class SchemaTests(ITestOutputHelper logger) : MessagePackSerializ
 
 	[Fact]
 	public void Recursive() => this.AssertSchema([new RecursiveType { Child = new RecursiveType() }]);
+
+	[Fact]
+	[Trait("Surrogates", "true")]
+	public void Surrogates()
+	{
+		this.AssertSchema<SurrogateTests.OriginalType>();
+	}
 
 	[Fact]
 	public void Complex() => this.AssertSchema([

--- a/test/Nerdbank.MessagePack.Tests/SurrogateTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/SurrogateTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+[Trait("Surrogates", "true")]
+public partial class SurrogateTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	[Fact]
+	public void NonNullReference()
+	{
+		OriginalType? deserialized = this.Roundtrip(new OriginalType(1, 2));
+		Assert.NotNull(deserialized);
+		Assert.Equal(3, deserialized.Sum);
+	}
+
+	[Fact]
+	public void NullReference()
+	{
+		OriginalType? deserialized = this.Roundtrip<OriginalType>(null);
+		Assert.Null(deserialized);
+	}
+
+	[Fact]
+	public async Task NonNullReference_Async()
+	{
+		OriginalType? deserialized = await this.RoundtripAsync(new OriginalType(1, 2));
+		Assert.NotNull(deserialized);
+		Assert.Equal(3, deserialized.Sum);
+	}
+
+	[Fact]
+	public async Task NullReference_Async()
+	{
+		OriginalType? deserialized = await this.RoundtripAsync<OriginalType>(null);
+		Assert.Null(deserialized);
+	}
+
+	[Fact]
+	[Trait("ReferencePreservation", "true")]
+	public void ReferencePreservation()
+	{
+		this.Serializer = this.Serializer with { PreserveReferences = true };
+		OriginalType original = new(1, 2);
+		OriginalType[]? deserializedArray = this.Roundtrip<OriginalType[], Witness>([original, original]);
+		Assert.NotNull(deserializedArray);
+		Assert.Same(deserializedArray[0], deserializedArray[1]);
+	}
+
+	[GenerateShape]
+	[TypeShape(Marshaller = typeof(Marshaller))]
+	internal partial class OriginalType
+	{
+		private int a;
+		private int b;
+
+		internal OriginalType(int a, int b)
+		{
+			this.a = a;
+			this.b = b;
+		}
+
+		public int Sum => this.a + this.b;
+
+		internal record struct MarshaledType(int A, int B);
+
+		internal class Marshaller : IMarshaller<OriginalType, MarshaledType?>
+		{
+			public OriginalType? FromSurrogate(MarshaledType? surrogate)
+				=> surrogate.HasValue ? new(surrogate.Value.A, surrogate.Value.B) : null;
+
+			public MarshaledType? ToSurrogate(OriginalType? value)
+				=> value is null ? null : new(value.a, value.b);
+		}
+	}
+
+	[GenerateShape<OriginalType[]>]
+	private partial class Witness;
+}


### PR DESCRIPTION
Surrogates provide a much easier alternative to implementing a custom converter for types that are not serializable.