### PR TITLE
Bump PolyType to 0.30.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <RoslynVersion>4.13.0</RoslynVersion>
     <RoslynVersionForAnalyzers>4.11.0</RoslynVersionForAnalyzers>
     <CodeAnalysisAnalyzerVersion>3.11.0-beta1.25076.3</CodeAnalysisAnalyzerVersion>
-    <PolyTypeVersion>0.29.3</PolyTypeVersion>
+    <PolyTypeVersion>0.30.1</PolyTypeVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />

--- a/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
+++ b/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
@@ -105,7 +105,7 @@ internal record struct PropertyAccessors<TDeclaringType>(
 	IPropertyShape Shape);
 
 /// <summary>
-/// Encapsulates the data passed through <see cref="ITypeShapeVisitor.VisitConstructor{TDeclaringType, TArgumentState}(IConstructorShape{TDeclaringType, TArgumentState}, object?)"/> state arguments
+/// Encapsulates the data passed through <see cref="TypeShapeVisitor.VisitConstructor{TDeclaringType, TArgumentState}(IConstructorShape{TDeclaringType, TArgumentState}, object?)"/> state arguments
 /// when serializing an object as a map.
 /// </summary>
 /// <typeparam name="TDeclaringType">The data type whose constructor is to be visited.</typeparam>
@@ -115,7 +115,7 @@ internal record struct PropertyAccessors<TDeclaringType>(
 internal record MapConstructorVisitorInputs<TDeclaringType>(MapSerializableProperties<TDeclaringType> Serializers, MapDeserializableProperties<TDeclaringType> Deserializers, Dictionary<string, IConstructorParameterShape> ParametersByName);
 
 /// <summary>
-/// Encapsulates the data passed through <see cref="ITypeShapeVisitor.VisitConstructor{TDeclaringType, TArgumentState}(IConstructorShape{TDeclaringType, TArgumentState}, object?)"/> state arguments
+/// Encapsulates the data passed through <see cref="TypeShapeVisitor.VisitConstructor{TDeclaringType, TArgumentState}(IConstructorShape{TDeclaringType, TArgumentState}, object?)"/> state arguments
 /// when serializing an object as an array.
 /// </summary>
 /// <typeparam name="TDeclaringType">The data type whose constructor is to be visited.</typeparam>

--- a/src/Nerdbank.MessagePack/ReferencePreservingVisitor.cs
+++ b/src/Nerdbank.MessagePack/ReferencePreservingVisitor.cs
@@ -7,7 +7,7 @@ namespace Nerdbank.MessagePack;
 /// A visitor that wraps the result of another visitor with a reference-preserving converter.
 /// </summary>
 /// <param name="inner">The inner visitor.</param>
-internal class ReferencePreservingVisitor(ITypeShapeVisitor inner) : TypeShapeVisitor
+internal class ReferencePreservingVisitor(TypeShapeVisitor inner) : TypeShapeVisitor
 {
 	/// <inheritdoc/>
 	public override object? VisitEnum<TEnum, TUnderlying>(IEnumTypeShape<TEnum, TUnderlying> enumShape, object? state = null)

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -42,7 +42,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	/// <remarks>
 	/// This may be changed to a wrapping visitor implementation to implement features such as reference preservation.
 	/// </remarks>
-	internal ITypeShapeVisitor OutwardVisitor { get; set; }
+	internal TypeShapeVisitor OutwardVisitor { get; set; }
 
 	/// <inheritdoc/>
 	object? ITypeShapeFunc.Invoke<T>(ITypeShape<T> typeShape, object? state)


### PR DESCRIPTION
Bump PolyType to 0.30.1

This update removes the `ITypeShapeVisitor` interface.