### PR TITLE
Fix header+body based `TryRead` methods on `MessagePackStreamingReader`

### DIFF
--- a/test/Nerdbank.MessagePack.Tests/MessagePackStreamingReaderTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackStreamingReaderTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable NBMsgPackAsync // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using System.Text;
 using DecodeResult = Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult;
 
 public class MessagePackStreamingReaderTests(ITestOutputHelper logger)
@@ -117,6 +118,126 @@ public class MessagePackStreamingReaderTests(ITestOutputHelper logger)
 		Assert.False(boolValue);
 		Assert.Equal(ros.End, reader.Position);
 		logger.WriteLine($"Fetched {fetchCount} times (for a sequence that is {ros.Length} bytes long.)");
+	}
+
+	[Fact]
+	public async Task TryRead_Extension()
+	{
+		Extension originalExtension = new(1, new byte[] { 1, 2, 3 });
+
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.Write(originalExtension);
+		writer.Flush();
+
+		FragmentedPipeReader pipeReader = new(seq);
+		MessagePackStreamingReader reader = new(
+			seq.AsReadOnlySequence.Slice(0, 3),
+			(_, pos, examined, ct) => new(new ReadResult(seq.AsReadOnlySequence.Slice(pos), false, true)),
+			null);
+		Extension deserializedExtension;
+		while (reader.TryRead(out deserializedExtension).NeedsMoreBytes())
+		{
+			reader = new(await reader.FetchMoreBytesAsync());
+		}
+
+		Assert.Equal(originalExtension, deserializedExtension);
+	}
+
+	[Fact]
+	public async Task TryReadBinary()
+	{
+		byte[] originalData = [1, 2, 3];
+
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.Write(originalData);
+		writer.Flush();
+
+		FragmentedPipeReader pipeReader = new(seq);
+		MessagePackStreamingReader reader = new(
+			seq.AsReadOnlySequence.Slice(0, 2),
+			(_, pos, examined, ct) => new(new ReadResult(seq.AsReadOnlySequence.Slice(pos), false, true)),
+			null);
+		ReadOnlySequence<byte> deserializedData;
+		while (reader.TryReadBinary(out deserializedData).NeedsMoreBytes())
+		{
+			reader = new(await reader.FetchMoreBytesAsync());
+		}
+
+		Assert.Equal(originalData, deserializedData.ToArray());
+	}
+
+	[Fact]
+	public async Task TryRead_String()
+	{
+		string originalData = "hello";
+
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.Write(originalData);
+		writer.Flush();
+
+		FragmentedPipeReader pipeReader = new(seq);
+		MessagePackStreamingReader reader = new(
+			seq.AsReadOnlySequence.Slice(0, 2),
+			(_, pos, examined, ct) => new(new ReadResult(seq.AsReadOnlySequence.Slice(pos), false, true)),
+			null);
+		string? deserializedString;
+		while (reader.TryRead(out deserializedString).NeedsMoreBytes())
+		{
+			reader = new(await reader.FetchMoreBytesAsync());
+		}
+
+		Assert.Equal(originalData, deserializedString);
+	}
+
+	[Fact]
+	public async Task TryReadStringSequence()
+	{
+		string originalData = "hello";
+
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.Write(originalData);
+		writer.Flush();
+
+		FragmentedPipeReader pipeReader = new(seq);
+		MessagePackStreamingReader reader = new(
+			seq.AsReadOnlySequence.Slice(0, 2),
+			(_, pos, examined, ct) => new(new ReadResult(seq.AsReadOnlySequence.Slice(pos), false, true)),
+			null);
+		ReadOnlySequence<byte> deserializedString;
+		while (reader.TryReadStringSequence(out deserializedString).NeedsMoreBytes())
+		{
+			reader = new(await reader.FetchMoreBytesAsync());
+		}
+
+		Assert.Equal(originalData, Encoding.UTF8.GetString(deserializedString.ToArray()));
+	}
+
+	[Fact]
+	public async Task TryReadStringSpan()
+	{
+		string originalData = "hello";
+
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.Write(originalData);
+		writer.Flush();
+
+		FragmentedPipeReader pipeReader = new(seq);
+		MessagePackStreamingReader reader = new(
+			seq.AsReadOnlySequence.Slice(0, 2),
+			(_, pos, examined, ct) => new(new ReadResult(seq.AsReadOnlySequence.Slice(pos), false, true)),
+			null);
+		ReadOnlySpan<byte> deserializedString;
+		while (reader.TryReadStringSpan(out bool contiguous, out deserializedString).NeedsMoreBytes())
+		{
+			reader = new(await reader.FetchMoreBytesAsync());
+		}
+
+		Assert.Equal(originalData, Encoding.UTF8.GetString(deserializedString.ToArray()));
 	}
 
 	private static ReadOnlySequence<byte> CreateMsgPackArrayOf3Bools()


### PR DESCRIPTION
Fix MessagePackStreamingReader multi-read methods in insufficient buffer scenarios

Several read methods read a header and then the data in two steps as an implementation detail. When there is sufficient buffer to read the first time, but insufficient the second time, these methods were all failing to "rewind" the reader so that buffering more and retrying could be done from the original point. These bugs led to a `TokenMismatch` error on subsequent attempts.

Fixed APIs are:

- `MessagePackStreamingReader.TryRead(out Extension)`
- `MessagePackStreamingReader.TryReadBinary`
- `MessagePackStreamingReader.TryRead(out string)`
- `MessagePackStreamingReader.TryReadStringSequence`
- `MessagePackStreamingReader.TryReadStringSpan`