### PR TITLE
Fix PipeReader position after an async deserialization

### DIFF
--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -280,7 +280,7 @@ public partial record MessagePackSerializer
 	/// Deserializes a value from a <see cref="PipeReader"/>.
 	/// </summary>
 	/// <typeparam name="T">The type of value to deserialize.</typeparam>
-	/// <param name="reader">The reader to deserialize from.</param>
+	/// <param name="reader">The reader to deserialize from. <see cref="PipeReader.Complete(Exception?)"/> is <em>not</em> called on this at the conclusion of deserialization, and the reader is left at the position after the last msgpack byte read.</param>
 	/// <param name="shape">The shape of the type, as obtained from an <see cref="ITypeShapeProvider"/>.</param>
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>The deserialized value.</returns>
@@ -512,7 +512,7 @@ public partial record MessagePackSerializer
 		}
 
 #pragma warning disable NBMsgPackAsync
-		MessagePackAsyncReader asyncReader = new(reader) { CancellationToken = cancellationToken };
+		using MessagePackAsyncReader asyncReader = new(reader) { CancellationToken = cancellationToken };
 		await asyncReader.ReadAsync().ConfigureAwait(false);
 		return await converter.ReadAsync(asyncReader, context.Value).ConfigureAwait(false);
 #pragma warning restore NBMsgPackAsync

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -473,6 +473,7 @@ virtual Nerdbank.MessagePack.MessagePackSerializer.PrintMembers(System.Text.Stri
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.CancellationToken.init -> void
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.CreateBufferedReader() -> Nerdbank.MessagePack.MessagePackReader
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.CreateStreamingReader() -> Nerdbank.MessagePack.MessagePackStreamingReader
+[NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.Dispose() -> void
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.MessagePackAsyncReader(System.IO.Pipelines.PipeReader! pipeReader) -> void
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.ReadAsync() -> System.Threading.Tasks.ValueTask
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.ReturnReader(ref Nerdbank.MessagePack.MessagePackReader reader) -> void

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -429,6 +429,7 @@ virtual Nerdbank.MessagePack.MessagePackSerializer.PrintMembers(System.Text.Stri
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.CancellationToken.init -> void
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.CreateBufferedReader() -> Nerdbank.MessagePack.MessagePackReader
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.CreateStreamingReader() -> Nerdbank.MessagePack.MessagePackStreamingReader
+[NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.Dispose() -> void
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.MessagePackAsyncReader(System.IO.Pipelines.PipeReader! pipeReader) -> void
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.ReadAsync() -> System.Threading.Tasks.ValueTask
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.ReturnReader(ref Nerdbank.MessagePack.MessagePackReader reader) -> void

--- a/test/Nerdbank.MessagePack.Tests/MessagePackAsyncReaderTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackAsyncReaderTests.cs
@@ -20,7 +20,7 @@ public class MessagePackAsyncReaderTests
 		FragmentedPipeReader pipeReader = new(ros, ros.GetPosition(1));
 
 		SerializationContext context = new();
-		MessagePackAsyncReader reader = new(pipeReader) { CancellationToken = default };
+		using MessagePackAsyncReader reader = new(pipeReader) { CancellationToken = default };
 		await reader.BufferNextStructureAsync(context);
 	}
 }


### PR DESCRIPTION
Prior to this fix, the `MessagePackSerializer.DeserializeAsync<T>(PipeReader, ...)` methods would leave the `PipeReader` in an undefined state.