### PR TITLE
Dictionary lookup perf optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ nunit-*.xml
 dlldata.c
 
 # Benchmark Results
-BenchmarkDotNet.Artifacts/
+BenchmarkDotNet.Artifacts*/
 
 # StyleCop
 StyleCopReport.xml

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <DebugSymbols>true</DebugSymbols>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/test/Benchmarks/Data.cs
+++ b/test/Benchmarks/Data.cs
@@ -1,12 +1,25 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using STJ = System.Text.Json;
+
 internal static class Data
 {
+	private static ReadOnlySequence<byte> SerializeJson<T>(T? value)
+	{
+		Sequence seq = new();
+		STJ.Utf8JsonWriter writer = new(seq);
+		STJ.JsonSerializer.Serialize(writer, value);
+		writer.Flush();
+		return seq;
+	}
+
 	internal static class PocoMapInit
 	{
 		internal static readonly global::PocoMapInit Single = new() { SomeInt = 42, SomeString = "Hello, World!" };
 		internal static readonly ReadOnlySequence<byte> SingleMsgpack = new(MsgPackCSharp.MessagePackSerializer.Serialize(Single, MsgPackCSharp.MessagePackSerializerOptions.Standard));
+		internal static readonly ReadOnlySequence<byte> SingleJson = SerializeJson(Single);
+		internal static readonly Stream SingleJsonStream = new MemoryStream(SingleJson.ToArray());
 
 		internal static readonly global::PocoMapInit[] Array = Enumerable.Range(0, 1000).Select(n => new global::PocoMapInit { SomeInt = n, SomeString = "Hello" }).ToArray();
 		internal static readonly ReadOnlySequence<byte> ArrayMsgpack = new(MsgPackCSharp.MessagePackSerializer.Serialize(Array, MsgPackCSharp.MessagePackSerializerOptions.Standard));
@@ -16,6 +29,8 @@ internal static class Data
 	{
 		internal static readonly global::PocoMap Single = new() { SomeInt = 42, SomeString = "Hello, World!" };
 		internal static readonly ReadOnlySequence<byte> SingleMsgpack = new(MsgPackCSharp.MessagePackSerializer.Serialize(Single, MsgPackCSharp.MessagePackSerializerOptions.Standard));
+		internal static readonly ReadOnlySequence<byte> SingleJson = SerializeJson(Single);
+		internal static readonly Stream SingleJsonStream = new MemoryStream(SingleJson.ToArray());
 
 		internal static readonly global::PocoMap[] Array = Enumerable.Range(0, 1000).Select(n => new global::PocoMap { SomeInt = n, SomeString = "Hello" }).ToArray();
 		internal static readonly ReadOnlySequence<byte> ArrayMsgpack = new(MsgPackCSharp.MessagePackSerializer.Serialize(Array, MsgPackCSharp.MessagePackSerializerOptions.Standard));
@@ -25,6 +40,8 @@ internal static class Data
 	{
 		internal static readonly global::PocoAsArrayInit Single = new() { SomeInt = 42, SomeString = "Hello, World!" };
 		internal static readonly ReadOnlySequence<byte> SingleMsgpack = new(MsgPackCSharp.MessagePackSerializer.Serialize(Single, MsgPackCSharp.MessagePackSerializerOptions.Standard));
+		internal static readonly ReadOnlySequence<byte> SingleJson = SerializeJson(Single);
+		internal static readonly Stream SingleJsonStream = new MemoryStream(SingleJson.ToArray());
 
 		internal static readonly global::PocoAsArrayInit[] Array = Enumerable.Range(0, 1000).Select(n => new global::PocoAsArrayInit { SomeInt = n, SomeString = "Hello" }).ToArray();
 		internal static readonly ReadOnlySequence<byte> ArrayMsgpack = new(MsgPackCSharp.MessagePackSerializer.Serialize(Array, MsgPackCSharp.MessagePackSerializerOptions.Standard));
@@ -34,6 +51,8 @@ internal static class Data
 	{
 		internal static readonly global::PocoAsArray Single = new() { SomeInt = 42, SomeString = "Hello, World!" };
 		internal static readonly ReadOnlySequence<byte> SingleMsgpack = new(MsgPackCSharp.MessagePackSerializer.Serialize(Single, MsgPackCSharp.MessagePackSerializerOptions.Standard));
+		internal static readonly ReadOnlySequence<byte> SingleJson = SerializeJson(Single);
+		internal static readonly Stream SingleJsonStream = new MemoryStream(SingleJson.ToArray());
 
 		internal static readonly global::PocoAsArray[] Array = Enumerable.Range(0, 1000).Select(n => new global::PocoAsArray { SomeInt = n, SomeString = "Hello" }).ToArray();
 		internal static readonly ReadOnlySequence<byte> ArrayMsgpack = new(MsgPackCSharp.MessagePackSerializer.Serialize(Array, MsgPackCSharp.MessagePackSerializerOptions.Standard));

--- a/test/Benchmarks/STJSourceGenerationContext.cs
+++ b/test/Benchmarks/STJSourceGenerationContext.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace Benchmarks;
+
+[JsonSerializable(typeof(PocoMap))]
+[JsonSerializable(typeof(PocoMapInit))]
+[JsonSerializable(typeof(PocoAsArray))]
+[JsonSerializable(typeof(PocoAsArrayInit))]
+internal partial class STJSourceGenerationContext : JsonSerializerContext;

--- a/test/Benchmarks/SimplePoco.cs
+++ b/test/Benchmarks/SimplePoco.cs
@@ -10,27 +10,7 @@ using STJ = System.Text.Json;
 public partial class SimplePoco
 {
 	private readonly MessagePackSerializer serializer = new() { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always };
-	private readonly Sequence buffer = new();
-
-	[Benchmark]
-	[BenchmarkCategory("map-init", "Serialize")]
-	public void SerializeMapInit()
-	{
-		this.serializer.Serialize(this.buffer, Data.PocoMapInit.Single);
-		this.buffer.Reset();
-	}
-
-	[Benchmark(Baseline = true)]
-	[BenchmarkCategory("map-init", "Serialize")]
-	public void SerializeMapInit_MsgPackCSharp()
-	{
-		MsgPackCSharp.MessagePackSerializer.Serialize(this.buffer, Data.PocoMapInit.Single, MsgPackCSharp.MessagePackSerializerOptions.Standard);
-		this.buffer.Reset();
-	}
-
-	[Benchmark]
-	[BenchmarkCategory("map-init", "Serialize")]
-	public void SerializeMapInit_STJ() => this.SerializeJson(Data.PocoMapInit.Single, STJSourceGenerationContext.Default.PocoMapInit);
+	private readonly ArrayBufferWriter<byte> buffer = new();
 
 	[Benchmark]
 	[BenchmarkCategory("map-init", "Deserialize")]
@@ -55,7 +35,7 @@ public partial class SimplePoco
 	public void SerializeMap()
 	{
 		this.serializer.Serialize(this.buffer, Data.PocoMap.Single);
-		this.buffer.Reset();
+		this.buffer.Clear();
 	}
 
 	[Benchmark(Baseline = true)]
@@ -63,7 +43,7 @@ public partial class SimplePoco
 	public void SerializeMap_MsgPackCSharp()
 	{
 		MsgPackCSharp.MessagePackSerializer.Serialize(this.buffer, Data.PocoMap.Single, MsgPackCSharp.MessagePackSerializerOptions.Standard);
-		this.buffer.Reset();
+		this.buffer.Clear();
 	}
 
 	[Benchmark]
@@ -93,7 +73,7 @@ public partial class SimplePoco
 	public void SerializeAsArray()
 	{
 		this.serializer.Serialize(this.buffer, Data.PocoAsArray.Single);
-		this.buffer.Reset();
+		this.buffer.Clear();
 	}
 
 	[Benchmark(Baseline = true)]
@@ -101,12 +81,8 @@ public partial class SimplePoco
 	public void SerializeAsArray_MsgPackCSharp()
 	{
 		MsgPackCSharp.MessagePackSerializer.Serialize(this.buffer, Data.PocoAsArray.Single, MsgPackCSharp.MessagePackSerializerOptions.Standard);
-		this.buffer.Reset();
+		this.buffer.Clear();
 	}
-
-	[Benchmark]
-	[BenchmarkCategory("array", "Serialize")]
-	public void SerializeAsArray_STJ() => this.SerializeJson(Data.PocoAsArray.Single, STJSourceGenerationContext.Default.PocoAsArray);
 
 	[Benchmark]
 	[BenchmarkCategory("array", "Deserialize")]
@@ -125,26 +101,6 @@ public partial class SimplePoco
 	[Benchmark]
 	[BenchmarkCategory("array", "Deserialize")]
 	public void DeserializeAsArray_STJ() => this.DeserializeJson(Data.PocoAsArray.SingleJson, STJSourceGenerationContext.Default.PocoAsArray);
-
-	[Benchmark]
-	[BenchmarkCategory("array-init", "Serialize")]
-	public void SerializeAsArrayInit()
-	{
-		this.serializer.Serialize(this.buffer, Data.PocoAsArrayInit.Single);
-		this.buffer.Reset();
-	}
-
-	[Benchmark(Baseline = true)]
-	[BenchmarkCategory("array-init", "Serialize")]
-	public void SerializeAsArrayInit_MsgPackCSharp()
-	{
-		MsgPackCSharp.MessagePackSerializer.Serialize(this.buffer, Data.PocoAsArrayInit.Single, MsgPackCSharp.MessagePackSerializerOptions.Standard);
-		this.buffer.Reset();
-	}
-
-	[Benchmark]
-	[BenchmarkCategory("array-init", "Serialize")]
-	public void SerializeAsArrayInit_STJ() => this.SerializeJson(Data.PocoAsArrayInit.Single, STJSourceGenerationContext.Default.PocoAsArrayInit);
 
 	[Benchmark]
 	[BenchmarkCategory("array-init", "Deserialize")]
@@ -169,7 +125,7 @@ public partial class SimplePoco
 		STJ.Utf8JsonWriter writer = new(this.buffer);
 		STJ.JsonSerializer.Serialize(writer, value, typeInfo);
 		writer.Flush();
-		this.buffer.Reset();
+		this.buffer.Clear();
 	}
 
 	private T? DeserializeJson<T>(ReadOnlySequence<byte> json, STJ.Serialization.Metadata.JsonTypeInfo<T> typeInfo)

--- a/test/Benchmarks/SimplePoco.cs
+++ b/test/Benchmarks/SimplePoco.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Benchmarks;
+using STJ = System.Text.Json;
+
 [MemoryDiagnoser]
 [GroupBenchmarksBy(BenchmarkDotNet.Configs.BenchmarkLogicalGroupRule.ByCategory)]
 [CategoriesColumn]
@@ -26,6 +29,10 @@ public partial class SimplePoco
 	}
 
 	[Benchmark]
+	[BenchmarkCategory("map-init", "Serialize")]
+	public void SerializeMapInit_STJ() => this.SerializeJson(Data.PocoMapInit.Single, STJSourceGenerationContext.Default.PocoMapInit);
+
+	[Benchmark]
 	[BenchmarkCategory("map-init", "Deserialize")]
 	public void DeserializeMapInit()
 	{
@@ -38,6 +45,10 @@ public partial class SimplePoco
 	{
 		MsgPackCSharp.MessagePackSerializer.Deserialize<PocoMapInit>(Data.PocoMapInit.SingleMsgpack, MsgPackCSharp.MessagePackSerializerOptions.Standard);
 	}
+
+	[Benchmark]
+	[BenchmarkCategory("map-init", "Deserialize")]
+	public void DeserializeMapInit_STJ() => this.DeserializeJson(Data.PocoMapInit.SingleJson, STJSourceGenerationContext.Default.PocoMapInit);
 
 	[Benchmark]
 	[BenchmarkCategory("map", "Serialize")]
@@ -56,6 +67,10 @@ public partial class SimplePoco
 	}
 
 	[Benchmark]
+	[BenchmarkCategory("map", "Serialize")]
+	public void SerializeMap_STJ() => this.SerializeJson(Data.PocoMap.Single, STJSourceGenerationContext.Default.PocoMap);
+
+	[Benchmark]
 	[BenchmarkCategory("map", "Deserialize")]
 	public void DeserializeMap()
 	{
@@ -68,6 +83,10 @@ public partial class SimplePoco
 	{
 		MsgPackCSharp.MessagePackSerializer.Deserialize<PocoMap>(Data.PocoMap.SingleMsgpack, MsgPackCSharp.MessagePackSerializerOptions.Standard);
 	}
+
+	[Benchmark]
+	[BenchmarkCategory("map", "Deserialize")]
+	public void DeserializeMap_STJ() => this.DeserializeJson(Data.PocoMap.SingleJson, STJSourceGenerationContext.Default.PocoMap);
 
 	[Benchmark]
 	[BenchmarkCategory("array", "Serialize")]
@@ -86,6 +105,10 @@ public partial class SimplePoco
 	}
 
 	[Benchmark]
+	[BenchmarkCategory("array", "Serialize")]
+	public void SerializeAsArray_STJ() => this.SerializeJson(Data.PocoAsArray.Single, STJSourceGenerationContext.Default.PocoAsArray);
+
+	[Benchmark]
 	[BenchmarkCategory("array", "Deserialize")]
 	public void DeserializeAsArray()
 	{
@@ -98,6 +121,10 @@ public partial class SimplePoco
 	{
 		MsgPackCSharp.MessagePackSerializer.Deserialize<PocoAsArray>(Data.PocoAsArray.SingleMsgpack, MsgPackCSharp.MessagePackSerializerOptions.Standard);
 	}
+
+	[Benchmark]
+	[BenchmarkCategory("array", "Deserialize")]
+	public void DeserializeAsArray_STJ() => this.DeserializeJson(Data.PocoAsArray.SingleJson, STJSourceGenerationContext.Default.PocoAsArray);
 
 	[Benchmark]
 	[BenchmarkCategory("array-init", "Serialize")]
@@ -116,6 +143,10 @@ public partial class SimplePoco
 	}
 
 	[Benchmark]
+	[BenchmarkCategory("array-init", "Serialize")]
+	public void SerializeAsArrayInit_STJ() => this.SerializeJson(Data.PocoAsArrayInit.Single, STJSourceGenerationContext.Default.PocoAsArrayInit);
+
+	[Benchmark]
 	[BenchmarkCategory("array-init", "Deserialize")]
 	public void DeserializeAsArrayInit()
 	{
@@ -127,5 +158,23 @@ public partial class SimplePoco
 	public void DeserializeAsArrayInit_MsgPackCSharp()
 	{
 		MsgPackCSharp.MessagePackSerializer.Deserialize<PocoAsArrayInit>(Data.PocoAsArrayInit.SingleMsgpack, MsgPackCSharp.MessagePackSerializerOptions.Standard);
+	}
+
+	[Benchmark]
+	[BenchmarkCategory("array-init", "Deserialize")]
+	public void DeserializeAsArrayInit_STJ() => this.DeserializeJson(Data.PocoAsArrayInit.SingleJson, STJSourceGenerationContext.Default.PocoAsArrayInit);
+
+	private void SerializeJson<T>(T value, STJ.Serialization.Metadata.JsonTypeInfo<T> typeInfo)
+	{
+		STJ.Utf8JsonWriter writer = new(this.buffer);
+		STJ.JsonSerializer.Serialize(writer, value, typeInfo);
+		writer.Flush();
+		this.buffer.Reset();
+	}
+
+	private T? DeserializeJson<T>(ReadOnlySequence<byte> json, STJ.Serialization.Metadata.JsonTypeInfo<T> typeInfo)
+	{
+		STJ.Utf8JsonReader r = new(json);
+		return STJ.JsonSerializer.Deserialize(ref r, typeInfo);
 	}
 }

--- a/test/Benchmarks/SyncVsAsyncPoco.cs
+++ b/test/Benchmarks/SyncVsAsyncPoco.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO.Pipelines;
+using Benchmarks;
+using STJ = System.Text.Json;
 
 [MemoryDiagnoser]
 [GroupBenchmarksBy(BenchmarkDotNet.Configs.BenchmarkLogicalGroupRule.ByCategory)]
@@ -11,6 +13,7 @@ public class SyncVsAsyncPoco
 	private readonly MessagePackSerializer serializer = new();
 	private readonly Sequence syncBuffer = new();
 	private readonly PipeWriter nullPipeWriter = PipeWriter.Create(Stream.Null);
+	private readonly MemoryStream jsonMemoryStream = new();
 
 	[Benchmark(Baseline = true)]
 	[BenchmarkCategory("map-init", "Serialize")]
@@ -27,6 +30,10 @@ public class SyncVsAsyncPoco
 		await this.serializer.SerializeAsync(this.nullPipeWriter, Data.PocoMapInit.Single, default);
 	}
 
+	[Benchmark]
+	[BenchmarkCategory("map-init", "Serialize")]
+	public Task JsonSerializeAsyncMapInit() => this.SerializeJsonAsync(Data.PocoMapInit.Single, STJSourceGenerationContext.Default.PocoMapInit);
+
 	[Benchmark(Baseline = true)]
 	[BenchmarkCategory("map-init", "Deserialize")]
 	public void DeserializeMapInit()
@@ -40,6 +47,10 @@ public class SyncVsAsyncPoco
 	{
 		PocoMapInit? result = await this.serializer.DeserializeAsync<PocoMapInit>(PipeReader.Create(Data.PocoMapInit.SingleMsgpack), default);
 	}
+
+	[Benchmark]
+	[BenchmarkCategory("map-init", "Deserialize")]
+	public async ValueTask JsonDeserializeAsyncMapInit() => await this.DeserializeJsonAsync(Data.PocoMapInit.SingleJsonStream, STJSourceGenerationContext.Default.PocoMapInit);
 
 	[Benchmark(Baseline = true)]
 	[BenchmarkCategory("map", "Serialize")]
@@ -56,6 +67,10 @@ public class SyncVsAsyncPoco
 		await this.serializer.SerializeAsync(this.nullPipeWriter, Data.PocoMap.Single, default);
 	}
 
+	[Benchmark]
+	[BenchmarkCategory("map", "Serialize")]
+	public Task JsonSerializeAsyncMap() => this.SerializeJsonAsync(Data.PocoMap.Single, STJSourceGenerationContext.Default.PocoMap);
+
 	[Benchmark(Baseline = true)]
 	[BenchmarkCategory("map", "Deserialize")]
 	public void DeserializeMap()
@@ -69,6 +84,10 @@ public class SyncVsAsyncPoco
 	{
 		PocoMap? result = await this.serializer.DeserializeAsync<PocoMap>(PipeReader.Create(Data.PocoMap.SingleMsgpack), default);
 	}
+
+	[Benchmark]
+	[BenchmarkCategory("map", "Deserialize")]
+	public async ValueTask JsonDeserializeAsyncMap() => await this.DeserializeJsonAsync(Data.PocoMap.SingleJsonStream, STJSourceGenerationContext.Default.PocoMap);
 
 	[Benchmark(Baseline = true)]
 	[BenchmarkCategory("array-init", "Serialize")]
@@ -84,6 +103,10 @@ public class SyncVsAsyncPoco
 	{
 		await this.serializer.SerializeAsync(this.nullPipeWriter, Data.PocoAsArrayInit.Single, default);
 	}
+
+	[Benchmark]
+	[BenchmarkCategory("array-init", "Serialize")]
+	public Task JsonSerializeAsyncAsArrayInit() => this.SerializeJsonAsync(Data.PocoAsArrayInit.Single, STJSourceGenerationContext.Default.PocoAsArrayInit);
 
 	[Benchmark(Baseline = true)]
 	[BenchmarkCategory("array-init", "Deserialize")]
@@ -126,5 +149,13 @@ public class SyncVsAsyncPoco
 	public async ValueTask DeserializeAsyncAsArray()
 	{
 		PocoAsArray? result = await this.serializer.DeserializeAsync<PocoAsArray>(PipeReader.Create(Data.PocoAsArray.SingleMsgpack), default);
+	}
+
+	private Task SerializeJsonAsync<T>(T value, STJ.Serialization.Metadata.JsonTypeInfo<T> typeInfo) => STJ.JsonSerializer.SerializeAsync(Stream.Null, value, typeInfo);
+
+	private ValueTask<T?> DeserializeJsonAsync<T>(Stream json, STJ.Serialization.Metadata.JsonTypeInfo<T> typeInfo)
+	{
+		json.Position = 0;
+		return STJ.JsonSerializer.DeserializeAsync(json, typeInfo);
 	}
 }

--- a/test/Benchmarks/SyncVsAsyncPoco.cs
+++ b/test/Benchmarks/SyncVsAsyncPoco.cs
@@ -11,28 +11,8 @@ using STJ = System.Text.Json;
 public class SyncVsAsyncPoco
 {
 	private readonly MessagePackSerializer serializer = new();
-	private readonly Sequence syncBuffer = new();
+	private readonly ArrayBufferWriter<byte> syncBuffer = new();
 	private readonly PipeWriter nullPipeWriter = PipeWriter.Create(Stream.Null);
-	private readonly MemoryStream jsonMemoryStream = new();
-
-	[Benchmark(Baseline = true)]
-	[BenchmarkCategory("map-init", "Serialize")]
-	public void SerializeMapInit()
-	{
-		this.serializer.Serialize(this.syncBuffer, Data.PocoMapInit.Single);
-		this.syncBuffer.Reset();
-	}
-
-	[Benchmark]
-	[BenchmarkCategory("map-init", "Serialize")]
-	public async Task SerializeAsyncMapInit()
-	{
-		await this.serializer.SerializeAsync(this.nullPipeWriter, Data.PocoMapInit.Single, default);
-	}
-
-	[Benchmark]
-	[BenchmarkCategory("map-init", "Serialize")]
-	public Task JsonSerializeAsyncMapInit() => this.SerializeJsonAsync(Data.PocoMapInit.Single, STJSourceGenerationContext.Default.PocoMapInit);
 
 	[Benchmark(Baseline = true)]
 	[BenchmarkCategory("map-init", "Deserialize")]
@@ -57,7 +37,7 @@ public class SyncVsAsyncPoco
 	public void SerializeMap()
 	{
 		this.serializer.Serialize(this.syncBuffer, Data.PocoMap.Single);
-		this.syncBuffer.Reset();
+		this.syncBuffer.Clear();
 	}
 
 	[Benchmark]
@@ -90,25 +70,6 @@ public class SyncVsAsyncPoco
 	public async ValueTask JsonDeserializeAsyncMap() => await this.DeserializeJsonAsync(Data.PocoMap.SingleJsonStream, STJSourceGenerationContext.Default.PocoMap);
 
 	[Benchmark(Baseline = true)]
-	[BenchmarkCategory("array-init", "Serialize")]
-	public void SerializeAsArrayInit()
-	{
-		this.serializer.Serialize(this.syncBuffer, Data.PocoAsArrayInit.Single);
-		this.syncBuffer.Reset();
-	}
-
-	[Benchmark]
-	[BenchmarkCategory("array-init", "Serialize")]
-	public async Task SerializeAsyncAsArrayInit()
-	{
-		await this.serializer.SerializeAsync(this.nullPipeWriter, Data.PocoAsArrayInit.Single, default);
-	}
-
-	[Benchmark]
-	[BenchmarkCategory("array-init", "Serialize")]
-	public Task JsonSerializeAsyncAsArrayInit() => this.SerializeJsonAsync(Data.PocoAsArrayInit.Single, STJSourceGenerationContext.Default.PocoAsArrayInit);
-
-	[Benchmark(Baseline = true)]
 	[BenchmarkCategory("array-init", "Deserialize")]
 	public void DeserializeAsArrayInit()
 	{
@@ -127,7 +88,7 @@ public class SyncVsAsyncPoco
 	public void SerializeAsArray()
 	{
 		this.serializer.Serialize(this.syncBuffer, Data.PocoAsArray.Single);
-		this.syncBuffer.Reset();
+		this.syncBuffer.Clear();
 	}
 
 	[Benchmark]

--- a/test/Benchmarks/Usings.cs
+++ b/test/Benchmarks/Usings.cs
@@ -3,7 +3,6 @@
 
 global using System.Buffers;
 global using BenchmarkDotNet.Attributes;
-global using BenchmarkDotNet.Jobs;
 global using Nerdbank.MessagePack;
 global using Nerdbank.Streams;
 global using PolyType;


### PR DESCRIPTION
## Changes

### Dictionary Lookup Optimizations

* We skip hashing strings when matching property names when the input has a length that does not match two or more known property names.
* Cache the last top-level converter to be used in a field to avoid dictionary lookups on repeated serialization jobs.

### JSON benchmarks

* Added JSON serialization and deserialization benchmarks using `System.Text.Json` and source generation context to include comparisons between MsgPack and JSON serialization.

### Miscellaneous

* Upgraded target framework for benchmarks from `net8.0` to `net9.0` to leverage new features and improvements (`test/Benchmarks/Benchmarks.csproj`).

## Perf impact

### Before

| Method                               | Categories             | Mean     | Error    | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------------------------------- |----------------------- |---------:|---------:|--------:|------:|--------:|-------:|----------:|------------:|
| DeserializeAsArrayInit               | array-init,Deserialize | 170.6 ns | 19.44 ns | 1.07 ns |  1.51 |    0.01 | 0.0095 |      80 B |        1.00 |
| DeserializeAsArrayInit_MsgPackCSharp | array-init,Deserialize | 113.1 ns | 12.91 ns | 0.71 ns |  1.00 |    0.01 | 0.0095 |      80 B |        1.00 |
|                                      |                        |          |          |         |       |         |        |           |             |
| SerializeAsArrayInit                 | array-init,Serialize   | 185.9 ns | 35.78 ns | 1.96 ns |  1.38 |    0.02 |      - |         - |          NA |
| SerializeAsArrayInit_MsgPackCSharp   | array-init,Serialize   | 134.5 ns | 22.64 ns | 1.24 ns |  1.00 |    0.01 |      - |         - |          NA |
|                                      |                        |          |          |         |       |         |        |           |             |
| DeserializeAsArray                   | array,Deserialize      | 161.9 ns | 15.95 ns | 0.87 ns |  1.24 |    0.01 | 0.0095 |      80 B |        1.00 |
| DeserializeAsArray_MsgPackCSharp     | array,Deserialize      | 130.8 ns | 24.93 ns | 1.37 ns |  1.00 |    0.01 | 0.0095 |      80 B |        1.00 |
|                                      |                        |          |          |         |       |         |        |           |             |
| SerializeAsArray                     | array,Serialize        | 171.5 ns | 13.23 ns | 0.73 ns |  1.28 |    0.01 |      - |         - |          NA |
| SerializeAsArray_MsgPackCSharp       | array,Serialize        | 133.9 ns | 14.75 ns | 0.81 ns |  1.00 |    0.01 |      - |         - |          NA |
|                                      |                        |          |          |         |       |         |        |           |             |
| DeserializeMapInit                   | map-init,Deserialize   | 248.0 ns | 19.67 ns | 1.08 ns |  1.68 |    0.01 | 0.0095 |      80 B |        1.00 |
| DeserializeMapInit_MsgPackCSharp     | map-init,Deserialize   | 147.6 ns |  1.66 ns | 0.09 ns |  1.00 |    0.00 | 0.0095 |      80 B |        1.00 |
|                                      |                        |          |          |         |       |         |        |           |             |
| SerializeMapInit                     | map-init,Serialize     | 186.7 ns | 11.42 ns | 0.63 ns |  1.27 |    0.01 |      - |         - |          NA |
| SerializeMapInit_MsgPackCSharp       | map-init,Serialize     | 147.6 ns |  9.10 ns | 0.50 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                      |                        |          |          |         |       |         |        |           |             |
| DeserializeMap                       | map,Deserialize        | 255.1 ns |  7.43 ns | 0.41 ns |  1.62 |    0.01 | 0.0095 |      80 B |        1.00 |
| DeserializeMap_MsgPackCSharp         | map,Deserialize        | 157.6 ns | 19.95 ns | 1.09 ns |  1.00 |    0.01 | 0.0095 |      80 B |        1.00 |
|                                      |                        |          |          |         |       |         |        |           |             |
| SerializeMap                         | map,Serialize          | 179.5 ns | 10.61 ns | 0.58 ns |  1.16 |    0.01 |      - |         - |          NA |
| SerializeMap_MsgPackCSharp           | map,Serialize          | 154.6 ns | 34.05 ns | 1.87 ns |  1.00 |    0.01 |      - |         - |          NA |

### After

| Method                               | Categories             | Mean      | Error      | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------------------------------- |----------------------- |----------:|-----------:|---------:|------:|--------:|-------:|----------:|------------:|
| DeserializeAsArrayInit               | array-init,Deserialize | 136.28 ns |  42.774 ns | 2.345 ns |  1.10 |    0.02 | 0.0095 |      80 B |        1.00 |
| DeserializeAsArrayInit_MsgPackCSharp | array-init,Deserialize | 123.77 ns |  18.689 ns | 1.024 ns |  1.00 |    0.01 | 0.0095 |      80 B |        1.00 |
| DeserializeAsArrayInit_STJ           | array-init,Deserialize | 536.07 ns |  63.183 ns | 3.463 ns |  4.33 |    0.04 | 0.0191 |     160 B |        2.00 |
|                                      |                        |           |            |          |       |         |        |           |             |
| DeserializeAsArray                   | array,Deserialize      | 134.18 ns |   4.144 ns | 0.227 ns |  1.15 |    0.00 | 0.0095 |      80 B |        1.00 |
| DeserializeAsArray_MsgPackCSharp     | array,Deserialize      | 116.88 ns |   9.132 ns | 0.501 ns |  1.00 |    0.01 | 0.0095 |      80 B |        1.00 |
| DeserializeAsArray_STJ               | array,Deserialize      | 444.79 ns |  87.567 ns | 4.800 ns |  3.81 |    0.04 | 0.0095 |      80 B |        1.00 |
|                                      |                        |           |            |          |       |         |        |           |             |
| SerializeAsArray                     | array,Serialize        |  80.33 ns |   4.730 ns | 0.259 ns |  1.04 |    0.00 |      - |         - |          NA |
| SerializeAsArray_MsgPackCSharp       | array,Serialize        |  77.14 ns |   6.090 ns | 0.334 ns |  1.00 |    0.01 |      - |         - |          NA |
|                                      |                        |           |            |          |       |         |        |           |             |
| DeserializeMapInit                   | map-init,Deserialize   | 188.35 ns |   8.336 ns | 0.457 ns |  1.26 |    0.01 | 0.0095 |      80 B |        1.00 |
| DeserializeMapInit_MsgPackCSharp     | map-init,Deserialize   | 149.98 ns |  12.969 ns | 0.711 ns |  1.00 |    0.01 | 0.0095 |      80 B |        1.00 |
| DeserializeMapInit_STJ               | map-init,Deserialize   | 529.37 ns |  46.610 ns | 2.555 ns |  3.53 |    0.02 | 0.0191 |     160 B |        2.00 |
|                                      |                        |           |            |          |       |         |        |           |             |
| DeserializeMap                       | map,Deserialize        | 175.66 ns |  16.575 ns | 0.909 ns |  1.12 |    0.01 | 0.0095 |      80 B |        1.00 |
| DeserializeMap_MsgPackCSharp         | map,Deserialize        | 157.00 ns |   8.952 ns | 0.491 ns |  1.00 |    0.00 | 0.0095 |      80 B |        1.00 |
| DeserializeMap_STJ                   | map,Deserialize        | 465.14 ns | 138.136 ns | 7.572 ns |  2.96 |    0.04 | 0.0095 |      80 B |        1.00 |
|                                      |                        |           |            |          |       |         |        |           |             |
| SerializeMap                         | map,Serialize          |  84.06 ns |  13.353 ns | 0.732 ns |  1.01 |    0.01 |      - |         - |          NA |
| SerializeMap_MsgPackCSharp           | map,Serialize          |  83.47 ns |   5.476 ns | 0.300 ns |  1.00 |    0.00 |      - |         - |          NA |
| SerializeMap_STJ                     | map,Serialize          | 102.51 ns |  36.235 ns | 1.986 ns |  1.23 |    0.02 | 0.0153 |     128 B |          NA |
