### PR TITLE
Add streaming enumeration of sequences with envelopes 

### DIFF
--- a/docfx/docs/streaming-deserialization.md
+++ b/docfx/docs/streaming-deserialization.md
@@ -18,7 +18,7 @@ Two forms are supported:
 ## Sequence with no envelope
 
 A sequence of msgpack structures without an array or any other data is said to have no envelope.
-To asynchronously enumerate each of these structures, we use the @Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync* methods that take no JSONPath parameter, such as @Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync``1(System.IO.Pipelines.PipeReader,System.Threading.CancellationToken).
+To asynchronously enumerate each of these structures, we use the @Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync* methods that take no @Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions`2 parameter, such as @Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync``1(System.IO.Pipelines.PipeReader,System.Threading.CancellationToken).
 
 # [.NET](#tab/net)
 
@@ -36,9 +36,17 @@ A sequence of msgpack structures that are found within a larger structure (e.g. 
 To asynchronously enumerate each of these structures requires first parsing through the envelope preamble to navigate to the sequence.
 After enumerating the sequence, the remainder of the envelope is parsed in order to leave the reader positioned at valid position, at the end of the overall msgpack structure.
 
-Navigating through the envelope is done by a [JSONPath](https://wikipedia.org/wiki/JSONPath) argument passed to any of the @Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync* methods that accept that as a parameter.
+Navigating through the envelope is done by an expression provided to the @Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions`2 argument passed to any of the @Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync* methods that accept that as a parameter.
 
-JSONPath is formally more expressive than these methods require or support.
-It is also insufficient to navigate msgpack structures that utilize features unsupported by JSON (e.g. maps with non-@System.String keys).
+# [.NET](#tab/net)
 
-🚧 This is not yet supported. 🚧
+[!code-csharp[](../../samples/StreamingDeserialization.cs#StreamingEnumerationWithEnvelopeNET)]
+
+# [.NET Standard](#tab/netfx)
+
+[!code-csharp[](../../samples/StreamingDeserialization.cs#StreamingEnumerationWithEnvelopeNETFX)]
+
+---
+
+The paths from envelope to sequence may include stepping through properties, indexing into arrays or even dictionaries.
+However, not every valid C# expression will be accepted as a path.

--- a/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
@@ -168,4 +168,10 @@ internal class ObjectMapWithNonDefaultCtorConverter<TDeclaringType, TArgumentSta
 
 		return value;
 	}
+
+	/// <inheritdoc/>
+	private protected override bool TryMatchPropertyName(ReadOnlySpan<byte> propertyName, string expectedName)
+	{
+		return parameters.Readers?.TryGetValue(propertyName, out DeserializableProperty<TArgumentState> propertyReader) is true && propertyReader.Name == expectedName;
+	}
 }

--- a/src/Nerdbank.MessagePack/IMessagePackConverter.cs
+++ b/src/Nerdbank.MessagePack/IMessagePackConverter.cs
@@ -48,4 +48,29 @@ public interface IMessagePackConverter
 
 	/// <inheritdoc cref="MessagePackConverter{T}.GetJsonSchema(JsonSchemaContext, ITypeShape)"/>
 	JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape);
+
+	/// <summary>
+	/// Skips ahead in the msgpack data to the point where the value of the specified property can be read.
+	/// </summary>
+	/// <param name="reader">The reader.</param>
+	/// <param name="propertyShape">The shape of the property whose value is to be skipped to.</param>
+	/// <param name="context">The serialization context.</param>
+	/// <returns><see langword="true" /> if the specified property was found in the data and the value is ready to be read; <see langword="false" /> otherwise.</returns>
+	/// <remarks><inheritdoc cref="SkipToIndexValueAsync(MessagePackAsyncReader, object?, SerializationContext)" path="/remarks"/></remarks>
+	[Experimental("NBMsgPackAsync")]
+	ValueTask<bool> SkipToPropertyValueAsync(MessagePackAsyncReader reader, IPropertyShape propertyShape, SerializationContext context);
+
+	/// <summary>
+	/// Skips ahead in the msgpack data to the point where the value at the specified index can be read.
+	/// </summary>
+	/// <param name="reader">The reader.</param>
+	/// <param name="index">The key or index of the value to be retrieved.</param>
+	/// <param name="context">The serialization context.</param>
+	/// <returns><see langword="true" /> if the specified index was found in the data and the value is ready to be read; <see langword="false" /> otherwise.</returns>
+	/// <remarks>
+	/// This method is used by <see cref="MessagePackSerializer.DeserializeEnumerableAsync{T, TElement}(System.IO.Pipelines.PipeReader, ITypeShape{T}, MessagePackSerializer.StreamingEnumerationOptions{T, TElement}, CancellationToken)"/>
+	/// to skip to the starting position of a sequence that should be asynchronously enumerated.
+	/// </remarks>
+	[Experimental("NBMsgPackAsync")]
+	ValueTask<bool> SkipToIndexValueAsync(MessagePackAsyncReader reader, object? index, SerializationContext context);
 }

--- a/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
+++ b/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
@@ -142,6 +142,16 @@ public abstract class MessagePackConverter<T> : IMessagePackConverter, IMessageP
 	public virtual JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape) => null;
 
 	/// <inheritdoc/>
+	[Experimental("NBMsgPackAsync")]
+	public virtual ValueTask<bool> SkipToPropertyValueAsync(MessagePackAsyncReader reader, IPropertyShape propertyShape, SerializationContext context)
+		=> throw new NotSupportedException($"The {this.GetType().FullName} converter does not support this operation.");
+
+	/// <inheritdoc/>
+	[Experimental("NBMsgPackAsync")]
+	public virtual ValueTask<bool> SkipToIndexValueAsync(MessagePackAsyncReader reader, object? index, SerializationContext context)
+		=> throw new NotSupportedException($"The {this.GetType().FullName} converter does not support this operation.");
+
+	/// <inheritdoc/>
 	void IMessagePackConverter.Write(ref MessagePackWriter writer, object? value, SerializationContext context)
 	{
 		this.Write(ref writer, (T?)value, context);

--- a/src/Nerdbank.MessagePack/MessagePackReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackReader.cs
@@ -93,6 +93,13 @@ public ref partial struct MessagePackReader
 		}
 	}
 
+	/// <inheritdoc cref="MessagePackStreamingReader.ExpectedRemainingStructures"/>
+	internal uint ExpectedRemainingStructures
+	{
+		get => this.streamingReader.ExpectedRemainingStructures;
+		set => this.streamingReader.ExpectedRemainingStructures = value;
+	}
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="MessagePackReader"/> struct,
 	/// with the same settings as this one, but with its own buffer to read from.
@@ -161,7 +168,7 @@ public ref partial struct MessagePackReader
 	/// <summary>
 	/// Reads a sequence of bytes without any decoding.
 	/// </summary>
-	/// <param name="length">The number of bytes to read.</param>
+	/// <param name="length"><inheritdoc cref="MessagePackStreamingReader.TryReadRaw(long, out ReadOnlySequence{byte})" path="/param[@name='length']"/></param>
 	/// <returns>
 	/// The raw MessagePack sequence, taken as a slice from the <see cref="Sequence"/>.
 	/// The caller should copy any data that must out-live its underlying buffers.
@@ -619,6 +626,10 @@ public ref partial struct MessagePackReader
 	/// <see cref="MessagePackCode.Ext32"/>.
 	/// </summary>
 	/// <returns>The extension header.</returns>
+	/// <remarks>
+	/// This call should always be followed by a successful call to <see cref="ReadRaw(long)"/>,
+	/// with the length of bytes specified by <see cref="ExtensionHeader.Length"/> (even if zero), so that the overall structure can be recorded as read.
+	/// </remarks>
 	/// <exception cref="EndOfStreamException">
 	/// Thrown if the header cannot be read in the bytes left in the <see cref="Sequence"/>
 	/// or if it is clear that there are insufficient bytes remaining after the header to include all the bytes the header claims to be there.
@@ -649,6 +660,10 @@ public ref partial struct MessagePackReader
 	/// <param name="extensionHeader">Receives the extension header if the remaining bytes in the <see cref="Sequence"/> fully describe the header.</param>
 	/// <returns>A value indicating whether an extension header is fully represented at the reader's position.</returns>
 	/// <exception cref="MessagePackSerializationException">Thrown if a code other than an extension format header is encountered.</exception>
+	/// <remarks>
+	/// This call should always be followed by a successful call to <see cref="ReadRaw(long)"/>,
+	/// with the length of bytes specified by <see cref="ExtensionHeader.Length"/> (even if zero), so that the overall structure can be recorded as read.
+	/// </remarks>
 	public bool TryReadExtensionHeader(out ExtensionHeader extensionHeader)
 	{
 		switch (this.streamingReader.TryRead(out extensionHeader))

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.AutomatedFriendlyOverloads.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.AutomatedFriendlyOverloads.cs
@@ -56,6 +56,13 @@ public partial record MessagePackSerializer
 #pragma warning restore RS0027 // optional parameter on a method with overloads
 		where T : IShapeable<T> => this.DeserializeEnumerableAsync(reader, T.GetShape(), cancellationToken);
 
+	/// <inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" />
+#pragma warning disable RS0027 // optional parameter on a method with overloads
+	[ExcludeFromCodeCoverage]
+	public IAsyncEnumerable<TElement?> DeserializeEnumerableAsync<T, TElement>(PipeReader reader, StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
+#pragma warning restore RS0027 // optional parameter on a method with overloads
+		where T : IShapeable<T> => this.DeserializeEnumerableAsync(reader, T.GetShape(), options, cancellationToken);
+
 	/// <inheritdoc cref="DeserializeAsync{T}(Stream, ITypeShape{T}, CancellationToken)" />
 #pragma warning disable RS0027 // optional parameter on a method with overloads
 	[ExcludeFromCodeCoverage]
@@ -69,6 +76,13 @@ public partial record MessagePackSerializer
 	public IAsyncEnumerable<T?> DeserializeEnumerableAsync<T>(Stream stream, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
 		where T : IShapeable<T> => this.DeserializeEnumerableAsync(stream, T.GetShape(), cancellationToken);
+
+	/// <inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(Stream, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" />
+#pragma warning disable RS0027 // optional parameter on a method with overloads
+	[ExcludeFromCodeCoverage]
+	public IAsyncEnumerable<TElement?> DeserializeEnumerableAsync<T, TElement>(Stream stream, StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
+#pragma warning restore RS0027 // optional parameter on a method with overloads
+		where T : IShapeable<T> => this.DeserializeEnumerableAsync(stream, T.GetShape(), options, cancellationToken);
 
 	/// <inheritdoc cref="SerializeAsync{T}(PipeWriter, T, ITypeShape{T}, CancellationToken)" />
 #pragma warning disable RS0027 // optional parameter on a method with overloads
@@ -128,6 +142,13 @@ public partial record MessagePackSerializer
 #pragma warning restore RS0027 // optional parameter on a method with overloads
 		where TProvider : IShapeable<T> => this.DeserializeEnumerableAsync(reader, TProvider.GetShape(), cancellationToken);
 
+	/// <inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" />
+#pragma warning disable RS0027 // optional parameter on a method with overloads
+	[ExcludeFromCodeCoverage]
+	public IAsyncEnumerable<TElement?> DeserializeEnumerableAsync<T, TElement, TProvider>(PipeReader reader, StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
+#pragma warning restore RS0027 // optional parameter on a method with overloads
+		where TProvider : IShapeable<T> => this.DeserializeEnumerableAsync(reader, TProvider.GetShape(), options, cancellationToken);
+
 	/// <inheritdoc cref="DeserializeAsync{T}(Stream, ITypeShape{T}, CancellationToken)" />
 #pragma warning disable RS0027 // optional parameter on a method with overloads
 	[ExcludeFromCodeCoverage]
@@ -141,6 +162,13 @@ public partial record MessagePackSerializer
 	public IAsyncEnumerable<T?> DeserializeEnumerableAsync<T, TProvider>(Stream stream, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
 		where TProvider : IShapeable<T> => this.DeserializeEnumerableAsync(stream, TProvider.GetShape(), cancellationToken);
+
+	/// <inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(Stream, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" />
+#pragma warning disable RS0027 // optional parameter on a method with overloads
+	[ExcludeFromCodeCoverage]
+	public IAsyncEnumerable<TElement?> DeserializeEnumerableAsync<T, TElement, TProvider>(Stream stream, StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
+#pragma warning restore RS0027 // optional parameter on a method with overloads
+		where TProvider : IShapeable<T> => this.DeserializeEnumerableAsync(stream, TProvider.GetShape(), options, cancellationToken);
 
 	/// <inheritdoc cref="SerializeAsync{T}(PipeWriter, T, ITypeShape{T}, CancellationToken)" />
 #pragma warning disable RS0027 // optional parameter on a method with overloads

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.AutomatedFriendlyOverloads.tt
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.AutomatedFriendlyOverloads.tt
@@ -28,10 +28,10 @@ public partial record MessagePackSerializer
     
     foreach (ShapeSource shapeSource in Enum.GetValues(typeof(ShapeSource)))
     {
-        (string genericTypeParameters, string typeConstraint, string shapeProviderName) = shapeSource switch
+        (string genericTypeParameters, string genericTypeParametersWithElement, string typeConstraint, string shapeProviderName) = shapeSource switch
         {
-            ShapeSource.T => ("T","T : IShapeable<T>","T"),
-            ShapeSource.TProvider => ("T, TProvider","TProvider : IShapeable<T>","TProvider"),
+            ShapeSource.T => ("T","T, TElement", "T : IShapeable<T>","T"),
+            ShapeSource.TProvider => ("T, TProvider","T, TElement, TProvider","TProvider : IShapeable<T>","TProvider"),
             _ => throw new NotSupportedException(),
         };
 
@@ -97,6 +97,13 @@ public partial record MessagePackSerializer
 	public IAsyncEnumerable<T?> DeserializeEnumerableAsync<<#=genericTypeParameters#>>(<#=firstParameter#>, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
 		where <#=typeConstraint#> => this.DeserializeEnumerableAsync(<#=firstArg#>, <#=shapeProviderName#>.GetShape(), cancellationToken);
+
+	/// <inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(<#=firstParameterDocId#>ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" />
+#pragma warning disable RS0027 // optional parameter on a method with overloads
+	[ExcludeFromCodeCoverage]
+	public IAsyncEnumerable<TElement?> DeserializeEnumerableAsync<<#=genericTypeParametersWithElement#>>(<#=firstParameter#>, StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
+#pragma warning restore RS0027 // optional parameter on a method with overloads
+		where <#=typeConstraint#> => this.DeserializeEnumerableAsync(<#=firstArg#>, <#=shapeProviderName#>.GetShape(), options, cancellationToken);
 <#
         }
 

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.FriendlyOverloads.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.FriendlyOverloads.cs
@@ -4,6 +4,7 @@
 #pragma warning disable RS0026 // optional parameter on a method with overloads
 #pragma warning disable RS0027 // optional parameter on a method with overloads
 
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
 using Microsoft;
@@ -301,18 +302,37 @@ public partial record MessagePackSerializer
 		return result;
 	}
 
-	/// <summary>
-	/// Deserializes an enumerable from a <see cref="Stream"/>.
-	/// </summary>
-	/// <typeparam name="T"><inheritdoc cref="SerializeAsync{T}(PipeWriter, T, ITypeShapeProvider, CancellationToken)" path="/typeparam[@name='T']"/></typeparam>
+	/// <summary><inheritdoc cref="DeserializeEnumerableAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" path="/summary"/></summary>
+	/// <typeparam name="T"><inheritdoc cref="DeserializeEnumerableAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" path="/typeparam[@name='T']"/></typeparam>
 	/// <param name="stream">The stream to deserialize from. If this stream contains more than one top-level msgpack structure, it may be positioned beyond its end after deserialization due to buffering.</param>
-	/// <param name="shape"><inheritdoc cref="DeserializeAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" path="/param[@name='shape']"/></param>
-	/// <param name="cancellationToken"><inheritdoc cref="DeserializeAsync{T}(PipeReader, ITypeShapeProvider, CancellationToken)" path="/param[@name='cancellationToken']"/></param>
-	/// <returns><inheritdoc cref="DeserializeAsync{T}(PipeReader, ITypeShapeProvider, CancellationToken)" path="/returns"/></returns>
+	/// <param name="shape"><inheritdoc cref="DeserializeEnumerableAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" path="/param[@name='shape']"/></param>
+	/// <param name="cancellationToken"><inheritdoc cref="DeserializeEnumerableAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" path="/param[@name='cancellationToken']"/></param>
+	/// <returns><inheritdoc cref="DeserializeEnumerableAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" path="/returns"/></returns>
+	/// <remarks><inheritdoc cref="DeserializeEnumerableAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" path="/remarks"/></remarks>
 	public async IAsyncEnumerable<T?> DeserializeEnumerableAsync<T>(Stream stream, ITypeShape<T> shape, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 	{
 		PipeReader pipeReader = PipeReader.Create(stream, PipeReaderOptions);
 		await foreach (T? result in this.DeserializeEnumerableAsync<T>(pipeReader, shape, cancellationToken).ConfigureAwait(false))
+		{
+			yield return result;
+		}
+
+		await pipeReader.CompleteAsync().ConfigureAwait(false);
+	}
+
+	/// <summary><inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" path="/summary"/></summary>
+	/// <typeparam name="T"><inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" path="/typeparam[@name='T']"/></typeparam>
+	/// <typeparam name="TElement"><inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" path="/typeparam[@name='TElement']"/></typeparam>
+	/// <param name="stream">The stream to deserialize from. If this stream contains more than one top-level msgpack structure, it may be positioned beyond its end after deserialization due to buffering.</param>
+	/// <param name="shape"><inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" path="/param[@name='shape']"/></param>
+	/// <param name="options"><inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" path="/param[@name='options']"/></param>
+	/// <param name="cancellationToken"><inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" path="/param[@name='cancellationToken']"/></param>
+	/// <returns><inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" path="/returns"/></returns>
+	/// <remarks><inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, StreamingEnumerationOptions{T, TElement}, CancellationToken)" path="/remarks"/></remarks>
+	public async IAsyncEnumerable<TElement?> DeserializeEnumerableAsync<T, TElement>(Stream stream, ITypeShape<T> shape, StreamingEnumerationOptions<T, TElement> options, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		PipeReader pipeReader = PipeReader.Create(stream, PipeReaderOptions);
+		await foreach (TElement? result in this.DeserializeEnumerableAsync(pipeReader, shape, options, cancellationToken).ConfigureAwait(false))
 		{
 			yield return result;
 		}

--- a/src/Nerdbank.MessagePack/MessagePackStreamingReader.Integers.cs
+++ b/src/Nerdbank.MessagePack/MessagePackStreamingReader.Integers.cs
@@ -29,7 +29,7 @@ public ref partial struct MessagePackStreamingReader
 		DecodeResult readResult = MessagePackPrimitives.TryRead(this.reader.UnreadSpan, out value, out int tokenSize);
 		if (readResult == DecodeResult.Success)
 		{
-			this.reader.Advance(tokenSize);
+			this.Advance(tokenSize);
 			return DecodeResult.Success;
 		}
 
@@ -40,7 +40,7 @@ public ref partial struct MessagePackStreamingReader
 			switch (readResult)
 			{
 				case DecodeResult.Success:
-					self.reader.Advance(tokenSize);
+					self.Advance(tokenSize);
 					return DecodeResult.Success;
 				case DecodeResult.TokenMismatch:
 					return DecodeResult.TokenMismatch;
@@ -77,7 +77,7 @@ public ref partial struct MessagePackStreamingReader
 		DecodeResult readResult = MessagePackPrimitives.TryRead(this.reader.UnreadSpan, out value, out int tokenSize);
 		if (readResult == DecodeResult.Success)
 		{
-			this.reader.Advance(tokenSize);
+			this.Advance(tokenSize);
 			return DecodeResult.Success;
 		}
 
@@ -88,7 +88,7 @@ public ref partial struct MessagePackStreamingReader
 			switch (readResult)
 			{
 				case DecodeResult.Success:
-					self.reader.Advance(tokenSize);
+					self.Advance(tokenSize);
 					return DecodeResult.Success;
 				case DecodeResult.TokenMismatch:
 					return DecodeResult.TokenMismatch;
@@ -125,7 +125,7 @@ public ref partial struct MessagePackStreamingReader
 		DecodeResult readResult = MessagePackPrimitives.TryRead(this.reader.UnreadSpan, out value, out int tokenSize);
 		if (readResult == DecodeResult.Success)
 		{
-			this.reader.Advance(tokenSize);
+			this.Advance(tokenSize);
 			return DecodeResult.Success;
 		}
 
@@ -136,7 +136,7 @@ public ref partial struct MessagePackStreamingReader
 			switch (readResult)
 			{
 				case DecodeResult.Success:
-					self.reader.Advance(tokenSize);
+					self.Advance(tokenSize);
 					return DecodeResult.Success;
 				case DecodeResult.TokenMismatch:
 					return DecodeResult.TokenMismatch;
@@ -173,7 +173,7 @@ public ref partial struct MessagePackStreamingReader
 		DecodeResult readResult = MessagePackPrimitives.TryRead(this.reader.UnreadSpan, out value, out int tokenSize);
 		if (readResult == DecodeResult.Success)
 		{
-			this.reader.Advance(tokenSize);
+			this.Advance(tokenSize);
 			return DecodeResult.Success;
 		}
 
@@ -184,7 +184,7 @@ public ref partial struct MessagePackStreamingReader
 			switch (readResult)
 			{
 				case DecodeResult.Success:
-					self.reader.Advance(tokenSize);
+					self.Advance(tokenSize);
 					return DecodeResult.Success;
 				case DecodeResult.TokenMismatch:
 					return DecodeResult.TokenMismatch;
@@ -221,7 +221,7 @@ public ref partial struct MessagePackStreamingReader
 		DecodeResult readResult = MessagePackPrimitives.TryRead(this.reader.UnreadSpan, out value, out int tokenSize);
 		if (readResult == DecodeResult.Success)
 		{
-			this.reader.Advance(tokenSize);
+			this.Advance(tokenSize);
 			return DecodeResult.Success;
 		}
 
@@ -232,7 +232,7 @@ public ref partial struct MessagePackStreamingReader
 			switch (readResult)
 			{
 				case DecodeResult.Success:
-					self.reader.Advance(tokenSize);
+					self.Advance(tokenSize);
 					return DecodeResult.Success;
 				case DecodeResult.TokenMismatch:
 					return DecodeResult.TokenMismatch;
@@ -269,7 +269,7 @@ public ref partial struct MessagePackStreamingReader
 		DecodeResult readResult = MessagePackPrimitives.TryRead(this.reader.UnreadSpan, out value, out int tokenSize);
 		if (readResult == DecodeResult.Success)
 		{
-			this.reader.Advance(tokenSize);
+			this.Advance(tokenSize);
 			return DecodeResult.Success;
 		}
 
@@ -280,7 +280,7 @@ public ref partial struct MessagePackStreamingReader
 			switch (readResult)
 			{
 				case DecodeResult.Success:
-					self.reader.Advance(tokenSize);
+					self.Advance(tokenSize);
 					return DecodeResult.Success;
 				case DecodeResult.TokenMismatch:
 					return DecodeResult.TokenMismatch;
@@ -317,7 +317,7 @@ public ref partial struct MessagePackStreamingReader
 		DecodeResult readResult = MessagePackPrimitives.TryRead(this.reader.UnreadSpan, out value, out int tokenSize);
 		if (readResult == DecodeResult.Success)
 		{
-			this.reader.Advance(tokenSize);
+			this.Advance(tokenSize);
 			return DecodeResult.Success;
 		}
 
@@ -328,7 +328,7 @@ public ref partial struct MessagePackStreamingReader
 			switch (readResult)
 			{
 				case DecodeResult.Success:
-					self.reader.Advance(tokenSize);
+					self.Advance(tokenSize);
 					return DecodeResult.Success;
 				case DecodeResult.TokenMismatch:
 					return DecodeResult.TokenMismatch;
@@ -365,7 +365,7 @@ public ref partial struct MessagePackStreamingReader
 		DecodeResult readResult = MessagePackPrimitives.TryRead(this.reader.UnreadSpan, out value, out int tokenSize);
 		if (readResult == DecodeResult.Success)
 		{
-			this.reader.Advance(tokenSize);
+			this.Advance(tokenSize);
 			return DecodeResult.Success;
 		}
 
@@ -376,7 +376,7 @@ public ref partial struct MessagePackStreamingReader
 			switch (readResult)
 			{
 				case DecodeResult.Success:
-					self.reader.Advance(tokenSize);
+					self.Advance(tokenSize);
 					return DecodeResult.Success;
 				case DecodeResult.TokenMismatch:
 					return DecodeResult.TokenMismatch;

--- a/src/Nerdbank.MessagePack/MessagePackStreamingReader.Integers.tt
+++ b/src/Nerdbank.MessagePack/MessagePackStreamingReader.Integers.tt
@@ -50,7 +50,7 @@ foreach (var intType in allTypes) {
 		DecodeResult readResult = MessagePackPrimitives.TryRead(this.reader.UnreadSpan, out value, out int tokenSize);
 		if (readResult == DecodeResult.Success)
 		{
-			this.reader.Advance(tokenSize);
+			this.Advance(tokenSize);
 			return DecodeResult.Success;
 		}
 
@@ -61,7 +61,7 @@ foreach (var intType in allTypes) {
 			switch (readResult)
 			{
 				case DecodeResult.Success:
-					self.reader.Advance(tokenSize);
+					self.Advance(tokenSize);
 					return DecodeResult.Success;
 				case DecodeResult.TokenMismatch:
 					return DecodeResult.TokenMismatch;

--- a/src/Nerdbank.MessagePack/SerializationContext.cs
+++ b/src/Nerdbank.MessagePack/SerializationContext.cs
@@ -76,7 +76,7 @@ public record struct SerializationContext
 	/// Gets or sets the number of elements that must still be skipped to complete a skip operation.
 	/// </summary>
 	/// <value>0 when no skip operation was suspended and is still incomplete.</value>
-	internal int MidSkipRemainingCount { get; set; }
+	internal uint MidSkipRemainingCount { get; set; }
 
 	/// <summary>
 	/// Gets or sets special state to be exposed to converters during serialization.

--- a/src/Nerdbank.MessagePack/StreamingDeserializer`1.cs
+++ b/src/Nerdbank.MessagePack/StreamingDeserializer`1.cs
@@ -1,0 +1,277 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft;
+using PolyType.Abstractions;
+
+namespace Nerdbank.MessagePack;
+
+#pragma warning disable NBMsgPackAsync
+
+/// <summary>
+/// Manages searching for a sequence within a MessagePack stream and deserializing its elements asynchronously, producing each element as it is deserialized.
+/// </summary>
+/// <typeparam name="TElement">The type of element to be deserialized.</typeparam>
+/// <param name="serializer">The serializer.</param>
+/// <param name="provider">The provider to use to obtain the <see cref="ITypeShape"/> objects we need along the way.</param>
+/// <param name="reader">The async reader of the msgpack data.</param>
+/// <param name="context">Deserialization context.</param>
+internal readonly struct StreamingDeserializer<TElement>(MessagePackSerializer serializer, ITypeShapeProvider provider, MessagePackAsyncReader reader, SerializationContext context)
+{
+	/// <summary>
+	/// Enumerates the elements of an array at the given path in the MessagePack stream.
+	/// </summary>
+	/// <param name="path">The path to the sequence to be enumerated.</param>
+	/// <param name="throwOnUnreachableSequence"><see langword="true" /> to throw if the <paramref name="path"/> cannot be reached or it is null when we get there; <see langword="false" /> to produce an empty sequence in that situation instead.</param>
+	/// <param name="elementConverter">The shape of the element to be deserialized.</param>
+	/// <param name="skipTrailingBytes">A value indicating whether to bother fast-forwarding after completing the enumeration to position the reader at the EOF or next top-level structure.</param>
+	/// <returns>The async enumeration.</returns>
+	internal async IAsyncEnumerable<TElement?> EnumerateArrayAsync(Expression path, bool throwOnUnreachableSequence, MessagePackConverter<TElement> elementConverter, bool skipTrailingBytes)
+	{
+		// Navigate to the sequence.
+		{
+			if (await this.NavigateToMemberAsync(path).ConfigureAwait(false) is Expression incompleteExpression)
+			{
+				// The path was not found. We probably encountered a null or absent member along the path.
+				if (throwOnUnreachableSequence)
+				{
+					throw IncompletePathException(incompleteExpression);
+				}
+
+				yield break;
+			}
+		}
+
+		// Enumerate the actual sequence.
+		{
+			MessagePackStreamingReader streamingReader = reader.CreateStreamingReader();
+
+			bool isNil;
+			while (streamingReader.TryReadNil(out isNil).NeedsMoreBytes())
+			{
+				streamingReader = new(await streamingReader.FetchMoreBytesAsync().ConfigureAwait(false));
+			}
+
+			if (isNil)
+			{
+				if (throwOnUnreachableSequence)
+				{
+					throw IncompletePathException(path is LambdaExpression lambda ? lambda.Body : path);
+				}
+
+				reader.ReturnReader(ref streamingReader);
+				yield break;
+			}
+
+			int count;
+			while (streamingReader.TryReadArrayHeader(out count).NeedsMoreBytes())
+			{
+				streamingReader = new(await streamingReader.FetchMoreBytesAsync().ConfigureAwait(false));
+			}
+
+			reader.ReturnReader(ref streamingReader);
+			if (elementConverter.PreferAsyncSerialization)
+			{
+				for (int i = 0; i < count; i++)
+				{
+					yield return await elementConverter.ReadAsync(reader, context).ConfigureAwait(false);
+				}
+			}
+			else
+			{
+				for (int i = 0; i < count; i++)
+				{
+					await reader.BufferNextStructureAsync(context).ConfigureAwait(false);
+					MessagePackReader bufferedReader = reader.CreateBufferedReader();
+					TElement? element = elementConverter.Read(ref bufferedReader, context);
+					reader.ReturnReader(ref bufferedReader);
+					yield return element;
+				}
+			}
+		}
+
+		// Skip enough structures to effectively 'pop' the reader down to the end of the top-level msgpack structure we started with.
+		// That way, the PipeReader is positioned to read the next structure or obviously at the EOF position.
+		if (skipTrailingBytes)
+		{
+			await reader.AdvanceToEndOfTopLevelStructureAsync().ConfigureAwait(false);
+		}
+
+		static Exception IncompletePathException(Expression incompletePath)
+			=> new MessagePackSerializationException($"The path to the sequence could not be followed. {incompletePath} is missing or has a null value.");
+	}
+
+	private ValueTask<Expression?> NavigateToMemberAsync(Expression path)
+	{
+		return new AsyncExpressionVisitor(serializer, reader, provider, context).VisitAsync(path);
+	}
+
+	private struct AsyncExpressionVisitor(MessagePackSerializer serializer, MessagePackAsyncReader reader, ITypeShapeProvider provider, SerializationContext context)
+	{
+		internal async ValueTask<Expression?> VisitAsync(Expression? expression)
+		{
+			Expression? result = expression switch
+			{
+				LambdaExpression lambdaExpression => await this.VisitLambda(lambdaExpression).ConfigureAwait(false),
+				ParameterExpression parameterExpression => await this.VisitParameter(parameterExpression).ConfigureAwait(false),
+				MemberExpression memberExpression => await this.VisitMember(memberExpression).ConfigureAwait(false),
+				BinaryExpression arrayIndexExpression when expression.NodeType == ExpressionType.ArrayIndex => await this.VisitIndex(arrayIndexExpression).ConfigureAwait(false),
+				MethodCallExpression methodCallExpression => await this.VisitMethodCall(methodCallExpression).ConfigureAwait(false),
+				null => default,
+				_ => throw new NotSupportedException($"{expression.NodeType} is not a supported expression type."),
+			};
+
+			// If the visit worked, but the next value is nil, we return the expression that led us to the nil value.
+			if (result is null && await this.IsNilAsync().ConfigureAwait(false))
+			{
+				return expression;
+			}
+
+			return result;
+		}
+
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
+		private async ValueTask<Expression?> VisitMethodCall(MethodCallExpression expression)
+		{
+			if (expression is not { Object: not null, Method: { Name: "get_Item", IsSpecialName: true }, Arguments.Count: 1 })
+			{
+				throw new NotSupportedException("Unsupported method call expression.");
+			}
+
+			object? indexArg = expression.Arguments[0] switch
+			{
+				ConstantExpression constantExpression => constantExpression.Value,
+				MemberExpression memberExpression when memberExpression.Expression is ConstantExpression owner => memberExpression.Member switch
+				{
+					FieldInfo fieldInfo => fieldInfo.GetValue(owner.Value),
+					PropertyInfo propertyInfo => propertyInfo.GetValue(owner.Value),
+					_ => throw new NotSupportedException("Unsupported index expression."),
+				},
+				_ => throw new NotSupportedException("Unsupported index expression."),
+			};
+
+			// First navigate to the object.
+			if ((await this.VisitAsync(expression.Object).ConfigureAwait(false)) is Expression incompletePath)
+			{
+				return incompletePath;
+			}
+
+			// Ask the converter to retrieve the element at the given index.
+			// We use a converter to do the actual skipping.
+			ITypeShape? typeShape = provider.GetShape(expression.Object.Type);
+			Requires.Argument(typeShape is not null, nameof(expression), "The expression does not have a known type shape.");
+			IMessagePackConverterInternal converter = serializer.GetConverter(typeShape);
+
+			return await converter.SkipToIndexValueAsync(reader, indexArg, context).ConfigureAwait(false) ? null : expression;
+		}
+
+		private ValueTask<Expression?> VisitLambda(LambdaExpression lambdaExpression)
+		{
+			return this.VisitAsync(lambdaExpression.Body);
+		}
+
+		private ValueTask<Expression?> VisitParameter(ParameterExpression expression)
+		{
+			// Do nothing.
+			// We've reached the root of the expression.
+			return new((Expression?)null);
+		}
+
+		private async ValueTask<Expression?> VisitIndex(BinaryExpression expression)
+		{
+			if (expression.Right is not ConstantExpression { Value: int skipElements })
+			{
+				throw new NotSupportedException("Unsupported index expression.");
+			}
+
+			// First navigate to the expression.
+			if ((await this.VisitAsync(expression.Left).ConfigureAwait(false)) is Expression incompletePath)
+			{
+				return incompletePath;
+			}
+
+			// Skip the given number of elements.
+			MessagePackStreamingReader streamingReader = reader.CreateStreamingReader();
+			int count;
+			while (streamingReader.TryReadArrayHeader(out count).NeedsMoreBytes())
+			{
+				streamingReader = new(await streamingReader.FetchMoreBytesAsync().ConfigureAwait(false));
+			}
+
+			if (count < skipElements + 1)
+			{
+				reader.ReturnReader(ref streamingReader);
+				return expression;
+			}
+
+			for (int i = 0; i < skipElements; i++)
+			{
+				while (streamingReader.TrySkip(ref context).NeedsMoreBytes())
+				{
+					streamingReader = new(await streamingReader.FetchMoreBytesAsync().ConfigureAwait(false));
+				}
+			}
+
+			reader.ReturnReader(ref streamingReader);
+			return null;
+		}
+
+		private async ValueTask<Expression?> VisitMember(MemberExpression expression)
+		{
+			Requires.Argument(expression.Expression is not null, nameof(expression), "Expression must not be null.");
+
+			// First navigate to the expression.
+			if ((await this.VisitAsync(expression.Expression).ConfigureAwait(false)) is Expression incompletePath)
+			{
+				return incompletePath;
+			}
+
+			// Now navigate to the member.
+
+			// Find the matching property shape.
+			ITypeShape? typeShape = provider.GetShape(expression.Expression.Type);
+			Requires.Argument(typeShape is not null, nameof(expression), "The expression does not have a known type shape.");
+
+			IPropertyShape? propertyShape = typeShape switch
+			{
+				IObjectTypeShape objectTypeShape => FindPropertyByName(objectTypeShape, expression.Member.Name),
+				_ => null,
+			};
+			Requires.Argument(propertyShape is not null, nameof(expression), "The expression does not refer to a serialized property.");
+
+			// We use a converter to do the actual skipping.
+			IMessagePackConverterInternal converter = serializer.GetConverter(typeShape);
+
+			return await converter.SkipToPropertyValueAsync(reader, propertyShape, context).ConfigureAwait(false) ? null : expression;
+
+			static IPropertyShape? FindPropertyByName(IObjectTypeShape typeShape, string name)
+			{
+				foreach (IPropertyShape property in typeShape.Properties)
+				{
+					if (property.Name == name)
+					{
+						return property;
+					}
+				}
+
+				return null;
+			}
+		}
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
+
+		private async ValueTask<bool> IsNilAsync()
+		{
+			MessagePackStreamingReader streamingReader = reader.CreateStreamingReader();
+			bool isNil;
+			while (streamingReader.TryReadNil(out isNil).NeedsMoreBytes())
+			{
+				streamingReader = new(await streamingReader.FetchMoreBytesAsync().ConfigureAwait(false));
+			}
+
+			reader.ReturnReader(ref streamingReader);
+			return isNil;
+		}
+	}
+}

--- a/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/net8.0/PublicAPI.Unshipped.txt
@@ -192,6 +192,13 @@ Nerdbank.MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Pipelin
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Stream! stream, PolyType.Abstractions.ITypeShape<T>! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T?>
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Stream! stream, PolyType.ITypeShapeProvider! provider, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T?>
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T?>
+Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TElement, TProvider>(System.IO.Pipelines.PipeReader! reader, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement?>!
+Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TElement, TProvider>(System.IO.Stream! stream, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement?>!
+Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TElement>(System.IO.Pipelines.PipeReader! reader, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement?>!
+Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TElement>(System.IO.Pipelines.PipeReader! reader, PolyType.Abstractions.ITypeShape<T>! shape, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement?>!
+Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TElement>(System.IO.Pipelines.PipeReader! reader, PolyType.ITypeShapeProvider! provider, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement?>!
+Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TElement>(System.IO.Stream! stream, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement?>!
+Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TElement>(System.IO.Stream! stream, PolyType.Abstractions.ITypeShape<T>! shape, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement?>!
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TProvider>(System.IO.Pipelines.PipeReader! reader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TProvider>(System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T>(System.IO.Pipelines.PipeReader! reader, PolyType.Abstractions.ITypeShape<T>! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
@@ -254,6 +261,16 @@ Nerdbank.MessagePack.MessagePackSerializer.SerializeEnumValuesByName.init -> voi
 Nerdbank.MessagePack.MessagePackSerializer.SerializeObject(ref Nerdbank.MessagePack.MessagePackWriter writer, object? value, PolyType.Abstractions.ITypeShape! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 Nerdbank.MessagePack.MessagePackSerializer.StartingContext.get -> Nerdbank.MessagePack.SerializationContext
 Nerdbank.MessagePack.MessagePackSerializer.StartingContext.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.Deconstruct(out System.Linq.Expressions.Expression<System.Func<T, System.Collections.Generic.IEnumerable<TElement>!>!>! Path) -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.EmptySequenceForUndiscoverablePath.get -> bool
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.EmptySequenceForUndiscoverablePath.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.LeaveOpen.get -> bool
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.LeaveOpen.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.Path.get -> System.Linq.Expressions.Expression<System.Func<T, System.Collections.Generic.IEnumerable<TElement>!>!>!
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.Path.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.StreamingEnumerationOptions(Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! original) -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.StreamingEnumerationOptions(System.Linq.Expressions.Expression<System.Func<T, System.Collections.Generic.IEnumerable<TElement>!>!>! Path) -> void
 Nerdbank.MessagePack.MessagePackString
 Nerdbank.MessagePack.MessagePackString.Equals(Nerdbank.MessagePack.MessagePackString? other) -> bool
 Nerdbank.MessagePack.MessagePackString.IsMatch(System.Buffers.ReadOnlySequence<byte> utf8String) -> bool
@@ -369,6 +386,9 @@ override Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.ToStri
 override Nerdbank.MessagePack.MessagePackSerializer.Equals(object? obj) -> bool
 override Nerdbank.MessagePack.MessagePackSerializer.GetHashCode() -> int
 override Nerdbank.MessagePack.MessagePackSerializer.ToString() -> string!
+override Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.Equals(object? obj) -> bool
+override Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.GetHashCode() -> int
+override Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.ToString() -> string!
 override Nerdbank.MessagePack.MessagePackString.Equals(object? obj) -> bool
 override Nerdbank.MessagePack.MessagePackString.GetHashCode() -> int
 override Nerdbank.MessagePack.SerializationContext.GetHashCode() -> int
@@ -442,6 +462,8 @@ static Nerdbank.MessagePack.MessagePackSerializer.ConvertToJson(ref Nerdbank.Mes
 static Nerdbank.MessagePack.MessagePackSerializer.ConvertToJson(System.ReadOnlyMemory<byte> msgpack) -> string!
 static Nerdbank.MessagePack.MessagePackSerializer.operator !=(Nerdbank.MessagePack.MessagePackSerializer? left, Nerdbank.MessagePack.MessagePackSerializer? right) -> bool
 static Nerdbank.MessagePack.MessagePackSerializer.operator ==(Nerdbank.MessagePack.MessagePackSerializer? left, Nerdbank.MessagePack.MessagePackSerializer? right) -> bool
+static Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.operator !=(Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>? left, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>? right) -> bool
+static Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.operator ==(Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>? left, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>? right) -> bool
 static Nerdbank.MessagePack.MessagePackWriter.GetEncodedLength(long value) -> int
 static Nerdbank.MessagePack.MessagePackWriter.GetEncodedLength(ulong value) -> int
 static Nerdbank.MessagePack.RawMessagePack.explicit operator Nerdbank.MessagePack.RawMessagePack(byte[]! msgpack) -> Nerdbank.MessagePack.RawMessagePack
@@ -471,7 +493,13 @@ virtual Nerdbank.MessagePack.MessagePackSerializer.<Clone>$() -> Nerdbank.Messag
 virtual Nerdbank.MessagePack.MessagePackSerializer.EqualityContract.get -> System.Type!
 virtual Nerdbank.MessagePack.MessagePackSerializer.Equals(Nerdbank.MessagePack.MessagePackSerializer? other) -> bool
 virtual Nerdbank.MessagePack.MessagePackSerializer.PrintMembers(System.Text.StringBuilder! builder) -> bool
+virtual Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.<Clone>$() -> Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>!
+virtual Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.EqualityContract.get -> System.Type!
+virtual Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.Equals(Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>? other) -> bool
+virtual Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.PrintMembers(System.Text.StringBuilder! builder) -> bool
 [NBMsgPackAsync]Nerdbank.MessagePack.IMessagePackConverter.ReadAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<object?>
+[NBMsgPackAsync]Nerdbank.MessagePack.IMessagePackConverter.SkipToIndexValueAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, object? index, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<bool>
+[NBMsgPackAsync]Nerdbank.MessagePack.IMessagePackConverter.SkipToPropertyValueAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, PolyType.Abstractions.IPropertyShape! propertyShape, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<bool>
 [NBMsgPackAsync]Nerdbank.MessagePack.IMessagePackConverter.WriteAsync(Nerdbank.MessagePack.MessagePackAsyncWriter! writer, object? value, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.BufferNextStructureAsync(Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask
@@ -546,6 +574,8 @@ virtual Nerdbank.MessagePack.MessagePackSerializer.PrintMembers(System.Text.Stri
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackStreamingReader.TrySkip(ref Nerdbank.MessagePack.SerializationContext context) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 [NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackAsyncWriter.SyncWriter<T>.Invoke(ref Nerdbank.MessagePack.MessagePackWriter writer, T state) -> void
 [NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackConverter<T>.ReadAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<T?>
+[NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackConverter<T>.SkipToIndexValueAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, object? index, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<bool>
+[NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackConverter<T>.SkipToPropertyValueAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, PolyType.Abstractions.IPropertyShape! propertyShape, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<bool>
 [NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackConverter<T>.WriteAsync(Nerdbank.MessagePack.MessagePackAsyncWriter! writer, T? value, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask
 [NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackStreamingReader.GetMoreBytesAsync.Invoke(object? state, System.SequencePosition consumed, System.SequencePosition examined, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Pipelines.ReadResult>
 ~override Nerdbank.MessagePack.Extension.Equals(object obj) -> bool

--- a/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -172,6 +172,9 @@ Nerdbank.MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Pipelin
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Pipelines.PipeReader! reader, PolyType.ITypeShapeProvider! provider, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T?>
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Stream! stream, PolyType.Abstractions.ITypeShape<T>! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T?>
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Stream! stream, PolyType.ITypeShapeProvider! provider, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T?>
+Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TElement>(System.IO.Pipelines.PipeReader! reader, PolyType.Abstractions.ITypeShape<T>! shape, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement?>!
+Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TElement>(System.IO.Pipelines.PipeReader! reader, PolyType.ITypeShapeProvider! provider, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement?>!
+Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T, TElement>(System.IO.Stream! stream, PolyType.Abstractions.ITypeShape<T>! shape, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TElement?>!
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T>(System.IO.Pipelines.PipeReader! reader, PolyType.Abstractions.ITypeShape<T>! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T>(System.IO.Pipelines.PipeReader! reader, PolyType.ITypeShapeProvider! provider, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Nerdbank.MessagePack.MessagePackSerializer.DeserializeEnumerableAsync<T>(System.IO.Stream! stream, PolyType.Abstractions.ITypeShape<T>! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
@@ -216,6 +219,16 @@ Nerdbank.MessagePack.MessagePackSerializer.SerializeEnumValuesByName.init -> voi
 Nerdbank.MessagePack.MessagePackSerializer.SerializeObject(ref Nerdbank.MessagePack.MessagePackWriter writer, object? value, PolyType.Abstractions.ITypeShape! shape, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 Nerdbank.MessagePack.MessagePackSerializer.StartingContext.get -> Nerdbank.MessagePack.SerializationContext
 Nerdbank.MessagePack.MessagePackSerializer.StartingContext.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.Deconstruct(out System.Linq.Expressions.Expression<System.Func<T, System.Collections.Generic.IEnumerable<TElement>!>!>! Path) -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.EmptySequenceForUndiscoverablePath.get -> bool
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.EmptySequenceForUndiscoverablePath.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.LeaveOpen.get -> bool
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.LeaveOpen.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.Path.get -> System.Linq.Expressions.Expression<System.Func<T, System.Collections.Generic.IEnumerable<TElement>!>!>!
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.Path.init -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.StreamingEnumerationOptions(Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>! original) -> void
+Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.StreamingEnumerationOptions(System.Linq.Expressions.Expression<System.Func<T, System.Collections.Generic.IEnumerable<TElement>!>!>! Path) -> void
 Nerdbank.MessagePack.MessagePackString
 Nerdbank.MessagePack.MessagePackString.Equals(Nerdbank.MessagePack.MessagePackString? other) -> bool
 Nerdbank.MessagePack.MessagePackString.IsMatch(System.Buffers.ReadOnlySequence<byte> utf8String) -> bool
@@ -325,6 +338,9 @@ override Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.ToStri
 override Nerdbank.MessagePack.MessagePackSerializer.Equals(object? obj) -> bool
 override Nerdbank.MessagePack.MessagePackSerializer.GetHashCode() -> int
 override Nerdbank.MessagePack.MessagePackSerializer.ToString() -> string!
+override Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.Equals(object? obj) -> bool
+override Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.GetHashCode() -> int
+override Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.ToString() -> string!
 override Nerdbank.MessagePack.MessagePackString.Equals(object? obj) -> bool
 override Nerdbank.MessagePack.MessagePackString.GetHashCode() -> int
 override Nerdbank.MessagePack.SerializationContext.GetHashCode() -> int
@@ -398,6 +414,8 @@ static Nerdbank.MessagePack.MessagePackSerializer.ConvertToJson(ref Nerdbank.Mes
 static Nerdbank.MessagePack.MessagePackSerializer.ConvertToJson(System.ReadOnlyMemory<byte> msgpack) -> string!
 static Nerdbank.MessagePack.MessagePackSerializer.operator !=(Nerdbank.MessagePack.MessagePackSerializer? left, Nerdbank.MessagePack.MessagePackSerializer? right) -> bool
 static Nerdbank.MessagePack.MessagePackSerializer.operator ==(Nerdbank.MessagePack.MessagePackSerializer? left, Nerdbank.MessagePack.MessagePackSerializer? right) -> bool
+static Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.operator !=(Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>? left, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>? right) -> bool
+static Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.operator ==(Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>? left, Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>? right) -> bool
 static Nerdbank.MessagePack.MessagePackWriter.GetEncodedLength(long value) -> int
 static Nerdbank.MessagePack.MessagePackWriter.GetEncodedLength(ulong value) -> int
 static Nerdbank.MessagePack.RawMessagePack.explicit operator Nerdbank.MessagePack.RawMessagePack(byte[]! msgpack) -> Nerdbank.MessagePack.RawMessagePack
@@ -423,7 +441,13 @@ virtual Nerdbank.MessagePack.MessagePackSerializer.<Clone>$() -> Nerdbank.Messag
 virtual Nerdbank.MessagePack.MessagePackSerializer.EqualityContract.get -> System.Type!
 virtual Nerdbank.MessagePack.MessagePackSerializer.Equals(Nerdbank.MessagePack.MessagePackSerializer? other) -> bool
 virtual Nerdbank.MessagePack.MessagePackSerializer.PrintMembers(System.Text.StringBuilder! builder) -> bool
+virtual Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.<Clone>$() -> Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>!
+virtual Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.EqualityContract.get -> System.Type!
+virtual Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.Equals(Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>? other) -> bool
+virtual Nerdbank.MessagePack.MessagePackSerializer.StreamingEnumerationOptions<T, TElement>.PrintMembers(System.Text.StringBuilder! builder) -> bool
 [NBMsgPackAsync]Nerdbank.MessagePack.IMessagePackConverter.ReadAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<object?>
+[NBMsgPackAsync]Nerdbank.MessagePack.IMessagePackConverter.SkipToIndexValueAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, object? index, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<bool>
+[NBMsgPackAsync]Nerdbank.MessagePack.IMessagePackConverter.SkipToPropertyValueAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, PolyType.Abstractions.IPropertyShape! propertyShape, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<bool>
 [NBMsgPackAsync]Nerdbank.MessagePack.IMessagePackConverter.WriteAsync(Nerdbank.MessagePack.MessagePackAsyncWriter! writer, object? value, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackAsyncReader.BufferNextStructureAsync(Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask
@@ -498,6 +522,8 @@ virtual Nerdbank.MessagePack.MessagePackSerializer.PrintMembers(System.Text.Stri
 [NBMsgPackAsync]Nerdbank.MessagePack.MessagePackStreamingReader.TrySkip(ref Nerdbank.MessagePack.SerializationContext context) -> Nerdbank.MessagePack.MessagePackPrimitives.DecodeResult
 [NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackAsyncWriter.SyncWriter<T>.Invoke(ref Nerdbank.MessagePack.MessagePackWriter writer, T state) -> void
 [NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackConverter<T>.ReadAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<T?>
+[NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackConverter<T>.SkipToIndexValueAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, object? index, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<bool>
+[NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackConverter<T>.SkipToPropertyValueAsync(Nerdbank.MessagePack.MessagePackAsyncReader! reader, PolyType.Abstractions.IPropertyShape! propertyShape, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask<bool>
 [NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackConverter<T>.WriteAsync(Nerdbank.MessagePack.MessagePackAsyncWriter! writer, T? value, Nerdbank.MessagePack.SerializationContext context) -> System.Threading.Tasks.ValueTask
 [NBMsgPackAsync]virtual Nerdbank.MessagePack.MessagePackStreamingReader.GetMoreBytesAsync.Invoke(object? state, System.SequencePosition consumed, System.SequencePosition examined, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Pipelines.ReadResult>
 ~override Nerdbank.MessagePack.Extension.Equals(object obj) -> bool

--- a/test/Nerdbank.MessagePack.Tests/AsyncSerializationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/AsyncSerializationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+[Trait("AsyncSerialization", "true")]
 public partial class AsyncSerializationTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
 {
 	[Fact]
@@ -95,66 +96,6 @@ public partial class AsyncSerializationTests(ITestOutputHelper logger) : Message
 		ReadResult readResult = await reader.ReadAsync(TestContext.Current.CancellationToken);
 		Assert.True(readResult.IsCompleted);
 		Assert.Equal("a"u8, readResult.Buffer.ToArray());
-	}
-
-	/// <summary>
-	/// Streams multiple elements with no array envelope.
-	/// </summary>
-	[Fact]
-	public async Task DeserializeEnumerableAsync_TopLevel_PipeReader()
-	{
-		using Sequence<byte> sequence = new();
-		MessagePackWriter writer = new(sequence);
-		for (int i = 1; i <= 10; i++)
-		{
-			writer.Write(i);
-		}
-
-		writer.Flush();
-
-		int readCount = 0;
-		PipeReader reader = PipeReader.Create(sequence);
-		await foreach (int current in this.Serializer.DeserializeEnumerableAsync<int>(reader, Witness.ShapeProvider, TestContext.Current.CancellationToken))
-		{
-			readCount++;
-			this.Logger.WriteLine(current.ToString());
-		}
-
-		Assert.Equal(10, readCount);
-	}
-
-	/// <summary>
-	/// Streams multiple elements with no array envelope.
-	/// </summary>
-	[Fact]
-	public async Task DeserializeEnumerableAsync_TopLevel_Stream()
-	{
-		using Sequence<byte> sequence = new();
-		MessagePackWriter writer = new(sequence);
-		for (int i = 1; i <= 10; i++)
-		{
-			writer.Write(i);
-		}
-
-		writer.Flush();
-
-		int readCount = 0;
-		MemoryStream reader = new(sequence.AsReadOnlySequence.ToArray());
-		await foreach (int current in this.Serializer.DeserializeEnumerableAsync<int>(reader, Witness.ShapeProvider.Resolve<int>(), TestContext.Current.CancellationToken))
-		{
-			readCount++;
-			this.Logger.WriteLine(current.ToString());
-		}
-
-		Assert.Equal(10, readCount);
-	}
-
-	/// <summary>
-	/// Streams elements of a top-level msgpack array.
-	/// </summary>
-	[Fact(Skip = "Not ready")]
-	public void DeserializeEnumerableAsync_Array()
-	{
 	}
 
 	[GenerateShape<string>]

--- a/test/Nerdbank.MessagePack.Tests/StreamingEnumerableTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StreamingEnumerableTests.cs
@@ -1,0 +1,410 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+[Trait("AsyncSerialization", "true")]
+public partial class StreamingEnumerableTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	/// <summary>
+	/// Streams multiple elements with no array envelope.
+	/// </summary>
+	[Fact]
+	public async Task DeserializeEnumerableAsync_TopLevel_PipeReader()
+	{
+		using Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		for (int i = 1; i <= 10; i++)
+		{
+			writer.Write(i);
+		}
+
+		writer.Flush();
+
+		int readCount = 0;
+		PipeReader reader = PipeReader.Create(sequence);
+		await foreach (int current in this.Serializer.DeserializeEnumerableAsync<int>(reader, Witness.ShapeProvider, TestContext.Current.CancellationToken))
+		{
+			readCount++;
+			this.Logger.WriteLine(current.ToString());
+		}
+
+		Assert.Equal(10, readCount);
+	}
+
+	/// <summary>
+	/// Streams multiple elements with no array envelope.
+	/// </summary>
+	[Fact]
+	public async Task DeserializeEnumerableAsync_TopLevel_Stream()
+	{
+		using Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		for (int i = 1; i <= 10; i++)
+		{
+			writer.Write(i);
+		}
+
+		writer.Flush();
+
+		int readCount = 0;
+		MemoryStream reader = new(sequence.AsReadOnlySequence.ToArray());
+		await foreach (int current in this.Serializer.DeserializeEnumerableAsync<int>(reader, Witness.ShapeProvider.Resolve<int>(), TestContext.Current.CancellationToken))
+		{
+			readCount++;
+			this.Logger.WriteLine(current.ToString());
+		}
+
+		Assert.Equal(10, readCount);
+	}
+
+	/// <summary>
+	/// Streams elements of a top-level msgpack array.
+	/// </summary>
+	[Fact]
+	public async Task DeserializeEnumerableAsync_Array()
+	{
+		using Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		writer.WriteArrayHeader(10);
+		for (int i = 1; i <= 10; i++)
+		{
+			writer.Write(i);
+		}
+
+		writer.Flush();
+
+		int readCount = 0;
+		PipeReader reader = PipeReader.Create(sequence);
+		MessagePackSerializer.StreamingEnumerationOptions<int[], int> options = new(a => a);
+		await foreach (int current in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+		{
+			readCount++;
+			this.Logger.WriteLine(current.ToString());
+		}
+
+		Assert.Equal(10, readCount);
+	}
+
+	[Theory, PairwiseData]
+	public async Task DeserializeEnumerableAsync_SequenceWithinTwoContainers(bool leaveOpen)
+	{
+		OuterStreamingContainer container = new(new(true, [1, 2, 3], true));
+		Sequence<byte> msgpack = new();
+		msgpack.Append(this.Serializer.Serialize(container, TestContext.Current.CancellationToken));
+		msgpack.Append(this.Serializer.Serialize<string, Witness>("hi", TestContext.Current.CancellationToken));
+		this.LogMsgPack(msgpack);
+		PipeReader reader = PipeReader.Create(msgpack);
+
+		int count = 0;
+		MessagePackSerializer.StreamingEnumerationOptions<OuterStreamingContainer, int> options = new(c => c.Inner!.Values!)
+		{
+			LeaveOpen = leaveOpen,
+		};
+		await foreach (int item in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+		{
+			Assert.Equal(count++ + 1, item);
+		}
+
+		Assert.Equal(3, count);
+
+		if (leaveOpen)
+		{
+			// Verify correct positioning by deserializing the next top-level structure in the pipe.
+			string? actual = await this.Serializer.DeserializeAsync<string>(reader, Witness.ShapeProvider, TestContext.Current.CancellationToken);
+			Assert.Equal("hi", actual);
+		}
+	}
+
+	[Theory, PairwiseData]
+	public async Task DeserializeEnumerableAsync_SequenceWithinTwoContainers_Keyed(bool leaveOpen, bool asMap)
+	{
+		SimpleStreamingContainerKeyed container = new() { Before = asMap ? null : "a", Values = [1, 2, 3], After = asMap ? null : "b" };
+		Sequence<byte> msgpack = new();
+		msgpack.Append(this.Serializer.Serialize(container, TestContext.Current.CancellationToken));
+		msgpack.Append(this.Serializer.Serialize<string, Witness>("hi", TestContext.Current.CancellationToken));
+		this.LogMsgPack(msgpack);
+		PipeReader reader = PipeReader.Create(msgpack);
+
+		int count = 0;
+		MessagePackSerializer.StreamingEnumerationOptions<SimpleStreamingContainerKeyed, int> options = new(c => c.Values!)
+		{
+			LeaveOpen = leaveOpen,
+		};
+		await foreach (int item in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+		{
+			Assert.Equal(count++ + 1, item);
+		}
+
+		Assert.Equal(3, count);
+
+		if (leaveOpen)
+		{
+			// Verify correct positioning by deserializing the next top-level structure in the pipe.
+			string? actual = await this.Serializer.DeserializeAsync<string>(reader, Witness.ShapeProvider, TestContext.Current.CancellationToken);
+			Assert.Equal("hi", actual);
+		}
+	}
+
+	/// <summary>
+	/// Verifies handling when the specified path includes an array indexer.
+	/// </summary>
+	/// <param name="leaveOpen">Whether to the reader should be positioned at the next element.</param>
+	[Theory, PairwiseData]
+	public async Task DeserializeEnumerableAsync_StepThroughArray(bool leaveOpen)
+	{
+		OuterStreamingContainerByArray container = new([null, new(true, [1, 2, 3], false), new(true, [1], false)]);
+		Sequence<byte> msgpack = new();
+		msgpack.Append(this.Serializer.Serialize(container, TestContext.Current.CancellationToken));
+		msgpack.Append(this.Serializer.Serialize<string, Witness>("hi", TestContext.Current.CancellationToken));
+		this.LogMsgPack(msgpack);
+		PipeReader reader = PipeReader.Create(msgpack);
+
+		int count = 0;
+		MessagePackSerializer.StreamingEnumerationOptions<OuterStreamingContainerByArray, int> options = new(c => c.Inner[1]!.Values!)
+		{
+			LeaveOpen = leaveOpen,
+		};
+		await foreach (int item in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+		{
+			Assert.Equal(count++ + 1, item);
+		}
+
+		Assert.Equal(3, count);
+
+		if (leaveOpen)
+		{
+			// Verify correct positioning by deserializing the next top-level structure in the pipe.
+			string? actual = await this.Serializer.DeserializeAsync<string>(reader, Witness.ShapeProvider, TestContext.Current.CancellationToken);
+			Assert.Equal("hi", actual);
+		}
+	}
+
+	/// <summary>
+	/// Verifies handling when the specified path includes an indexer.
+	/// </summary>
+	/// <param name="leaveOpen">Whether to the reader should be positioned at the next element.</param>
+	[Theory, PairwiseData]
+	public async Task DeserializeEnumerableAsync_StepThroughImmutableArray(bool leaveOpen)
+	{
+		OuterStreamingContainerByImmutableArray container = new([null, new(true, [1, 2, 3], false), new(true, [1], false)]);
+		Sequence<byte> msgpack = new();
+		msgpack.Append(this.Serializer.Serialize(container, TestContext.Current.CancellationToken));
+		msgpack.Append(this.Serializer.Serialize<string, Witness>("hi", TestContext.Current.CancellationToken));
+		this.LogMsgPack(msgpack);
+		PipeReader reader = PipeReader.Create(msgpack);
+
+		int count = 0;
+		MessagePackSerializer.StreamingEnumerationOptions<OuterStreamingContainerByImmutableArray, int> options = new(c => c.Inner[1]!.Values!)
+		{
+			LeaveOpen = leaveOpen,
+		};
+		await foreach (int item in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+		{
+			Assert.Equal(count++ + 1, item);
+		}
+
+		Assert.Equal(3, count);
+
+		if (leaveOpen)
+		{
+			// Verify correct positioning by deserializing the next top-level structure in the pipe.
+			string? actual = await this.Serializer.DeserializeAsync<string>(reader, Witness.ShapeProvider, TestContext.Current.CancellationToken);
+			Assert.Equal("hi", actual);
+		}
+	}
+
+	/// <summary>
+	/// Verifies handling when the specified path includes an indexer.
+	/// </summary>
+	/// <param name="leaveOpen">Whether to the reader should be positioned at the next element.</param>
+	[Theory, PairwiseData]
+	public async Task DeserializeEnumerableAsync_StepThroughDictionary(bool leaveOpen)
+	{
+		OuterStreamingContainerByDictionary container = new(new() { ["a"] = null, ["b"] = new(true, [1, 2, 3], false) });
+		Sequence<byte> msgpack = new();
+		msgpack.Append(this.Serializer.Serialize(container, TestContext.Current.CancellationToken));
+		msgpack.Append(this.Serializer.Serialize<string, Witness>("hi", TestContext.Current.CancellationToken));
+		this.LogMsgPack(msgpack);
+		PipeReader reader = PipeReader.Create(msgpack);
+
+		int count = 0;
+		MessagePackSerializer.StreamingEnumerationOptions<OuterStreamingContainerByDictionary, int> options = new(c => c.Inner["b"]!.Values!)
+		{
+			LeaveOpen = leaveOpen,
+		};
+		await foreach (int item in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+		{
+			Assert.Equal(count++ + 1, item);
+		}
+
+		Assert.Equal(3, count);
+
+		if (leaveOpen)
+		{
+			// Verify correct positioning by deserializing the next top-level structure in the pipe.
+			string? actual = await this.Serializer.DeserializeAsync<string>(reader, Witness.ShapeProvider, TestContext.Current.CancellationToken);
+			Assert.Equal("hi", actual);
+		}
+	}
+
+	/// <summary>
+	/// Verifies handling when the specified path includes an indexer.
+	/// </summary>
+	/// <param name="leaveOpen">Whether to the reader should be positioned at the next element.</param>
+	[Theory, PairwiseData]
+	public async Task DeserializeEnumerableAsync_StepThroughDictionaryCustomKey(bool leaveOpen)
+	{
+		OuterStreamingContainerByDictionaryCustomKey container = new(new() { [new CustomKey(5)] = null, [new CustomKey(3)] = new(true, [1, 2, 3], false) });
+		Sequence<byte> msgpack = new();
+		msgpack.Append(this.Serializer.Serialize(container, TestContext.Current.CancellationToken));
+		msgpack.Append(this.Serializer.Serialize<string, Witness>("hi", TestContext.Current.CancellationToken));
+		this.LogMsgPack(msgpack);
+		PipeReader reader = PipeReader.Create(msgpack);
+
+		CustomKey key = new(3);
+		int count = 0;
+		MessagePackSerializer.StreamingEnumerationOptions<OuterStreamingContainerByDictionaryCustomKey, int> options = new(c => c.Inner[key]!.Values!)
+		{
+			LeaveOpen = leaveOpen,
+		};
+		await foreach (int item in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+		{
+			Assert.Equal(count++ + 1, item);
+		}
+
+		Assert.Equal(3, count);
+
+		if (leaveOpen)
+		{
+			// Verify correct positioning by deserializing the next top-level structure in the pipe.
+			string? actual = await this.Serializer.DeserializeAsync<string>(reader, Witness.ShapeProvider, TestContext.Current.CancellationToken);
+			Assert.Equal("hi", actual);
+		}
+	}
+
+	/// <summary>
+	/// Verifies handling when the specified path turns out to be a null value.
+	/// </summary>
+	/// <param name="preferEmptySequence">A value indicating whether we're verifying behavior that prefers an empty sequence over throwing when a null is encountered.</param>
+	[Theory, PairwiseData]
+	public async Task DeserializeEnumerableAsync_NullRoot(bool preferEmptySequence)
+	{
+		byte[] msgpack = this.Serializer.Serialize<OuterStreamingContainer>(null, TestContext.Current.CancellationToken);
+		MessagePackSerializer.StreamingEnumerationOptions<OuterStreamingContainer, int> options = new(c => c.Inner!.Values!)
+		{
+			EmptySequenceForUndiscoverablePath = preferEmptySequence,
+		};
+		PipeReader reader = PipeReader.Create(new(msgpack));
+		try
+		{
+			await foreach (int item in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+			{
+				Assert.Fail("Should not have received any items.");
+			}
+
+			Assert.True(preferEmptySequence, "Should have thrown an exception.");
+		}
+		catch (MessagePackSerializationException ex)
+		{
+			this.Logger.WriteLine(ex.ToString());
+			Assert.False(preferEmptySequence, "Should not have thrown an exception.");
+			Assert.Matches(@"\Wc(?!\.Inner)", ex.Message);
+		}
+	}
+
+	/// <summary>
+	/// Verifies handling when the specified path turns out to be a null value.
+	/// </summary>
+	/// <param name="preferEmptySequence">A value indicating whether we're verifying behavior that prefers an empty sequence over throwing when a null is encountered.</param>
+	[Theory, PairwiseData]
+	public async Task DeserializeEnumerableAsync_NullMidPath(bool preferEmptySequence)
+	{
+		byte[] msgpack = this.Serializer.Serialize(new OuterStreamingContainer(null), TestContext.Current.CancellationToken);
+		MessagePackSerializer.StreamingEnumerationOptions<OuterStreamingContainer, int> options = new(c => c.Inner!.Values!)
+		{
+			EmptySequenceForUndiscoverablePath = preferEmptySequence,
+		};
+		PipeReader reader = PipeReader.Create(new(msgpack));
+		try
+		{
+			await foreach (int item in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+			{
+				Assert.Fail("Should not have received any items.");
+			}
+
+			Assert.True(preferEmptySequence, "Should have thrown an exception.");
+		}
+		catch (MessagePackSerializationException ex)
+		{
+			this.Logger.WriteLine(ex.ToString());
+			Assert.False(preferEmptySequence, "Should not have thrown an exception.");
+			Assert.Matches(@"\Wc\.Inner(?!\.Values)", ex.Message);
+		}
+	}
+
+	/// <summary>
+	/// Verifies handling when the specified path turns out to be a null value.
+	/// </summary>
+	/// <param name="preferEmptySequence">A value indicating whether we're verifying behavior that prefers an empty sequence over throwing when a null is encountered.</param>
+	[Theory, PairwiseData]
+	public async Task DeserializeEnumerableAsync_NullSequenceMember(bool preferEmptySequence)
+	{
+		byte[] msgpack = this.Serializer.Serialize(new OuterStreamingContainer(new(true, null, false)), TestContext.Current.CancellationToken);
+		MessagePackSerializer.StreamingEnumerationOptions<OuterStreamingContainer, int> options = new(c => c.Inner!.Values!)
+		{
+			EmptySequenceForUndiscoverablePath = preferEmptySequence,
+		};
+		PipeReader reader = PipeReader.Create(new(msgpack));
+		try
+		{
+			await foreach (int item in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+			{
+				Assert.Fail("Should not have received any items.");
+			}
+
+			Assert.True(preferEmptySequence, "Should have thrown an exception.");
+		}
+		catch (MessagePackSerializationException ex)
+		{
+			this.Logger.WriteLine(ex.ToString());
+			Assert.False(preferEmptySequence, "Should not have thrown an exception.");
+			Assert.Matches(@"\Wc\.Inner\.Values", ex.Message);
+		}
+	}
+
+	public record struct CustomKey(int Key);
+
+	[GenerateShape<string>]
+	[GenerateShape<int>]
+	private partial class Witness;
+
+	[GenerateShape]
+	public partial record SimpleStreamingContainer(bool Before, int[]? Values, bool After);
+
+	[GenerateShape]
+	public partial record OuterStreamingContainer(SimpleStreamingContainer? Inner);
+
+	[GenerateShape]
+	public partial record OuterStreamingContainerByArray(SimpleStreamingContainer?[] Inner);
+
+	[GenerateShape]
+	public partial record OuterStreamingContainerByImmutableArray(ImmutableArray<SimpleStreamingContainer?> Inner);
+
+	[GenerateShape]
+	public partial record OuterStreamingContainerByDictionary(Dictionary<string, SimpleStreamingContainer?> Inner);
+
+	[GenerateShape]
+	public partial record OuterStreamingContainerByDictionaryCustomKey(Dictionary<CustomKey, SimpleStreamingContainer?> Inner);
+
+	[GenerateShape]
+	public partial class SimpleStreamingContainerKeyed
+	{
+		[Key(0)]
+		public string? Before { get; set; }
+
+		[Key(1)]
+		public string? After { get; set; }
+
+		[Key(2)]
+		public int[]? Values { get; set; }
+	}
+}


### PR DESCRIPTION
This pull request includes several changes to enhance the streaming deserialization capabilities and add new asynchronous methods for skipping to specific values within MessagePack data. The most important changes include updates to the documentation, the addition of new methods for asynchronous skipping, and modifications to existing converters to support these new methods.

### Documentation Updates:
* [`docfx/docs/streaming-deserialization.md`](diffhunk://#diff-4ab4ab7b6858efcbeeb604190c7fbbc55afa94b11390f5183ab1f7448382305eL21-R21): Updated to reflect the use of `StreamingEnumerationOptions` instead of JSONPath for navigating through envelopes in MessagePack structures. [[1]](diffhunk://#diff-4ab4ab7b6858efcbeeb604190c7fbbc55afa94b11390f5183ab1f7448382305eL21-R21) [[2]](diffhunk://#diff-4ab4ab7b6858efcbeeb604190c7fbbc55afa94b11390f5183ab1f7448382305eL39-R52)

### New Asynchronous Methods:
* `src/Nerdbank.MessagePack/Converters/DictionaryConverter``3.cs`: Added the `SkipToIndexValueAsync` method to asynchronously skip to the value of a specified key in a dictionary.
* `src/Nerdbank.MessagePack/Converters/EnumerableConverter``2.cs`: Added the `SkipToIndexValueAsync` method to asynchronously skip to the value at a specified index in an array.
* `src/Nerdbank.MessagePack/Converters/ObjectArrayConverter``1.cs`: Added the `SkipToPropertyValueAsync` method to asynchronously skip to the value of a specified property in an object array.
* `src/Nerdbank.MessagePack/Converters/ObjectMapConverter``1.cs`: Added the `SkipToPropertyValueAsync` method to asynchronously skip to the value of a specified property in an object map.

### Interface and Reader Enhancements:
* [`src/Nerdbank.MessagePack/IMessagePackConverter.cs`](diffhunk://#diff-5046139cd1ba2fbf6d3a0b9a18f0530940853dd42ba59330d9285cad633585fdR51-R75): Added new methods `SkipToPropertyValueAsync` and `SkipToIndexValueAsync` to the `IMessagePackConverter` interface.
* [`src/Nerdbank.MessagePack/MessagePackAsyncReader.cs`](diffhunk://#diff-39f0bdba5891db4c8e28b020f51bfa3ac22124bf9373b41745846c009ee4d8e5R31-R33): Enhanced the `MessagePackAsyncReader` class to support creating streaming readers with expected remaining structures and added the `AdvanceToEndOfTopLevelStructureAsync` method. [[1]](diffhunk://#diff-39f0bdba5891db4c8e28b020f51bfa3ac22124bf9373b41745846c009ee4d8e5R31-R33) [[2]](diffhunk://#diff-39f0bdba5891db4c8e28b020f51bfa3ac22124bf9373b41745846c009ee4d8e5L151-R157) [[3]](diffhunk://#diff-39f0bdba5891db4c8e28b020f51bfa3ac22124bf9373b41745846c009ee4d8e5L167-R176) [[4]](diffhunk://#diff-39f0bdba5891db4c8e28b020f51bfa3ac22124bf9373b41745846c009ee4d8e5R188) [[5]](diffhunk://#diff-39f0bdba5891db4c8e28b020f51bfa3ac22124bf9373b41745846c009ee4d8e5R202) [[6]](diffhunk://#diff-39f0bdba5891db4c8e28b020f51bfa3ac22124bf9373b41745846c009ee4d8e5R239-R260)

These changes collectively improve the flexibility and performance of the MessagePack deserialization process, especially in scenarios requiring asynchronous operations and partial data reading.