### PR TITLE
Add test to verify a custom collection type can be serialized

### DIFF
--- a/test/Nerdbank.MessagePack.Tests/CustomEnumerableTypes.cs
+++ b/test/Nerdbank.MessagePack.Tests/CustomEnumerableTypes.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public partial class CustomEnumerableTypes(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	[Fact]
+	public void CustomListOfIntDerivedCollection()
+	{
+		ListOfInt list = new() { 1, 2, 3 };
+		ListOfInt? deserialized = this.Roundtrip(list);
+		Assert.Equal<int>(list, deserialized);
+
+		MessagePackReader reader = new(this.lastRoundtrippedMsgpack);
+		Assert.Equal(3, reader.ReadArrayHeader());
+	}
+
+	[GenerateShape, TypeShape(Kind = TypeShapeKind.Enumerable)]
+	public partial class ListOfInt : List<int>
+	{
+		public ListOfInt()
+			: base()
+		{
+		}
+
+		public ListOfInt(IEnumerable<int> values)
+			: base(values)
+		{
+		}
+
+		public ListOfInt(int value)
+			: base(value)
+		{
+		}
+	}
+}


### PR DESCRIPTION
@robertoschiabel started a discussion over at MessagePack-CSharp because that library fails at source generation for custom list collections. 

I was curious to see whether Nerdbank.MessagePack could handle it. To my delight, it Just Works. :)