### PR TITLE
Improve exported JSON schemas for array of values objects

### DIFF
--- a/src/Nerdbank.MessagePack/Converters/ObjectConverterBase`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectConverterBase`1.cs
@@ -19,11 +19,26 @@ internal abstract class ObjectConverterBase<T> : MessagePackConverter<T>
 	/// </summary>
 	/// <param name="attributeProvider">The attribute provider for the target.</param>
 	/// <param name="schema">The schema for the target.</param>
-	protected static void ApplyDescription(ICustomAttributeProvider? attributeProvider, JsonObject schema)
+	/// <param name="namePrefix">An optional prefix to include in the description, or to use by itself when no <see cref="DescriptionAttribute"/> is present.</param>
+	protected static void ApplyDescription(ICustomAttributeProvider? attributeProvider, JsonObject schema, string? namePrefix = null)
 	{
-		if (attributeProvider?.GetCustomAttribute<DescriptionAttribute>() is DescriptionAttribute description)
+		string? description;
+		if (attributeProvider?.GetCustomAttribute<DescriptionAttribute>() is DescriptionAttribute descriptionAttribute)
 		{
-			schema["description"] = description.Description;
+			description = descriptionAttribute.Description;
+			if (namePrefix is not null)
+			{
+				description = $"{namePrefix}: {description}";
+			}
+		}
+		else
+		{
+			description = namePrefix;
+		}
+
+		if (description is not null)
+		{
+			schema["description"] = description;
 		}
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/Resources/KnownGoodSchemas/BasicObject_Key.schema.json
+++ b/test/Nerdbank.MessagePack.Tests/Resources/KnownGoodSchemas/BasicObject_Key.schema.json
@@ -58,15 +58,18 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "description": "Property0"
         },
         "2": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "GappedProperty"
         },
         "3": {
           "oneOf": [
             {
-              "$ref": "#/definitions/SchemaTests\u002BPerson"
+              "$ref": "#/definitions/SchemaTests\u002BPerson",
+              "description": "Person"
             },
             {
               "type": "null"
@@ -79,7 +82,8 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "description": "Property0"
         },
         {
           "type": [
@@ -94,12 +98,14 @@
           "description": "This is an undocumented element that is ignored by the deserializer and always serialized as null."
         },
         {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "GappedProperty"
         },
         {
           "oneOf": [
             {
-              "$ref": "#/definitions/SchemaTests\u002BPerson"
+              "$ref": "#/definitions/SchemaTests\u002BPerson",
+              "description": "Person"
             },
             {
               "type": "null"

--- a/test/Nerdbank.MessagePack.Tests/Resources/KnownGoodSchemas/BasicObject_Key_Required.schema.json
+++ b/test/Nerdbank.MessagePack.Tests/Resources/KnownGoodSchemas/BasicObject_Key_Required.schema.json
@@ -1,0 +1,49 @@
+﻿{
+  "oneOf": [
+    {
+      "$ref": "#/definitions/SchemaTests\u002BArrayOfValuesWithRequired"
+    },
+    {
+      "type": "null"
+    }
+  ],
+  "definitions": {
+    "SchemaTests\u002BArrayOfValuesWithRequired": {
+      "type": [
+        "object",
+        "array"
+      ],
+      "properties": {
+        "0": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Property0: The first and required property."
+        },
+        "1": {
+          "type": "boolean",
+          "description": "Property1"
+        }
+      },
+      "items": [
+        {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Property0: The first and required property."
+        },
+        {
+          "type": "boolean",
+          "description": "Property1"
+        }
+      ],
+      "required": [
+        "0"
+      ],
+      "minItems": 1
+    }
+  },
+  "$schema": "http://json-schema.org/draft-04/schema"
+}


### PR DESCRIPTION
- Fix `required` property to use index-based property names to match the object schema.
- Add `minItems` property to reflect the required number of array elements.
- Include property name in the `description` property for indexed elements.