### PR TITLE
Fix hang waiting for more data when async enumerable elements are already in the buffer

### DIFF
--- a/src/Nerdbank.MessagePack/MessagePackAsyncReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackAsyncReader.cs
@@ -250,10 +250,14 @@ public class MessagePackAsyncReader(PipeReader pipeReader) : IDisposable
 	/// <summary>
 	/// Gets a value indicating whether we've reached the end of the stream.
 	/// </summary>
+	/// <param name="forceRead"><see langword="true" /> to guarantee that we call <see cref="ReadAsync"/> unless we already hit the EOF marker, even if we know we're not at the end of the stream.</param>
 	/// <returns>A boolean value.</returns>
-	internal async ValueTask<bool> GetIsEndOfStreamAsync()
+	/// <remarks>
+	/// This method <em>may</em> call <see cref="ReadAsync"/>.
+	/// </remarks>
+	internal async ValueTask<bool> GetIsEndOfStreamAsync(bool forceRead)
 	{
-		if (this.refresh is null or { Buffer.IsEmpty: true, EndOfStream: false })
+		if (this.refresh is null or { Buffer.IsEmpty: true, EndOfStream: false } || (forceRead && this.refresh is not { EndOfStream: true }))
 		{
 			await this.ReadAsync().ConfigureAwait(false);
 		}

--- a/test/Nerdbank.MessagePack.Tests/FragmentedPipeReader.cs
+++ b/test/Nerdbank.MessagePack.Tests/FragmentedPipeReader.cs
@@ -40,6 +40,8 @@ internal class FragmentedPipeReader : PipeReader
 #endif
 	}
 
+	internal int ChunksRead { get; private set; }
+
 	public override void AdvanceTo(SequencePosition consumed) => this.AdvanceTo(consumed, consumed);
 
 	public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
@@ -69,6 +71,7 @@ internal class FragmentedPipeReader : PipeReader
 			if (this.lastReadReturnedPosition.HasValue && this.examined.Equals(this.lastReadReturnedPosition.Value))
 			{
 				// The caller has examined everything we gave them. Give them more.
+				this.ChunksRead++;
 #if NETFRAMEWORK
 				long examinedIndex = this.buffer.Slice(0, this.examined).Length;
 				int lastChunkGivenIndex = Array.IndexOf(this.chunkIndexes!, examinedIndex);
@@ -83,6 +86,11 @@ internal class FragmentedPipeReader : PipeReader
 				// The caller hasn't finished processing the last chunk we gave them.
 				// Give them the same chunk again.
 				chunkEnd = this.lastReadReturnedPosition ?? this.chunkPositions[0];
+				if (this.lastReadReturnedPosition is null)
+				{
+					// This is the first read.
+					this.ChunksRead++;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #282