### PR TITLE
Fix bugs in async deserialization

### DIFF
--- a/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapWithNonDefaultCtorConverter`2.cs
@@ -125,23 +125,44 @@ internal class ObjectMapWithNonDefaultCtorConverter<TDeclaringType, TArgumentSta
 					{
 						// The property name has already been buffered.
 						ReadOnlySpan<byte> propertyName = StringEncoding.ReadStringSpan(ref syncReader);
-						if (parameters.Readers.TryGetValue(propertyName, out DeserializableProperty<TArgumentState> propertyReader) && propertyReader.PreferAsyncSerialization)
+						if (parameters.Readers.TryGetValue(propertyName, out DeserializableProperty<TArgumentState> propertyReader))
 						{
-							// The next property value is async, so turn in our sync reader and read it asynchronously.
+							if (propertyReader.PreferAsyncSerialization)
+							{
+								// The next property value is async, so turn in our sync reader and read it asynchronously.
+								reader.ReturnReader(ref syncReader);
+								argState = await propertyReader.ReadAsync(argState, reader, context).ConfigureAwait(false);
+								remainingEntries--;
+								continue;
+							}
+							else
+							{
+								// Deserialize the value synchronously.
+								reader.ReturnReader(ref syncReader);
+								await reader.BufferNextStructuresAsync(1, 1, context).ConfigureAwait(false);
+								syncReader = reader.CreateBufferedReader();
+								propertyReader.Read(ref argState, ref syncReader, context);
+								reader.ReturnReader(ref syncReader);
+								remainingEntries--;
+								continue;
+							}
+						}
+						else
+						{
+							// We don't recognize the property name, so skip the value.
 							reader.ReturnReader(ref syncReader);
-							argState = await propertyReader.ReadAsync(argState, reader, context).ConfigureAwait(false);
-							remainingEntries--;
 
-							// Now loop around to see what else we can do with the next buffer.
+							streamingReader = reader.CreateStreamingReader();
+							while (streamingReader.TrySkip(ref context).NeedsMoreBytes())
+							{
+								streamingReader = new(await streamingReader.FetchMoreBytesAsync().ConfigureAwait(false));
+							}
+
+							reader.ReturnReader(ref streamingReader);
+
+							remainingEntries--;
 							continue;
 						}
-					}
-					else
-					{
-						// The property name isn't in the buffer, and thus whether it'll have an async reader.
-						// Advance the reader so it knows we need more buffer than we got last time.
-						reader.ReturnReader(ref syncReader);
-						continue;
 					}
 				}
 

--- a/src/Nerdbank.MessagePack/MessagePackStreamingReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackStreamingReader.cs
@@ -65,6 +65,7 @@ public ref partial struct MessagePackStreamingReader
 		this.reader = new SequenceReader<byte>(sequence);
 		this.getMoreBytesAsync = additionalBytesSource;
 		this.getMoreBytesState = getMoreBytesState;
+		this.eof = additionalBytesSource is null;
 	}
 
 	/// <summary>
@@ -127,7 +128,7 @@ public ref partial struct MessagePackStreamingReader
 	/// <summary>
 	/// Gets the error code to return when the buffer has insufficient bytes to finish a decode request.
 	/// </summary>
-	private DecodeResult InsufficientBytes => this.eof ? DecodeResult.EmptyBuffer : DecodeResult.InsufficientBuffer;
+	private DecodeResult InsufficientBytes => this.eof && this.SequenceReader.Sequence.IsEmpty ? DecodeResult.EmptyBuffer : DecodeResult.InsufficientBuffer;
 
 	/// <summary>
 	/// Peeks at the next msgpack byte without advancing the reader.

--- a/test/Nerdbank.MessagePack.Tests/MessagePackStreamingReaderTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackStreamingReaderTests.cs
@@ -41,7 +41,7 @@ public class MessagePackStreamingReaderTests(ITestOutputHelper logger)
 		Assert.Equal(DecodeResult.Success, incompleteReader.TryRead(out boolean));
 		Assert.False(boolean);
 
-		Assert.Equal(DecodeResult.EmptyBuffer, incompleteReader.TryReadNil());
+		Assert.Equal(DecodeResult.InsufficientBuffer, incompleteReader.TryReadNil());
 	}
 
 	[Fact]

--- a/test/Nerdbank.MessagePack.Tests/StreamingEnumerableTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StreamingEnumerableTests.cs
@@ -34,6 +34,19 @@ public partial class StreamingEnumerableTests(ITestOutputHelper logger) : Messag
 	/// Streams multiple elements with no array envelope.
 	/// </summary>
 	[Fact]
+	public async Task DeserializeEnumerableAsync_TopLevel_Empty()
+	{
+		PipeReader reader = PipeReader.Create(new([]));
+		await foreach (int current in this.Serializer.DeserializeEnumerableAsync<int>(reader, Witness.ShapeProvider, TestContext.Current.CancellationToken))
+		{
+			Assert.Fail("No items should have been read.");
+		}
+	}
+
+	/// <summary>
+	/// Streams multiple elements with no array envelope.
+	/// </summary>
+	[Fact]
 	public async Task DeserializeEnumerableAsync_TopLevel_Stream()
 	{
 		using Sequence<byte> sequence = new();


### PR DESCRIPTION
- Fix async deserialization of maps with particular buffer boundaries
  In particular, when the buffer boundary happens to be between a property name and its value and the value prefers to be deserialized synchronously, we had a bug where we'd read the property name, then expect to be able to read it again. 
- Fix exception when enumerating top-level elements from an empty buffer

Fixes both issues reported in #242