### PR TITLE
Reference System.IO.Pipelines 8.0 instead of 9.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
 			"allowedVersions": "!/-g[a-f0-9]+$/"
 		},
 		{
-			"matchPackageNames": ["System.Collections.Immutable", "System.Text.Json"],
+			"matchPackageNames": ["System.Collections.Immutable", "System.Text.Json", "System.IO.Pipelines"],
 			"allowedVersions": "<9.0",
 			"groupName": "Included in .NET runtime"
 		},

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageVersion Include="PolyType" Version="$(PolyTypeVersion)" />
     <PackageVersion Include="PolyType.TestCases" Version="$(PolyTypeVersion)" />
-    <PackageVersion Include="System.IO.Pipelines" Version="9.0.3" />
+    <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
     <PackageVersion Include="Xunit.Combinatorial" Version="2.0.24" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)'!='.NETCoreApp'">

--- a/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
+++ b/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
@@ -27,8 +27,6 @@
     <PackageReference Include="Nerdbank.Streams" />
     <PackageReference Include="Newtonsoft.Json.Schema" />
     <PackageReference Include="PolyType.TestCases" />
-    <!-- Override S.T.J. version just until we get a PolyType update that includes https://github.com/eiriktsarpalis/PolyType/pull/90 -->
-    <PackageReference Include="System.Text.Json" VersionOverride="9.0.0" />
     <PackageReference Include="Xunit.Combinatorial" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit.v3" />


### PR DESCRIPTION
This allows an ASP.NET Core app to target .NET 8 without having to ship System.IO.Pipelines.dll with the app, since it's included in the runtime.