### PR TITLE
Provide more flexibility in which properties to serialize default values of

### DIFF
--- a/docfx/docs/customizing-serialization.md
+++ b/docfx/docs/customizing-serialization.md
@@ -128,7 +128,7 @@ When some properties of the object would ideally be skipped because the values a
 A map has its own overhead because indexes are not implicit.
 
 When @Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues?displayProperty=nameWithType is set to @Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Always?displayProperty=nameWithType, the array format is always chosen, even if gaps from unassigned indexes may exist in the array.
-But when this property is left to its default value of @Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Never, even if the array format is chosen, it may be a shorter array because of properties at the end of the array that are set to their default values.
+But when this property is set to @Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Never, even if the array format is chosen, it may be a shorter array because of properties at the end of the array that are set to their default values.
 
 In the case above, the array format would have been chosen because there are two non-default values and no gaps.
 Let's now consider another case:
@@ -145,7 +145,7 @@ If both properties were set, the serialized form might look like this:
 ["value1",null,null,null,null,"value2"]
 ```
 
-For the rest of this section, let's assume @Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues is at its default @Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Never value.
+For the rest of this section, let's assume @Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues is set to @Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Never.
 This immediately changes the binary representation of the serialized object above to just this:
 
 ```json

--- a/docfx/docs/customizing-serialization.md
+++ b/docfx/docs/customizing-serialization.md
@@ -127,9 +127,8 @@ When all values on an object are set to non-default values and there are no gaps
 When some properties of the object would ideally be skipped because the values are their defaults and/or there are gaps in assigned indexes, a map may be more compact.
 A map has its own overhead because indexes are not implicit.
 
-When @Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues?displayProperty=nameWithType is `true`, the array format is always chosen, even if gaps from unassigned indexes may exist in the array.
-But when this property is left to its default value of `false`, even if the array format is chosen, it may be a shorter array because of properties at the end of the array that are set to their default values.
-
+When @Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues?displayProperty=nameWithType is set to @Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Always?displayProperty=nameWithType, the array format is always chosen, even if gaps from unassigned indexes may exist in the array.
+But when this property is left to its default value of @Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Never, even if the array format is chosen, it may be a shorter array because of properties at the end of the array that are set to their default values.
 
 In the case above, the array format would have been chosen because there are two non-default values and no gaps.
 Let's now consider another case:
@@ -139,14 +138,14 @@ Let's now consider another case:
 Note the large gap between assigned indexes 0 and 5 in this class.
 This could be justified by the removal of properties with indexes 1-4 and a desire to retain compatibility with previous versions of the serialized schema.
 
-Serializing this object with @Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues?displayProperty=nameWithType set to `true`, we'd get a 6-element array.
+Serializing this object with @Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues set to @Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Always, we'd get a 6-element array.
 If both properties were set, the serialized form might look like this:
 
 ```json
 ["value1",null,null,null,null,"value2"]
 ```
 
-For the rest of this section, let's assume @Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues?displayProperty=nameWithType is at its default `false` value.
+For the rest of this section, let's assume @Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues is at its default @Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Never value.
 This immediately changes the binary representation of the serialized object above to just this:
 
 ```json

--- a/src/Nerdbank.MessagePack/ConverterCache.cs
+++ b/src/Nerdbank.MessagePack/ConverterCache.cs
@@ -32,7 +32,7 @@ internal record class ConverterCache
 
 	private bool preserveReferences;
 	private bool serializeEnumValuesByName;
-	private SerializeDefaultValuesPolicy serializeDefaultValues;
+	private SerializeDefaultValuesPolicy serializeDefaultValues = SerializeDefaultValuesPolicy.Required;
 	private bool internStrings;
 	private bool disableHardwareAcceleration;
 	private MessagePackNamingPolicy? propertyNamingPolicy;
@@ -110,7 +110,7 @@ internal record class ConverterCache
 	/// <summary>
 	/// Gets the policy concerning which properties to serialize though they are set to their default values.
 	/// </summary>
-	/// <value>The default value is <see cref="SerializeDefaultValuesPolicy.Never"/>, meaning that only properties with non-default values will be serialized.</value>
+	/// <value>The default value is <see cref="SerializeDefaultValuesPolicy.Required"/>, meaning that only required properties or properties with non-default values will be serialized.</value>
 	/// <remarks>
 	/// <para>
 	/// By default, the serializer omits properties and fields that are set to their default values when serializing objects.

--- a/src/Nerdbank.MessagePack/ConverterCache.cs
+++ b/src/Nerdbank.MessagePack/ConverterCache.cs
@@ -32,7 +32,7 @@ internal record class ConverterCache
 
 	private bool preserveReferences;
 	private bool serializeEnumValuesByName;
-	private bool serializeDefaultValues;
+	private SerializeDefaultValuesPolicy serializeDefaultValues;
 	private bool internStrings;
 	private bool disableHardwareAcceleration;
 	private MessagePackNamingPolicy? propertyNamingPolicy;
@@ -108,27 +108,28 @@ internal record class ConverterCache
 	}
 
 	/// <summary>
-	/// Gets a value indicating whether to serialize properties that are set to their default values.
+	/// Gets the policy concerning which properties to serialize though they are set to their default values.
 	/// </summary>
-	/// <value>The default value is <see langword="false" />.</value>
+	/// <value>The default value is <see cref="SerializeDefaultValuesPolicy.Never"/>, meaning that only properties with non-default values will be serialized.</value>
 	/// <remarks>
 	/// <para>
 	/// By default, the serializer omits properties and fields that are set to their default values when serializing objects.
 	/// This property can be used to override that behavior and serialize all properties and fields, regardless of their value.
 	/// </para>
 	/// <para>
-	/// This property currently only impacts objects serialized as maps (i.e. types that are <em>not</em> using <see cref="KeyAttribute"/> on their members),
-	/// but this could be expanded to truncate value arrays as well.
+	/// Objects that are serialized as arrays (i.e. types that use <see cref="KeyAttribute"/> on their members),
+	/// have a limited ability to omit default values because the order of the elements in the array is significant.
+	/// See the <see cref="KeyAttribute" /> documentation for details.
 	/// </para>
 	/// <para>
 	/// Default values are assumed to be <c>default(TPropertyType)</c> except where overridden, as follows:
 	/// <list type="bullet">
 	///   <item><description>Primary constructor default parameter values. e.g. <c>record Person(int Age = 18)</c></description></item>
-	///   <item><description>Properties or fields attributed with <see cref="System.ComponentModel.DefaultValueAttribute"/>. e.g. <c>[DefaultValue(18)] internal int Age { get; set; }</c></description></item>
+	///   <item><description>Properties or fields attributed with <see cref="System.ComponentModel.DefaultValueAttribute"/>. e.g. <c>[DefaultValue(18)] internal int Age { get; set; } = 18;</c></description></item>
 	/// </list>
 	/// </para>
 	/// </remarks>
-	internal bool SerializeDefaultValues
+	internal SerializeDefaultValuesPolicy SerializeDefaultValues
 	{
 		get => this.serializeDefaultValues;
 		init => this.ChangeSetting(ref this.serializeDefaultValues, value);

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayWithNonDefaultCtorConverter`2.cs
@@ -15,13 +15,13 @@ namespace Nerdbank.MessagePack.Converters;
 /// <param name="argStateCtor">The constructor for the <typeparamref name="TArgumentState"/> that is later passed to the <typeparamref name="TDeclaringType"/> constructor.</param>
 /// <param name="ctor">The data type's constructor helper.</param>
 /// <param name="parameters">Constructor parameter initializers, in array positions matching serialization indexes.</param>
-/// <param name="callShouldSerialize"><inheritdoc cref="ObjectArrayConverter{T}.ObjectArrayConverter(ReadOnlyMemory{PropertyAccessors{T}?}, Func{T}?, bool)" path="/param[@name='callShouldSerialize']"/></param>
+/// <param name="defaultValuesPolicy"><inheritdoc cref="ObjectArrayConverter{T}.ObjectArrayConverter(ReadOnlyMemory{PropertyAccessors{T}?}, Func{T}?, SerializeDefaultValuesPolicy)" path="/param[@name='defaultValuesPolicy']"/></param>
 internal class ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentState>(
 	PropertyAccessors<TDeclaringType>?[] properties,
 	Func<TArgumentState> argStateCtor,
 	Constructor<TArgumentState, TDeclaringType> ctor,
 	DeserializableProperty<TArgumentState>?[] parameters,
-	bool callShouldSerialize) : ObjectArrayConverter<TDeclaringType>(properties, null, callShouldSerialize)
+	SerializeDefaultValuesPolicy defaultValuesPolicy) : ObjectArrayConverter<TDeclaringType>(properties, null, defaultValuesPolicy)
 {
 	/// <inheritdoc/>
 	public override TDeclaringType? Read(ref MessagePackReader reader, SerializationContext context)

--- a/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
@@ -15,13 +15,13 @@ namespace Nerdbank.MessagePack.Converters;
 /// <param name="argStateCtor">The constructor for the <typeparamref name="TArgumentState"/> that is later passed to the <typeparamref name="TDeclaringType"/> constructor.</param>
 /// <param name="ctor">The data type's constructor helper.</param>
 /// <param name="parameters">Tools for deserializing individual property values.</param>
-/// <param name="callShouldSerialize"><see langword="true" /> if some of the properties should maybe be omitted; <see langword="false" /> to allow a fast path that assumes all properties are serialized.</param>
+/// <param name="defaultValuesPolicy"><inheritdoc cref="ObjectMapConverter{T}.ObjectMapConverter(MapSerializableProperties{T}, MapDeserializableProperties{T}?, Func{T}?, SerializeDefaultValuesPolicy)" path="/param[@name='defaultValuesPolicy']"/></param>
 internal class ObjectMapWithNonDefaultCtorConverter<TDeclaringType, TArgumentState>(
 	MapSerializableProperties<TDeclaringType> serializable,
 	Func<TArgumentState> argStateCtor,
 	Constructor<TArgumentState, TDeclaringType> ctor,
 	MapDeserializableProperties<TArgumentState> parameters,
-	bool callShouldSerialize) : ObjectMapConverter<TDeclaringType>(serializable, null, null, callShouldSerialize)
+	SerializeDefaultValuesPolicy defaultValuesPolicy) : ObjectMapConverter<TDeclaringType>(serializable, null, null, defaultValuesPolicy)
 {
 	/// <inheritdoc/>
 	public override TDeclaringType? Read(ref MessagePackReader reader, SerializationContext context)

--- a/src/Nerdbank.MessagePack/KeyAttribute.cs
+++ b/src/Nerdbank.MessagePack/KeyAttribute.cs
@@ -18,8 +18,9 @@ namespace Nerdbank.MessagePack;
 /// An object that uses this attribute may be serialized as an array of values where the index given to this attribute becomes the index into the array for the value of the applied property,
 /// or the object may be serialized as a map where the index given to this attribute provides the key instead of the property name, and the map value is set to the value of the property.
 /// Whether an object serializes as a map or an array is determined at runtime.
-/// When <see cref="MessagePackSerializer.SerializeDefaultValues"/> is <see langword="false"/> and there are "holes" in the would-be array (due to properties with default values or unused indexes),
-/// the map format will be chosen when a quick estimate determines that it will be a more compact representation than an array with holes in it.
+/// When <see cref="MessagePackSerializer.SerializeDefaultValues"/> is not <see cref="SerializeDefaultValuesPolicy.Always"/> and there are "holes" in the would-be array
+/// (due to properties with default values or unused indexes), the map format will be chosen when a quick estimate determines that it will be a more compact representation
+/// than an array with holes in it.
 /// Deserializers should always be prepared for either the map or the array representation of the object.
 /// </para>
 /// </remarks>

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -54,7 +54,7 @@ public partial record MessagePackSerializer
 	}
 
 	/// <inheritdoc cref="ConverterCache.SerializeDefaultValues"/>
-	public bool SerializeDefaultValues
+	public SerializeDefaultValuesPolicy SerializeDefaultValues
 	{
 		get => this.converterCache.SerializeDefaultValues;
 		init => this.converterCache = this.converterCache with { SerializeDefaultValues = value };

--- a/src/Nerdbank.MessagePack/SerializeDefaultValuesPolicy.cs
+++ b/src/Nerdbank.MessagePack/SerializeDefaultValuesPolicy.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// Specifies the policy for serializing default values.
+/// </summary>
+[Flags]
+public enum SerializeDefaultValuesPolicy
+{
+	/// <summary>
+	/// Do not serialize any default values.
+	/// </summary>
+	Never = 0x0,
+
+	/// <summary>
+	/// Serialize default values when they are required by the schema.
+	/// </summary>
+	/// <remarks>
+	/// Properties are considered required when they have the <c>required</c> modifier on them
+	/// or they appear as parameters in the deserializing constructor without a default value specified.
+	/// </remarks>
+	Required = 0x1,
+
+	/// <summary>
+	/// Serialize default values for value types.
+	/// </summary>
+	/// <remarks>
+	/// This means values such as <c>0</c> and <see langword="false" /> will be serialized,
+	/// but <see langword="null"/> will not be serialized.
+	/// </remarks>
+	ValueTypes = 0x2,
+
+	/// <summary>
+	/// Serialize default values for reference types.
+	/// </summary>
+	/// <remarks>
+	/// This means that properties with <see langword="null"/> values will be serialized.
+	/// </remarks>
+	ReferenceTypes = 0x4,
+
+	/// <summary>
+	/// Serialize all properties, regardless of their values.
+	/// </summary>
+	Always = Required | ValueTypes | ReferenceTypes,
+}

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -240,7 +240,7 @@ Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Pipelines
 Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Stream! stream, in T? value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Stream! stream, T? value, PolyType.Abstractions.ITypeShape<T>! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Stream! stream, T? value, PolyType.ITypeShapeProvider! provider, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
-Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues.get -> bool
+Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues.get -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
 Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.SerializeEnumValuesByName.get -> bool
 Nerdbank.MessagePack.MessagePackSerializer.SerializeEnumValuesByName.init -> void
@@ -346,6 +346,12 @@ Nerdbank.MessagePack.SerializationContext.this[object! key].set -> void
 Nerdbank.MessagePack.SerializationContext.TypeShapeProvider.get -> PolyType.ITypeShapeProvider?
 Nerdbank.MessagePack.SerializationContext.UnflushedBytesThreshold.get -> int
 Nerdbank.MessagePack.SerializationContext.UnflushedBytesThreshold.init -> void
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Always = Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Required | Nerdbank.MessagePack.SerializeDefaultValuesPolicy.ValueTypes | Nerdbank.MessagePack.SerializeDefaultValuesPolicy.ReferenceTypes -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Never = 0 -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy.ReferenceTypes = 4 -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Required = 1 -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy.ValueTypes = 2 -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
 Nerdbank.MessagePack.StructuralEqualityComparer
 override Nerdbank.MessagePack.Extension.GetHashCode() -> int
 override Nerdbank.MessagePack.ExtensionHeader.GetHashCode() -> int

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -206,7 +206,7 @@ Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Pipelines
 Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Pipelines.PipeWriter! writer, T? value, PolyType.ITypeShapeProvider! provider, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Stream! stream, T? value, PolyType.Abstractions.ITypeShape<T>! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Nerdbank.MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Stream! stream, T? value, PolyType.ITypeShapeProvider! provider, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
-Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues.get -> bool
+Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues.get -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
 Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues.init -> void
 Nerdbank.MessagePack.MessagePackSerializer.SerializeEnumValuesByName.get -> bool
 Nerdbank.MessagePack.MessagePackSerializer.SerializeEnumValuesByName.init -> void
@@ -307,6 +307,12 @@ Nerdbank.MessagePack.SerializationContext.this[object! key].set -> void
 Nerdbank.MessagePack.SerializationContext.TypeShapeProvider.get -> PolyType.ITypeShapeProvider?
 Nerdbank.MessagePack.SerializationContext.UnflushedBytesThreshold.get -> int
 Nerdbank.MessagePack.SerializationContext.UnflushedBytesThreshold.init -> void
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Always = Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Required | Nerdbank.MessagePack.SerializeDefaultValuesPolicy.ValueTypes | Nerdbank.MessagePack.SerializeDefaultValuesPolicy.ReferenceTypes -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Never = 0 -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy.ReferenceTypes = 4 -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy.Required = 1 -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
+Nerdbank.MessagePack.SerializeDefaultValuesPolicy.ValueTypes = 2 -> Nerdbank.MessagePack.SerializeDefaultValuesPolicy
 Nerdbank.MessagePack.StructuralEqualityComparer
 override Nerdbank.MessagePack.Extension.GetHashCode() -> int
 override Nerdbank.MessagePack.ExtensionHeader.GetHashCode() -> int

--- a/test/Benchmarks/ArraysOfMultipleCategoryPrimitives.cs
+++ b/test/Benchmarks/ArraysOfMultipleCategoryPrimitives.cs
@@ -15,9 +15,9 @@ using System.Runtime.InteropServices;
 public partial class ArraysOfMultipleCategoryPrimitives
 {
 	private const int Length = 10_000;
-	private static readonly MessagePackSerializer AcceleratedSerializer = new() { SerializeDefaultValues = true, DisableHardwareAcceleration = false };
-	private static readonly MessagePackSerializer UnacceleratedSerializer = new() { SerializeDefaultValues = true, DisableHardwareAcceleration = true };
-	private static readonly MessagePackSerializer TestSerializer = new() { SerializeDefaultValues = true };
+	private static readonly MessagePackSerializer AcceleratedSerializer = new() { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always, DisableHardwareAcceleration = false };
+	private static readonly MessagePackSerializer UnacceleratedSerializer = new() { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always, DisableHardwareAcceleration = true };
+	private static readonly MessagePackSerializer TestSerializer = new() { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always };
 	private static readonly sbyte[] Int8Values = GetRandomValues<sbyte>(Length);
 	private static readonly sbyte[] Int8ValuesMultipleCategory = GetRandomInt8Values2Category(Length);
 	private static readonly byte[] Int8ValuesMsgPack = TestSerializer.Serialize<sbyte[], Witness>(Int8Values);

--- a/test/Benchmarks/ArraysOfPrimitives.cs
+++ b/test/Benchmarks/ArraysOfPrimitives.cs
@@ -6,9 +6,9 @@
 public partial class ArraysOfPrimitives
 {
 	private const int Length = 10_000;
-	private static readonly MessagePackSerializer AcceleratedSerializer = new() { SerializeDefaultValues = true, DisableHardwareAcceleration = false };
-	private static readonly MessagePackSerializer UnacceleratedSerializer = new() { SerializeDefaultValues = true, DisableHardwareAcceleration = true };
-	private static readonly MessagePackSerializer TestSerializer = new() { SerializeDefaultValues = true };
+	private static readonly MessagePackSerializer AcceleratedSerializer = new() { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always, DisableHardwareAcceleration = false };
+	private static readonly MessagePackSerializer UnacceleratedSerializer = new() { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always, DisableHardwareAcceleration = true };
+	private static readonly MessagePackSerializer TestSerializer = new() { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always };
 	private static readonly bool[] BoolValues = GetRandomBools(Length);
 	private static readonly byte[] BoolValuesMsgPack = TestSerializer.Serialize<bool[], Witness>(BoolValues);
 	private static readonly float[] SingleValues = GetRandomFloats(Length);

--- a/test/Benchmarks/SimplePoco.cs
+++ b/test/Benchmarks/SimplePoco.cs
@@ -6,7 +6,7 @@
 [CategoriesColumn]
 public partial class SimplePoco
 {
-	private readonly MessagePackSerializer serializer = new() { SerializeDefaultValues = true };
+	private readonly MessagePackSerializer serializer = new() { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always };
 	private readonly Sequence buffer = new();
 
 	[Benchmark]

--- a/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
@@ -45,9 +45,12 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 		Assert.Equal(person, deserialized);
 	}
 
+	[Trait("ShouldSerialize", "true")]
 	[Theory, PairwiseData]
 	public async Task Person_WithoutLastName(bool async)
 	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Never };
+
 		// The most compact representation of this is an array of length 1.
 		// Verify that this is what the converter chose.
 		Person person = new() { FirstName = "Andrew", LastName = null };
@@ -56,9 +59,12 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 		Assert.Equal(1, reader.ReadArrayHeader());
 	}
 
+	[Trait("ShouldSerialize", "true")]
 	[Theory, PairwiseData]
 	public async Task Person_WithoutFirstName(bool async)
 	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Never };
+
 		// The most compact representation of this is a map of length 1.
 		// Verify that this is what the converter chose.
 		Person person = new() { FirstName = null, LastName = "Arnott" };
@@ -67,9 +73,12 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 		Assert.Equal(1, reader.ReadMapHeader());
 	}
 
+	[Trait("ShouldSerialize", "true")]
 	[Theory, PairwiseData]
 	public async Task Person_AllDefaultValues(bool async)
 	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Never };
+
 		// The most compact representation of this is a map of length 1.
 		// Verify that this is what the converter chose.
 		Person person = new Person { FirstName = null, LastName = null };
@@ -214,9 +223,12 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 		Assert.Equal(5, reader.ReadArrayHeader());
 	}
 
+	[Trait("ShouldSerialize", "true")]
 	[Fact]
 	public async Task AsyncAndSyncPropertyMix_AsMap()
 	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Never };
+
 		// Initialize a default late in the array to motivate serialization as a map.
 		FamilyWithAsyncProperties family = new()
 		{

--- a/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
@@ -141,8 +141,11 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 		Assert.Equal(1, reader.ReadMapHeader());
 	}
 
+	[Trait("ShouldSerialize", "true")]
 	[Theory, PairwiseData]
-	public async Task PersonWithDefaultConstructor_AllDefaultValues(bool async, bool serializeDefaultValues)
+	public async Task PersonWithDefaultConstructor_AllDefaultValues(
+		bool async,
+		[CombinatorialValues(SerializeDefaultValuesPolicy.Always, SerializeDefaultValuesPolicy.Never)] SerializeDefaultValuesPolicy serializeDefaultValues)
 	{
 		// The most compact representation of this is a map of length 1.
 		// Verify that this is what the converter chose, iff we're in that mode.
@@ -151,7 +154,7 @@ public partial class ObjectsAsArraysTests(ITestOutputHelper logger) : MessagePac
 		PersonWithDefaultConstructor person = new() { FirstName = null, LastName = null };
 		ReadOnlySequence<byte> msgpack = async ? await this.AssertRoundtripAsync(person) : this.AssertRoundtrip(person);
 		MessagePackReader reader = new(msgpack);
-		Assert.Equal(serializeDefaultValues ? 3 : 0, reader.ReadArrayHeader());
+		Assert.Equal(serializeDefaultValues == SerializeDefaultValuesPolicy.Always ? 3 : 0, reader.ReadArrayHeader());
 	}
 
 	[Theory, PairwiseData]

--- a/test/Nerdbank.MessagePack.Tests/ShouldSerializeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ShouldSerializeTests.cs
@@ -42,6 +42,7 @@ public partial class ShouldSerializeTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void PersonWithPrimaryConstructor_AllDefaultsByType()
 	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Never };
 		PersonWithPrimaryConstructor person = new(null, 0, null);
 		ReadOnlySequence<byte> sequence = this.AssertRoundtrip(person);
 
@@ -54,6 +55,7 @@ public partial class ShouldSerializeTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void PersonWithPrimaryConstructor_AllDefaultsByExplicitDefault()
 	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Never };
 		PersonWithPrimaryConstructor person = new(null, 0, "Blue");
 		ReadOnlySequence<byte> sequence = this.AssertRoundtrip(person);
 
@@ -107,6 +109,7 @@ public partial class ShouldSerializeTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void PersonWithPrimaryConstructor_DifferentFavoriteColor()
 	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Never };
 		PersonWithPrimaryConstructor person = new(null, 0, "Red");
 		ReadOnlySequence<byte> sequence = this.AssertRoundtrip(person);
 		MessagePackReader reader = new(sequence);
@@ -128,6 +131,7 @@ public partial class ShouldSerializeTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void PersonWithPrimaryConstructor_NoFavoriteColor()
 	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Never };
 		PersonWithPrimaryConstructor person = new(null, 0, FavoriteColor: null);
 		ReadOnlySequence<byte> sequence = this.AssertRoundtrip(person);
 		MessagePackReader reader = new(sequence);

--- a/test/Nerdbank.MessagePack.Tests/ShouldSerializeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ShouldSerializeTests.cs
@@ -3,8 +3,22 @@
 
 using System.ComponentModel;
 
+[Trait("ShouldSerialize", "true")]
 public partial class ShouldSerializeTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
 {
+	public static IEnumerable<SerializeDefaultValuesPolicy> AllPolicies
+	{
+		get
+		{
+			// Enumerate all possible values of the SerializeDefaultValuesPolicy flags enum from None to All.
+			// This is done by iterating over all possible values of the underlying integer type.
+			for (int i = 0; i <= (int)SerializeDefaultValuesPolicy.Always; i++)
+			{
+				yield return (SerializeDefaultValuesPolicy)i;
+			}
+		}
+	}
+
 	[Fact]
 	public void Person_AllDefaults()
 	{
@@ -26,9 +40,21 @@ public partial class ShouldSerializeTests(ITestOutputHelper logger) : MessagePac
 	}
 
 	[Fact]
-	public void PersonWithPrimaryConstructor_AllDefaults()
+	public void PersonWithPrimaryConstructor_AllDefaultsByType()
 	{
-		PersonWithPrimaryConstructor person = new(null, 0);
+		PersonWithPrimaryConstructor person = new(null, 0, null);
+		ReadOnlySequence<byte> sequence = this.AssertRoundtrip(person);
+
+		MessagePackReader reader = new(sequence);
+		Assert.Equal(1, reader.ReadMapHeader());
+		Assert.Equal(nameof(PersonWithPrimaryConstructor.FavoriteColor), reader.ReadString());
+		Assert.True(reader.TryReadNil());
+	}
+
+	[Fact]
+	public void PersonWithPrimaryConstructor_AllDefaultsByExplicitDefault()
+	{
+		PersonWithPrimaryConstructor person = new(null, 0, "Blue");
 		ReadOnlySequence<byte> sequence = this.AssertRoundtrip(person);
 
 		MessagePackReader reader = new(sequence);
@@ -38,7 +64,7 @@ public partial class ShouldSerializeTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void SerializeDefaultValues()
 	{
-		this.Serializer = this.Serializer with { SerializeDefaultValues = true };
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always };
 		Person person = new();
 		ReadOnlySequence<byte> sequence = this.AssertRoundtrip(person);
 
@@ -140,6 +166,76 @@ public partial class ShouldSerializeTests(ITestOutputHelper logger) : MessagePac
 		Assert.Equal(1, reader.ReadMapHeader());
 	}
 
+	[Theory]
+	[PairwiseData]
+	public void Flags_OnMembersOfAllKinds([CombinatorialMemberData(nameof(AllPolicies))] SerializeDefaultValuesPolicy policy)
+	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = policy };
+
+		PersonWithRequiredAndOptionalProperties obj = new() { Name = null, Stamina = 0 };
+		ReadOnlySequence<byte> sequence = this.AssertRoundtrip(obj);
+
+		bool hasName = (policy & (SerializeDefaultValuesPolicy.Required | SerializeDefaultValuesPolicy.ReferenceTypes)) != 0;
+		bool hasStamina = (policy & (SerializeDefaultValuesPolicy.Required | SerializeDefaultValuesPolicy.ValueTypes)) != 0;
+		bool hasFavoriteColor = policy.HasFlag(SerializeDefaultValuesPolicy.ReferenceTypes);
+		bool hasAge = policy.HasFlag(SerializeDefaultValuesPolicy.ValueTypes);
+		int expectedCount = (hasName ? 1 : 0)
+			+ (hasStamina ? 1 : 0)
+			+ (hasAge ? 1 : 0)
+			+ (hasFavoriteColor ? 1 : 0);
+
+		MessagePackReader reader = new(sequence);
+		Assert.Equal(expectedCount, reader.ReadMapHeader());
+
+		if (hasName)
+		{
+			Assert.Equal(nameof(PersonWithRequiredAndOptionalProperties.Name), reader.ReadString());
+			reader.Skip(default);
+		}
+
+		if (hasStamina)
+		{
+			Assert.Equal(nameof(PersonWithRequiredAndOptionalProperties.Stamina), reader.ReadString());
+			reader.Skip(default);
+		}
+
+		if (hasFavoriteColor)
+		{
+			Assert.Equal(nameof(PersonWithRequiredAndOptionalProperties.FavoriteColor), reader.ReadString());
+			reader.Skip(default);
+		}
+
+		if (hasAge)
+		{
+			Assert.Equal(nameof(PersonWithRequiredAndOptionalProperties.Age), reader.ReadString());
+			reader.Skip(default);
+		}
+	}
+
+	[Theory]
+	[InlineData(SerializeDefaultValuesPolicy.Never)]
+	[InlineData(SerializeDefaultValuesPolicy.Required)]
+	public void Flags_OnRequiredAndOptionalParameters(SerializeDefaultValuesPolicy policy)
+	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = policy };
+		PersonWithRequiredAndOptionalParameters obj = new(null);
+		ReadOnlySequence<byte> sequence = this.AssertRoundtrip(obj);
+
+		MessagePackReader reader = new(sequence);
+
+		if (policy.HasFlag(SerializeDefaultValuesPolicy.Required))
+		{
+			// One parameter of two have a default value supplied. The other is inherently required.
+			// So although we provided no non-default values for this object, one property should be serialized.
+			Assert.Equal(1, reader.ReadMapHeader());
+			Assert.Equal(nameof(PersonWithRequiredAndOptionalParameters.Name), reader.ReadString());
+		}
+		else
+		{
+			Assert.Equal(0, reader.ReadMapHeader());
+		}
+	}
+
 	[GenerateShape]
 	public partial record Person
 	{
@@ -167,4 +263,19 @@ public partial class ShouldSerializeTests(ITestOutputHelper logger) : MessagePac
 		[PropertyShape(Name = "person_name")]
 		public string? Name { get; }
 	}
+
+	[GenerateShape]
+	public partial record PersonWithRequiredAndOptionalProperties
+	{
+		public required string? Name { get; set; }
+
+		public required int Stamina { get; set; }
+
+		public string? FavoriteColor { get; set; }
+
+		public int Age { get; set; }
+	}
+
+	[GenerateShape]
+	public partial record PersonWithRequiredAndOptionalParameters(string? Name, int? Age = null);
 }


### PR DESCRIPTION
Before, the choice was boolean: do you want to serialize properties with default values or not?

Now, it's a flags enum that allows you to choose always and never (as before), but also properties that are `required` (per C# rules), value types and/or ref types.