### PR TITLE
`Extension` struct enhancements

### DIFF
--- a/src/Nerdbank.MessagePack/Extension.cs
+++ b/src/Nerdbank.MessagePack/Extension.cs
@@ -15,7 +15,7 @@ public record struct Extension(sbyte TypeCode, ReadOnlySequence<byte> Data)
 	/// </summary>
 	/// <param name="typeCode"><inheritdoc cref="Extension(sbyte, ReadOnlySequence{byte})" path="/param[@name='TypeCode']"/></param>
 	/// <param name="data"><inheritdoc cref="Extension(sbyte, ReadOnlySequence{byte})" path="/param[@name='Data']"/></param>
-	public Extension(sbyte typeCode, Memory<byte> data)
+	public Extension(sbyte typeCode, ReadOnlyMemory<byte> data)
 		: this(typeCode, new ReadOnlySequence<byte>(data))
 	{
 	}

--- a/src/Nerdbank.MessagePack/Extension.cs
+++ b/src/Nerdbank.MessagePack/Extension.cs
@@ -23,5 +23,11 @@ public record struct Extension(sbyte TypeCode, ReadOnlySequence<byte> Data)
 	/// <summary>
 	/// Gets the header for the extension that should precede the <see cref="Data"/> in the msgpack encoded format.
 	/// </summary>
-	public ExtensionHeader Header => new(this.TypeCode, checked((uint)this.Data.Length));
+	public readonly ExtensionHeader Header => new(this.TypeCode, checked((uint)this.Data.Length));
+
+	/// <inheritdoc/>
+	public readonly bool Equals(Extension other) => this.TypeCode == other.TypeCode && this.Data.SequenceEqual(other.Data);
+
+	/// <inheritdoc/>
+	public override readonly int GetHashCode() => HashCode.Combine(this.TypeCode, this.Data.Length);
 }

--- a/src/Nerdbank.MessagePack/Utilities/ReadOnlySequenceExtensions.cs
+++ b/src/Nerdbank.MessagePack/Utilities/ReadOnlySequenceExtensions.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // This is a copy of the Sequence<T> class from the Nerdbank.Streams library.
+using Microsoft;
+
 namespace Nerdbank.MessagePack.Utilities;
 
 /// <summary>
 /// Extension methods for the <see cref="ReadOnlySequence{T}"/> type.
 /// </summary>
-internal static class ReadOnlySequenceExtensions
+internal static partial class ReadOnlySequenceExtensions
 {
 	/// <summary>
 	/// Copies the content of one <see cref="ReadOnlySequence{T}"/> to another that is backed by its own
@@ -25,4 +27,80 @@ internal static class ReadOnlySequenceExtensions
 		sequence.Write(template);
 		return sequence;
 	}
+
+	/// <summary>
+	/// Compares two <see cref="ReadOnlySequence{T}"/> instances for structural equality.
+	/// </summary>
+	/// <typeparam name="T">The type of element.</typeparam>
+	/// <param name="a">The first sequence.</param>
+	/// <param name="b">The second sequence.</param>
+	/// <returns>A boolean value indicating equality.</returns>
+	internal static bool SequenceEqual<T>(this in ReadOnlySequence<T> a, in ReadOnlySequence<T> b)
+#if !NET
+		where T : IEquatable<T>
+#endif
+	{
+		if (a.Length != b.Length)
+		{
+			return false;
+		}
+
+		if (a.IsSingleSegment && b.IsSingleSegment)
+		{
+#if NET
+			return a.FirstSpan.SequenceEqual(b.FirstSpan);
+#else
+			return a.First.Span.SequenceEqual(b.First.Span);
+#endif
+		}
+
+		ReadOnlySequence<T>.Enumerator aEnumerator = a.GetEnumerator();
+		ReadOnlySequence<T>.Enumerator bEnumerator = b.GetEnumerator();
+
+		ReadOnlySpan<T> aCurrent = default;
+		ReadOnlySpan<T> bCurrent = default;
+		while (true)
+		{
+			bool aNext = TryGetNonEmptySpan(ref aEnumerator, ref aCurrent);
+			bool bNext = TryGetNonEmptySpan(ref bEnumerator, ref bCurrent);
+			if (!aNext && !bNext)
+			{
+				// We've reached the end of both sequences at the same time.
+				return true;
+			}
+			else if (aNext != bNext)
+			{
+				// One ran out of bytes before the other.
+				// We don't anticipate this, because we already checked the lengths.
+				throw Assumes.NotReachable();
+			}
+
+			int commonLength = Math.Min(aCurrent.Length, bCurrent.Length);
+			if (!aCurrent[..commonLength].SequenceEqual(bCurrent[..commonLength]))
+			{
+				return false;
+			}
+
+			aCurrent = aCurrent.Slice(commonLength);
+			bCurrent = bCurrent.Slice(commonLength);
+		}
+
+		static bool TryGetNonEmptySpan(ref ReadOnlySequence<T>.Enumerator enumerator, ref ReadOnlySpan<T> span)
+		{
+			while (span.Length == 0)
+			{
+				if (!enumerator.MoveNext())
+				{
+					return false;
+				}
+
+				span = enumerator.Current.Span;
+			}
+
+			return true;
+		}
+	}
+
+	[GenerateShape<ReadOnlySequence<byte>>]
+	private partial class Witness;
 }

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -52,7 +52,7 @@ Nerdbank.MessagePack.Extension.Deconstruct(out sbyte TypeCode, out System.Buffer
 Nerdbank.MessagePack.Extension.Equals(Nerdbank.MessagePack.Extension other) -> bool
 Nerdbank.MessagePack.Extension.Extension() -> void
 Nerdbank.MessagePack.Extension.Extension(sbyte TypeCode, System.Buffers.ReadOnlySequence<byte> Data) -> void
-Nerdbank.MessagePack.Extension.Extension(sbyte typeCode, System.Memory<byte> data) -> void
+Nerdbank.MessagePack.Extension.Extension(sbyte typeCode, System.ReadOnlyMemory<byte> data) -> void
 Nerdbank.MessagePack.Extension.Header.get -> Nerdbank.MessagePack.ExtensionHeader
 Nerdbank.MessagePack.Extension.TypeCode.get -> sbyte
 Nerdbank.MessagePack.Extension.TypeCode.set -> void

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -52,7 +52,7 @@ Nerdbank.MessagePack.Extension.Deconstruct(out sbyte TypeCode, out System.Buffer
 Nerdbank.MessagePack.Extension.Equals(Nerdbank.MessagePack.Extension other) -> bool
 Nerdbank.MessagePack.Extension.Extension() -> void
 Nerdbank.MessagePack.Extension.Extension(sbyte TypeCode, System.Buffers.ReadOnlySequence<byte> Data) -> void
-Nerdbank.MessagePack.Extension.Extension(sbyte typeCode, System.Memory<byte> data) -> void
+Nerdbank.MessagePack.Extension.Extension(sbyte typeCode, System.ReadOnlyMemory<byte> data) -> void
 Nerdbank.MessagePack.Extension.Header.get -> Nerdbank.MessagePack.ExtensionHeader
 Nerdbank.MessagePack.Extension.TypeCode.get -> sbyte
 Nerdbank.MessagePack.Extension.TypeCode.set -> void

--- a/test/Nerdbank.MessagePack.Tests/ExtensionTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ExtensionTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public class ExtensionTests
+{
+	private Extension ext1a = new(1, new byte[] { 1, 2, 3 });
+	private Extension ext1b = new(1, new byte[] { 1, 2, 3 });
+	private Extension ext2 = new(2, new byte[] { 1, 2, 3, 4, 5 });
+	private Extension ext3 = new(1, new byte[] { 1, 2, 4, 5 });
+
+	[Fact]
+	public void Equality()
+	{
+		Assert.Equal(this.ext1a, this.ext1b);
+		Assert.NotEqual(this.ext1a, this.ext2);
+		Assert.NotEqual(this.ext1a, this.ext3);
+	}
+
+	[Fact]
+	public void GetHashCode_Overridden()
+	{
+		Assert.Equal(this.ext1a.GetHashCode(), this.ext1b.GetHashCode());
+		Assert.NotEqual(this.ext1a.GetHashCode(), this.ext2.GetHashCode());
+		Assert.NotEqual(this.ext1a.GetHashCode(), this.ext3.GetHashCode());
+	}
+}


### PR DESCRIPTION
This pull request includes several changes to the `Nerdbank.MessagePack` library, focusing on improving the equality checks and updating the `Extension` struct. The most significant changes include the addition of equality and hash code methods, the removal of a redundant method, and the introduction of new tests for equality and hash code verification.

### Enhancements to Equality and Hash Code Methods:
* [`src/Nerdbank.MessagePack/Extension.cs`](diffhunk://#diff-14c13e2f1a37fe61f6ea08be93b041654d4515620cca6f949dd74967a9ba3e2bL18-R32): Added `Equals` and `GetHashCode` methods to the `Extension` struct to improve equality checks and hash code generation.

### Code Simplification:
* [`src/Nerdbank.MessagePack/RawMessagePack.cs`](diffhunk://#diff-9e5da3f37b04cce622d8e25b814573807e593a3373b0fe6a6b7ec873cd9fb781L113-L178): Removed the private `SequenceEqual` method and replaced its usage with the new `SequenceEqual` extension method.
* [`src/Nerdbank.MessagePack/Utilities/ReadOnlySequenceExtensions.cs`](diffhunk://#diff-2e441b06f63508dae92c2351d7a569d08433d3473889e923545ce90ee107fd0eR30-R105): Added a new `SequenceEqual` extension method for `ReadOnlySequence<T>`, which was moved from `RawMessagePack`.

### API Updates:
* [`src/Nerdbank.MessagePack/Extension.cs`](diffhunk://#diff-14c13e2f1a37fe61f6ea08be93b041654d4515620cca6f949dd74967a9ba3e2bL18-R32): Changed the constructor parameter type from `Memory<byte>` to `ReadOnlyMemory<byte>`.
* `src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt` and `src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt`: Updated the API documentation to reflect the constructor parameter type change. [[1]](diffhunk://#diff-065f63a198ca8513e6d3f47f9ebff0e40d69992f852362c423b0258ac7d974ebL55-R55) [[2]](diffhunk://#diff-a05d14b6acd608c3d2f257f2960323c46e80453920406c051f30d640b0ec7c7cL55-R55)

### Testing Enhancements:
* [`test/Nerdbank.MessagePack.Tests/ExtensionTests.cs`](diffhunk://#diff-d1745c53d9d158193ddc367184e0f0817252cd5ba490e54b858830f7a5f1b6b1R1-R26): Added new tests to verify the equality and hash code methods for the `Extension` struct.