### PR TITLE
Improve async deserialization performance

### DIFF
--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
@@ -21,7 +21,7 @@ internal class StringConverter : MessagePackConverter<string>
 {
 #if NET
 	/// <inheritdoc/>
-	public override bool PreferAsyncSerialization => true;
+	public override bool PreferAsyncSerialization => false; // async is slower, and incremental decoding isn't worth it.
 #endif
 
 	/// <inheritdoc/>
@@ -65,7 +65,7 @@ internal class StringConverter : MessagePackConverter<string>
 			Decoder decoder = StringEncoding.UTF8.GetDecoder();
 			while (remainingBytesToDecode > 0)
 			{
-				// We'll always require at least a reasonable numbe of bytes to decode at once,
+				// We'll always require at least a reasonable number of bytes to decode at once,
 				// to keep overhead to a minimum.
 				uint desiredBytesThisRound = Math.Min(remainingBytesToDecode, MinChunkSize);
 				if (streamingReader.SequenceReader.Remaining < desiredBytesThisRound)

--- a/test/Nerdbank.MessagePack.Tests/StreamingEnumerableTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StreamingEnumerableTests.cs
@@ -97,6 +97,24 @@ public partial class StreamingEnumerableTests(ITestOutputHelper logger) : Messag
 		Assert.Equal(10, readCount);
 	}
 
+	[Fact]
+	public async Task DeserializeEnumerableAsync_AsyncElementConverter()
+	{
+		SimpleStreamingContainerKeyed[] array = [new(), new()];
+		byte[] msgpack = this.Serializer.Serialize<SimpleStreamingContainerKeyed[], Witness>(array, TestContext.Current.CancellationToken);
+		this.LogMsgPack(new(msgpack));
+
+		PipeReader reader = PipeReader.Create(new(msgpack));
+		MessagePackSerializer.StreamingEnumerationOptions<SimpleStreamingContainerKeyed[], SimpleStreamingContainerKeyed> options = new(a => a);
+		List<SimpleStreamingContainerKeyed?> actual = new();
+		await foreach (SimpleStreamingContainerKeyed? item in this.Serializer.DeserializeEnumerableAsync(reader, Witness.ShapeProvider, options, TestContext.Current.CancellationToken))
+		{
+			actual.Add(item);
+		}
+
+		Assert.Equal(2, actual.Count);
+	}
+
 	[Trait("ReferencePreservation", "true")]
 	[Fact]
 	public async Task DeserializeEnumerableAsync_ReferencesPreserved()


### PR DESCRIPTION
- Improve string deserialization perf overall (from `DeserializeAsync` methods)
- Opportunistically use synchronous deserialization during async enumeration of top-level elements when we have the next item buffered already anyway.
- Use sync deserialization opportunistically during async enumeration with envelopes

Together, this gets the async top-level enumeration scenario from 38% slower than MessagePack-CSharp to 14% _faster_.

Closes #253