### PR TITLE
Refactor `MessagePackSerializer` to be entirely immutable

### DIFF
--- a/docfx/docs/custom-converters.md
+++ b/docfx/docs/custom-converters.md
@@ -55,10 +55,10 @@ public class MyType<T>
 }
 ```
 
-Or you may register the converter at runtime with the @Nerdbank.MessagePack.MessagePackSerializer.RegisterConverter* method, using the open generic type syntax:
+Or you may register the converter at runtime with the @Nerdbank.MessagePack.MessagePackSerializer.ConverterTypes?displayProperty=nameWithType collection, using the open generic type syntax:
 
 ```cs
-serializer.RegisterConverter(typeof(MyConverter<>));
+serializer = serializer with { ConverterTypes = [typeof(MyConverter<>)] };
 ```
 
 ### Security considerations
@@ -222,9 +222,9 @@ The generic converter will be constructed using the same list of generic type ar
 
 ### Runtime registration
 
-For precise runtime control of where your converter is used and/or how it is instantiated/configured, you may register an instance of your custom converter with an instance of @Nerdbank.MessagePack.MessagePackSerializer using the @Nerdbank.MessagePack.MessagePackSerializer.RegisterConverter*.
+For precise runtime control of where your converter is used and/or how it is instantiated/configured, you may register an instance of your custom converter with an instance of @Nerdbank.MessagePack.MessagePackSerializer using the @Nerdbank.MessagePack.MessagePackSerializer.Converters property.
 
-[!code-csharp[](../../samples/cs/CustomConverters.cs#CustomConverterByRegister)]
+[!code-csharp[](../../samples/cs/CustomConverters.cs#CustomConverterRegisteredAtRuntime)]
 
 Runtime registration of open generic converters (i.e. converters that themselves are generic types) can either be as live objects (which necessarily locks the converters down to just one closed generic type) or you can register the converter's open generic type itself, in which case the converter will be activated on-demand when an object graph that carries an instance of the generic data type needs to be serialized.
 
@@ -232,7 +232,7 @@ Runtime registration of open generic converters (i.e. converters that themselves
 
 When you have a converter that must be applied to many (possibly unrelated) types, you can define it as an open generic class and define a converter factory for it by implementing an @Nerdbank.MessagePack.IMessagePackConverterFactory.
 A converter factory is consulted for any data type that requires a converter and has the option to return a matching converter.
-You register your converter factory using the @Nerdbank.MessagePack.MessagePackSerializer.RegisterConverterFactory* method.
+You register your converter factory using the @Nerdbank.MessagePack.MessagePackSerializer.ConverterFactories property.
 
 In the following example, a converter operates on arbitrary data types by serializing only a handle to them instead of the data itself.
 The converter factory applies this novel converter for any type that has a particular attribute applied.

--- a/samples/cs/CustomConverters.cs
+++ b/samples/cs/CustomConverters.cs
@@ -323,13 +323,13 @@ namespace CustomConverterRegistration
         }
     }
 
-    class CustomConverterByRegister
+    class CustomConverterRegisteredAtRuntime
     {
         void Main()
         {
-            #region CustomConverterByRegister
+            #region CustomConverterRegisteredAtRuntime
             MessagePackSerializer serializer = new();
-            serializer.RegisterConverter(new MyCustomTypeConverter());
+            serializer = serializer with { Converters = [new MyCustomTypeConverter()] };
             #endregion
         }
     }
@@ -626,8 +626,8 @@ namespace CustomConverterFactory
                 {
                     ["MarshalingState"] = new Dictionary<int, object?>(),
                 },
+                ConverterFactories = [new MarshalingConverterFactory("MarshalingState")],
             };
-            serializer.RegisterConverterFactory(new MarshalingConverterFactory("MarshalingState"));
 
             // Use the serializer to pass object graphs that may include objects that must retain reference identity
             // between parties.

--- a/samples/cs/Unions.cs
+++ b/samples/cs/Unions.cs
@@ -144,13 +144,13 @@ namespace RuntimeSubTypes
 
     class SerializationConfigurator
     {
-        internal void ConfigureAnimalsMapping(MessagePackSerializer serializer)
+        internal MessagePackSerializer ConfigureAnimalsMapping(MessagePackSerializer serializer)
         {
             DerivedTypeMapping<Animal> mapping = new();
             mapping.Add<Horse>(1);
             mapping.Add<Cow>(2);
 
-            serializer.RegisterDerivedTypes(mapping);
+            return serializer with { DerivedTypeMappings = [.. serializer.DerivedTypeMappings, mapping] };
         }
     }
     #endregion
@@ -170,13 +170,13 @@ namespace RuntimeSubTypes
 
     class SerializationConfigurator
     {
-        internal void ConfigureAnimalsMapping(MessagePackSerializer serializer)
+        internal MessagePackSerializer ConfigureAnimalsMapping(MessagePackSerializer serializer)
         {
             DerivedTypeMapping<Animal> mapping = new();
             mapping.Add<Horse>(1, Witness.ShapeProvider);
             mapping.Add<Cow>(2, Witness.ShapeProvider);
 
-            serializer.RegisterDerivedTypes(mapping);
+            return serializer with { DerivedTypeMappings = [.. serializer.DerivedTypeMappings, mapping] };
         }
     }
     #endregion

--- a/src/Nerdbank.MessagePack/ConverterCollection.cs
+++ b/src/Nerdbank.MessagePack/ConverterCollection.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// An immutable collection of converters.
+/// </summary>
+[CollectionBuilder(typeof(ConverterCollection), nameof(Create))]
+public class ConverterCollection : IReadOnlyCollection<MessagePackConverter>
+{
+	private ConverterCollection(FrozenDictionary<Type, MessagePackConverter> map)
+	{
+		this.Map = map;
+	}
+
+	/// <inheritdoc/>
+	public int Count => this.Map.Count;
+
+	private FrozenDictionary<Type, MessagePackConverter> Map { get; }
+
+	/// <summary>
+	/// Creates a new instance of <see cref="ConverterCollection"/> from the specified converters.
+	/// </summary>
+	/// <param name="converters">The converters to fill the collection with.</param>
+	/// <returns>The initialized collection.</returns>
+	public static ConverterCollection Create(ReadOnlySpan<MessagePackConverter> converters)
+	{
+		Dictionary<Type, MessagePackConverter> map = [];
+		foreach (MessagePackConverter converter in converters)
+		{
+			map.Add(converter.DataType, converter);
+		}
+
+		return new(map.ToFrozenDictionary());
+	}
+
+	/// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
+	public ImmutableArray<MessagePackConverter>.Enumerator GetEnumerator() => this.Map.Values.GetEnumerator();
+
+	/// <inheritdoc/>
+	IEnumerator<MessagePackConverter> IEnumerable<MessagePackConverter>.GetEnumerator() => ((IReadOnlyList<MessagePackConverter>)this.Map.Values).GetEnumerator();
+
+	/// <inheritdoc/>
+	IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<MessagePackConverter>)this).GetEnumerator();
+
+	/// <summary>
+	/// Retrieves a converter for a given data type, if the user supplied one.
+	/// </summary>
+	/// <param name="dataType">The data type.</param>
+	/// <param name="converter">Receives the converter, if available.</param>
+	/// <returns>A value indicating whether a converter was available.</returns>
+	internal bool TryGetConverter(Type dataType, [NotNullWhen(true)] out MessagePackConverter? converter)
+	{
+		if (this.Map.TryGetValue(dataType, out converter))
+		{
+			return true;
+		}
+
+		converter = default;
+		return false;
+	}
+
+	/// <summary>
+	/// Retrieves a converter for a given data type, if the user supplied one.
+	/// </summary>
+	/// <typeparam name="T">The data type.</typeparam>
+	/// <param name="converter">Receives the converter, if available.</param>
+	/// <returns>A value indicating whether a converter was available.</returns>
+	internal bool TryGetConverter<T>([NotNullWhen(true)] out MessagePackConverter<T>? converter)
+	{
+		if (this.Map.TryGetValue(typeof(T), out MessagePackConverter? converterBase))
+		{
+			converter = (MessagePackConverter<T>)converterBase;
+			return true;
+		}
+
+		converter = default;
+		return false;
+	}
+}

--- a/src/Nerdbank.MessagePack/ConverterTypeCollection.cs
+++ b/src/Nerdbank.MessagePack/ConverterTypeCollection.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Microsoft;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// An immutable collection of <see cref="MessagePackConverter{T}"/> types.
+/// </summary>
+[CollectionBuilder(typeof(ConverterTypeCollection), nameof(Create))]
+public class ConverterTypeCollection : IReadOnlyCollection<Type>
+{
+	private ConverterTypeCollection(FrozenDictionary<Type, Type> map)
+	{
+		this.Map = map;
+	}
+
+	/// <inheritdoc />
+	public int Count => this.Map.Count;
+
+	/// <summary>
+	/// Gets a mapping of data types to their custom converter types.
+	/// </summary>
+	private FrozenDictionary<Type, Type> Map { get; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ConverterTypeCollection"/> class
+	/// populated with a collection of <see cref="Type"/>s.
+	/// </summary>
+	/// <param name="converterTypes">The <see cref="MessagePackConverter{T}"/> types that should be elements in the collection.</param>
+	/// <returns>The newly initialized collection type.</returns>
+	public static ConverterTypeCollection Create(ReadOnlySpan<Type> converterTypes)
+	{
+		Dictionary<Type, Type> map = [];
+
+		foreach (Type converterType in converterTypes)
+		{
+			Requires.Argument(converterType is not null, nameof(converterTypes), "Null elements are not allowed.");
+			Requires.Argument(converterType.IsClass && !converterType.IsAbstract, nameof(converterTypes), "All types must be concrete classes.");
+
+			// Discover what the data type being converted is.
+			Type? baseType = converterType.BaseType;
+			while (baseType is not null && !(baseType.IsGenericType && typeof(MessagePackConverter<>).IsAssignableFrom(baseType.GetGenericTypeDefinition())))
+			{
+				baseType = baseType.BaseType;
+			}
+
+			Requires.Argument(baseType is not null, nameof(converterType), $"Type does not derive from MessagePackConverter<T>.");
+			Type dataType = baseType.GetGenericArguments()[0];
+
+			// If the data type has no generic type arguments, turn it into a proper generic type definition so we can find it later.
+			if (dataType.GenericTypeArguments is [{ IsGenericParameter: true }, ..])
+			{
+				dataType = dataType.GetGenericTypeDefinition();
+			}
+
+			map[dataType] = converterType;
+		}
+
+		return new(map.ToFrozenDictionary());
+	}
+
+	/// <summary>Gets an enumerator over the <see cref="Type"/> elements of the collection.</summary>
+	/// <returns>The enumerator.</returns>
+	public ImmutableArray<Type>.Enumerator GetEnumerator() => this.Map.Values.GetEnumerator();
+
+	/// <inheritdoc />
+	IEnumerator<Type> IEnumerable<Type>.GetEnumerator() => ((IReadOnlyList<Type>)this.Map.Values).GetEnumerator();
+
+	/// <inheritdoc />
+	IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<Type>)this).GetEnumerator();
+
+	/// <summary>
+	/// Retrieves a converter type for a given data type.
+	/// </summary>
+	/// <param name="dataType">The data type.</param>
+	/// <param name="converterType">Receives the converter type, if available.</param>
+	/// <returns>A value indicating whether the converter type was available.</returns>
+	internal bool TryGetConverterType(Type dataType, [NotNullWhen(true)] out Type? converterType)
+	{
+		if (this.Map.TryGetValue(dataType, out converterType))
+		{
+			return true;
+		}
+
+		converterType = default;
+		return false;
+	}
+}

--- a/src/Nerdbank.MessagePack/DerivedTypeMapping.cs
+++ b/src/Nerdbank.MessagePack/DerivedTypeMapping.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Frozen;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// A non-generic abstract base class for <see cref="DerivedTypeMapping{TBase}"/>.
+/// </summary>
+/// <remarks>
+/// All users of this class should create an instance of the generic derived <see cref="DerivedTypeMapping{TBase}"/> class instead.
+/// </remarks>
+public abstract class DerivedTypeMapping : IDerivedTypeMapping
+{
+	/// <summary>
+	/// Gets the base union type.
+	/// </summary>
+	internal abstract Type BaseType { get; }
+
+	/// <inheritdoc/>
+	FrozenDictionary<DerivedTypeIdentifier, ITypeShape> IDerivedTypeMapping.CreateDerivedTypesMapping() => this.CreateDerivedTypesMapping();
+
+	/// <inheritdoc cref="IDerivedTypeMapping.CreateDerivedTypesMapping"/>
+	internal abstract FrozenDictionary<DerivedTypeIdentifier, ITypeShape> CreateDerivedTypesMapping();
+}

--- a/src/Nerdbank.MessagePack/DerivedTypeMappingCollection.cs
+++ b/src/Nerdbank.MessagePack/DerivedTypeMappingCollection.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Microsoft;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// An immutable collection of <see cref="DerivedTypeMapping{TBase}"/> objects.
+/// </summary>
+/// <remarks>
+/// Since the <see cref="DerivedTypeMapping"/> object is mutable and this collection must be immutable,
+/// we freeze the result of each mapping as it is added, and that is what is used during serialization.
+/// If the original <see cref="DerivedTypeMapping"/> object mutates later, serialization will be unaffected.
+/// </remarks>
+[CollectionBuilder(typeof(DerivedTypeMappingCollection), nameof(Create))]
+public class DerivedTypeMappingCollection : IReadOnlyCollection<DerivedTypeMapping>
+{
+	private readonly ImmutableArray<DerivedTypeMapping> derivedTypeMappings = [];
+
+	private DerivedTypeMappingCollection(FrozenDictionary<Type, FrozenDictionary<DerivedTypeIdentifier, ITypeShape>> map, ImmutableArray<DerivedTypeMapping> mappings)
+	{
+		this.Map = map;
+	}
+
+	/// <inheritdoc/>
+	public int Count => this.Map.Count;
+
+	private FrozenDictionary<Type, FrozenDictionary<DerivedTypeIdentifier, ITypeShape>> Map { get; }
+
+	/// <summary>
+	/// Constructs a new <see cref="DerivedTypeMappingCollection"/> from a collection of <see cref="DerivedTypeMapping{TBase}"/> objects.
+	/// </summary>
+	/// <param name="derivedTypeMappings">The mappings to fill the collection with.</param>
+	/// <returns>A new instance of <see cref="DerivedTypeMappingCollection"/>.</returns>
+	public static DerivedTypeMappingCollection Create(ReadOnlySpan<DerivedTypeMapping> derivedTypeMappings)
+	{
+		Dictionary<Type, FrozenDictionary<DerivedTypeIdentifier, ITypeShape>> map = [];
+
+		foreach (DerivedTypeMapping mapping in derivedTypeMappings)
+		{
+			map.Add(mapping.BaseType, mapping.CreateDerivedTypesMapping());
+		}
+
+		return new(map.ToFrozenDictionary(), derivedTypeMappings.ToImmutableArray());
+	}
+
+	/// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
+	public ImmutableArray<DerivedTypeMapping>.Enumerator GetEnumerator() => this.derivedTypeMappings.GetEnumerator();
+
+	/// <inheritdoc/>
+	IEnumerator<DerivedTypeMapping> IEnumerable<DerivedTypeMapping>.GetEnumerator() => ((IReadOnlyList<DerivedTypeMapping>)this.derivedTypeMappings).GetEnumerator();
+
+	/// <inheritdoc/>
+	IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<DerivedTypeMapping>)this).GetEnumerator();
+
+	/// <summary>
+	/// Tries to retrieve a derived type mapping for a given base type.
+	/// </summary>
+	/// <param name="baseType">The base type.</param>
+	/// <param name="derivedTypes">Receives the mapping, if available.</param>
+	/// <returns>A value indicating whether a mapping was found.</returns>
+	internal bool TryGetDerivedTypeMapping(Type baseType, [NotNullWhen(true)] out FrozenDictionary<DerivedTypeIdentifier, ITypeShape>? derivedTypes) => this.Map.TryGetValue(baseType, out derivedTypes);
+}

--- a/src/Nerdbank.MessagePack/DerivedTypeMapping`1.cs
+++ b/src/Nerdbank.MessagePack/DerivedTypeMapping`1.cs
@@ -10,10 +10,13 @@ namespace Nerdbank.MessagePack;
 /// Describes a mapping between a base type and its known sub-types, along with the aliases that identify them.
 /// </summary>
 /// <typeparam name="TBase">The base type or interface that all sub-types derive from or implement.</typeparam>
-public class DerivedTypeMapping<TBase> : IDerivedTypeMapping
+public class DerivedTypeMapping<TBase> : DerivedTypeMapping
 {
 	private readonly Dictionary<DerivedTypeIdentifier, ITypeShape> map = new();
 	private readonly HashSet<Type> addedTypes = new();
+
+	/// <inheritdoc/>
+	internal override Type BaseType => typeof(TBase);
 
 	/// <summary>
 	/// Adds a known sub-type to the mapping.
@@ -112,5 +115,5 @@ public class DerivedTypeMapping<TBase> : IDerivedTypeMapping
 #endif
 
 	/// <inheritdoc />
-	FrozenDictionary<DerivedTypeIdentifier, ITypeShape> IDerivedTypeMapping.CreateDerivedTypesMapping() => this.map.ToFrozenDictionary();
+	internal override FrozenDictionary<DerivedTypeIdentifier, ITypeShape> CreateDerivedTypesMapping() => this.map.ToFrozenDictionary();
 }

--- a/src/Nerdbank.MessagePack/MessagePackConverter.cs
+++ b/src/Nerdbank.MessagePack/MessagePackConverter.cs
@@ -22,6 +22,11 @@ public abstract class MessagePackConverter
 	public abstract bool PreferAsyncSerialization { get; }
 
 	/// <summary>
+	/// Gets the data type that this converter can serialize and deserialize.
+	/// </summary>
+	internal abstract Type DataType { get; }
+
+	/// <summary>
 	/// Serializes an instance of an object.
 	/// </summary>
 	/// <param name="writer">The writer to use.</param>

--- a/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
+++ b/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
@@ -35,6 +35,9 @@ public abstract class MessagePackConverter<T> : MessagePackConverter, IMessagePa
 	/// <inheritdoc />
 	public override bool PreferAsyncSerialization => false;
 
+	/// <inheritdoc />
+	internal override Type DataType => typeof(T);
+
 	/// <summary>
 	/// Serializes an instance of <typeparamref name="T"/>.
 	/// </summary>

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.GetSchema.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.GetSchema.cs
@@ -55,7 +55,7 @@ public partial record MessagePackSerializer
 			throw new NotSupportedException($"Schema generation is not supported when {nameof(this.PreserveReferences)} is enabled.");
 		}
 
-		return new JsonSchemaGenerator(this.converterCache).GenerateSchema(typeShape);
+		return new JsonSchemaGenerator(this.ConverterCache).GenerateSchema(typeShape);
 	}
 
 	private sealed class JsonSchemaGenerator : ITypeShapeFunc

--- a/test/Nerdbank.MessagePack.Tests/CustomConverterFactoryTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/CustomConverterFactoryTests.cs
@@ -14,7 +14,7 @@ public partial class CustomConverterFactoryTests(ITestOutputHelper logger) : Mes
 	[Fact]
 	public void CustomUnionSerializer()
 	{
-		this.Serializer.RegisterConverterFactory(new CustomUnionConverterFactory());
+		this.Serializer = this.Serializer with { ConverterFactories = [new CustomUnionConverterFactory()] };
 
 		A? a = this.Roundtrip(new A());
 		Assert.NotNull(a);
@@ -32,7 +32,7 @@ public partial class CustomConverterFactoryTests(ITestOutputHelper logger) : Mes
 	[Fact]
 	public void MarshaledInterfaceSerializer()
 	{
-		this.Serializer.RegisterConverterFactory(new MarshaledObjectConverterFactory());
+		this.Serializer = this.Serializer with { ConverterFactories = [new MarshaledObjectConverterFactory()] };
 
 		MarshaledObject obj = new();
 		IMarshaledInterface? proxy = this.Roundtrip<IMarshaledInterface>(obj);
@@ -43,8 +43,11 @@ public partial class CustomConverterFactoryTests(ITestOutputHelper logger) : Mes
 	[Trait("ReferencePreservation", "true")]
 	public void FactoryWithReferencePreservation()
 	{
-		this.Serializer = this.Serializer with { PreserveReferences = ReferencePreservationMode.RejectCycles };
-		this.Serializer.RegisterConverterFactory(new CustomUnionConverterFactory());
+		this.Serializer = this.Serializer with
+		{
+			PreserveReferences = ReferencePreservationMode.RejectCycles,
+			ConverterFactories = [new CustomUnionConverterFactory()],
+		};
 
 		A a = new A();
 		A[] array = [a, a];

--- a/test/Nerdbank.MessagePack.Tests/CustomConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/CustomConverterTests.cs
@@ -26,7 +26,7 @@ public partial class CustomConverterTests(ITestOutputHelper logger) : MessagePac
 
 		// Registering a converter after serialization is allowed (but will reset the converter cache).
 		TreeConverter treeConverter = new();
-		this.Serializer.RegisterConverter(treeConverter);
+		this.Serializer = this.Serializer with { Converters = [treeConverter] };
 
 		// Verify that the converter was used.
 		this.AssertRoundtrip(new Tree(3));
@@ -36,14 +36,14 @@ public partial class CustomConverterTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void UseNonGenericSubConverters_ShapeProvider()
 	{
-		this.Serializer.RegisterConverter(new CustomTypeConverterNonGenericTypeShapeProvider());
+		this.Serializer = this.Serializer with { Converters = [new CustomTypeConverterNonGenericTypeShapeProvider()] };
 		this.AssertRoundtrip(new CustomType { InternalProperty = "Hello, World!" });
 	}
 
 	[Fact]
 	public void UseNonGenericSubConverters_Shape()
 	{
-		this.Serializer.RegisterConverter(new CustomTypeConverterNonGenericTypeShape());
+		this.Serializer = this.Serializer with { Converters = [new CustomTypeConverterNonGenericTypeShape()] };
 		this.AssertRoundtrip(new CustomType { InternalProperty = "Hello, World!" });
 	}
 
@@ -76,7 +76,7 @@ public partial class CustomConverterTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void GenericDataAndGenericConverterByClosedGenericRuntimeRegistration()
 	{
-		this.Serializer.RegisterConverter(new GenericDataConverter2<string>());
+		this.Serializer = this.Serializer with { Converters = [new GenericDataConverter2<string>()] };
 		GenericData<string>? deserialized = this.Roundtrip<GenericData<string>, Witness>(new GenericData<string> { Value = "Hello, World!" });
 		Assert.Equal("Hello, World!22", deserialized?.Value);
 	}
@@ -84,7 +84,7 @@ public partial class CustomConverterTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void GenericDataAndGenericConverterByOpenGenericRuntimeRegistration()
 	{
-		this.Serializer.RegisterConverter(typeof(GenericDataConverter2<>));
+		this.Serializer = this.Serializer with { ConverterTypes = [typeof(GenericDataConverter2<>)] };
 		GenericData<string>? deserialized = this.Roundtrip<GenericData<string>, Witness>(new GenericData<string> { Value = "Hello, World!" });
 		Assert.Equal("Hello, World!22", deserialized?.Value);
 	}
@@ -92,7 +92,7 @@ public partial class CustomConverterTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void GenericDataAndNonGenericConverterByRuntimeRegistration()
 	{
-		this.Serializer.RegisterConverter(typeof(GenericDataConverterNonGeneric));
+		this.Serializer = this.Serializer with { ConverterTypes = [typeof(GenericDataConverterNonGeneric)] };
 		GenericData<string>? deserialized = this.Roundtrip<GenericData<string>, Witness>(new GenericData<string> { Value = "Hello, World!" });
 		Assert.Equal("Hello, World!44", deserialized?.Value);
 
@@ -104,7 +104,7 @@ public partial class CustomConverterTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void NonGenericRuntimeRegistrationOfConverterByType()
 	{
-		this.Serializer.RegisterConverter(typeof(TreeConverterPlus2));
+		this.Serializer = this.Serializer with { ConverterTypes = [typeof(TreeConverterPlus2)] };
 		Tree? deserialized = this.Roundtrip(new Tree(3));
 		Assert.Equal(5, deserialized?.FruitCount);
 	}
@@ -112,7 +112,7 @@ public partial class CustomConverterTests(ITestOutputHelper logger) : MessagePac
 	[Fact]
 	public void GenericDataAndGenericConverterByOpenGenericRuntimeRegistration_NotAssociated()
 	{
-		this.Serializer.RegisterConverter(typeof(GenericDataConverter3<>));
+		this.Serializer = this.Serializer with { ConverterTypes = [typeof(GenericDataConverter3<>)] };
 		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Serialize<GenericData<string>, Witness>(new GenericData<string> { Value = "Hello, World!" }, TestContext.Current.CancellationToken));
 		this.Logger.WriteLine(ex.Message);
 	}

--- a/test/Nerdbank.MessagePack.Tests/DerivedTypeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/DerivedTypeTests.cs
@@ -39,7 +39,7 @@ public partial class DerivedTypeTests(ITestOutputHelper logger) : MessagePackSer
 	{
 		DerivedTypeMapping<BaseClass> mapping = new();
 		mapping.Add<BaseClass>(3, Witness.ShapeProvider);
-		this.Serializer.RegisterDerivedTypes(mapping);
+		this.Serializer = this.Serializer with { DerivedTypeMappings = [mapping] };
 
 		BaseClass? result = this.Roundtrip(new BaseClass());
 
@@ -156,7 +156,7 @@ public partial class DerivedTypeTests(ITestOutputHelper logger) : MessagePackSer
 			mapping.Add<DerivedA>(1, Witness.ShapeProvider);
 			mapping.Add<DerivedAA>(2, Witness.ShapeProvider);
 			mapping.Add<DerivedB>(3, Witness.ShapeProvider);
-			this.Serializer.RegisterDerivedTypes(mapping);
+			this.Serializer = this.Serializer with { DerivedTypeMappings = [mapping] };
 		}
 
 		Assert.IsType<DerivedA>(this.Roundtrip<BaseClass>(new DerivedAUnknown()));
@@ -211,7 +211,7 @@ public partial class DerivedTypeTests(ITestOutputHelper logger) : MessagePackSer
 		mapping.Add<DynamicallyRegisteredDerivedA>(1, Witness.ShapeProvider);
 		mapping.Add<DynamicallyRegisteredDerivedB>(2, Witness.ShapeProvider);
 #endif
-		this.Serializer.RegisterDerivedTypes(mapping);
+		this.Serializer = this.Serializer with { DerivedTypeMappings = [mapping] };
 
 		this.AssertRoundtrip<DynamicallyRegisteredBase>(new DynamicallyRegisteredBase());
 		this.AssertRoundtrip<DynamicallyRegisteredBase>(new DynamicallyRegisteredDerivedA());
@@ -229,7 +229,7 @@ public partial class DerivedTypeTests(ITestOutputHelper logger) : MessagePackSer
 		mapping.Add<DynamicallyRegisteredDerivedA>("A", Witness.ShapeProvider);
 		mapping.Add<DynamicallyRegisteredDerivedB>("B", Witness.ShapeProvider);
 #endif
-		this.Serializer.RegisterDerivedTypes(mapping);
+		this.Serializer = this.Serializer with { DerivedTypeMappings = [mapping] };
 
 		this.AssertRoundtrip<DynamicallyRegisteredBase>(new DynamicallyRegisteredBase());
 		this.AssertRoundtrip<DynamicallyRegisteredBase>(new DynamicallyRegisteredDerivedA());
@@ -241,7 +241,7 @@ public partial class DerivedTypeTests(ITestOutputHelper logger) : MessagePackSer
 	{
 		DerivedTypeMapping<BaseClass> mapping = new();
 		mapping.Add<DerivedB>(1, Witness.ShapeProvider);
-		this.Serializer.RegisterDerivedTypes(mapping);
+		this.Serializer = this.Serializer with { DerivedTypeMappings = [mapping] };
 
 		// Verify that the base type has just one header.
 		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip<BaseClass>(new BaseClass { BaseClassProperty = 5 });
@@ -267,7 +267,7 @@ public partial class DerivedTypeTests(ITestOutputHelper logger) : MessagePackSer
 	public void RuntimeRegistration_EmptyMapping()
 	{
 		DerivedTypeMapping<DynamicallyRegisteredBase> mapping = new();
-		this.Serializer.RegisterDerivedTypes(mapping);
+		this.Serializer = this.Serializer with { DerivedTypeMappings = [mapping] };
 		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip(new DynamicallyRegisteredBase());
 		MessagePackReader reader = new(msgpack);
 		Assert.Equal(2, reader.ReadArrayHeader());

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
@@ -262,7 +262,7 @@ public partial class MessagePackSerializerTests(ITestOutputHelper logger) : Mess
 	[Fact]
 	public void CustomConverterVsBuiltIn_TopLevel()
 	{
-		this.Serializer.RegisterConverter(new CustomStringConverter());
+		this.Serializer = this.Serializer with { Converters = [new CustomStringConverter()] };
 		byte[] msgpack = this.Serializer.Serialize<string, Witness>("Hello", TestContext.Current.CancellationToken);
 		this.LogMsgPack(new(msgpack));
 		Assert.Equal("HelloWR", this.Serializer.Deserialize<string, Witness>(msgpack, TestContext.Current.CancellationToken));
@@ -271,7 +271,7 @@ public partial class MessagePackSerializerTests(ITestOutputHelper logger) : Mess
 	[Fact]
 	public void CustomConverterVsBuiltIn_SubLevel()
 	{
-		this.Serializer.RegisterConverter(new CustomStringConverter());
+		this.Serializer = this.Serializer with { Converters = [new CustomStringConverter()] };
 		byte[] msgpack = this.Serializer.Serialize(new OtherPrimitiveTypes("Hello", false, 0, 0), TestContext.Current.CancellationToken);
 		this.LogMsgPack(new(msgpack));
 		Assert.Equal("HelloWR", this.Serializer.Deserialize<OtherPrimitiveTypes>(msgpack, TestContext.Current.CancellationToken)?.AString);

--- a/test/Nerdbank.MessagePack.Tests/ReferencePreservationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ReferencePreservationTests.cs
@@ -55,7 +55,7 @@ public partial class ReferencePreservationTests : MessagePackSerializerTestBase
 	[Fact]
 	public void CustomConverterByRegistrationSkippedByReferencePreservation()
 	{
-		this.Serializer.RegisterConverter(new CustomTypeConverter());
+		this.Serializer = this.Serializer with { Converters = [new CustomTypeConverter()] };
 		CustomType value = new() { Message = "test" };
 		CustomType[] array = [value, value];
 		CustomType[]? deserializedArray = this.Roundtrip<CustomType[], Witness>(array);
@@ -69,8 +69,11 @@ public partial class ReferencePreservationTests : MessagePackSerializerTestBase
 	[Fact]
 	public void CustomConverterByRegistrationSkippedByReferencePreservation_Reconfigured()
 	{
-		this.Serializer = this.Serializer with { PreserveReferences = ReferencePreservationMode.Off };
-		this.Serializer.RegisterConverter(new CustomTypeConverter());
+		this.Serializer = this.Serializer with
+		{
+			PreserveReferences = ReferencePreservationMode.Off,
+			Converters = [new CustomTypeConverter()],
+		};
 		this.Serializer = this.Serializer with { PreserveReferences = ReferencePreservationMode.RejectCycles };
 
 		CustomType value = new() { Message = "test" };
@@ -227,7 +230,7 @@ public partial class ReferencePreservationTests : MessagePackSerializerTestBase
 	{
 		DerivedTypeMapping<BaseRecord> mapping = new();
 		mapping.Add<DerivedRecordB>(1, Witness.ShapeProvider);
-		this.Serializer.RegisterDerivedTypes(mapping);
+		this.Serializer = this.Serializer with { DerivedTypeMappings = [mapping] };
 
 		BaseRecord baseInstance = new BaseRecord();
 		BaseRecord derivedInstance = new DerivedRecordB();

--- a/test/Nerdbank.MessagePack.Tests/SchemaTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/SchemaTests.cs
@@ -153,7 +153,7 @@ public partial class SchemaTests(ITestOutputHelper logger) : MessagePackSerializ
 	[Fact]
 	public void CustomConverterWithDocumentedSchema()
 	{
-		this.Serializer.RegisterConverter(new DocumentingCustomConverter());
+		this.Serializer = this.Serializer with { Converters = [new DocumentingCustomConverter()] };
 		this.AssertSchema([new CustomType(), null]);
 	}
 
@@ -167,9 +167,11 @@ public partial class SchemaTests(ITestOutputHelper logger) : MessagePackSerializ
 	[Fact]
 	public void ReferencePreservationGraphReset()
 	{
-		this.Serializer = this.Serializer with { PreserveReferences = ReferencePreservationMode.RejectCycles };
-		this.Serializer.RegisterConverter(new DocumentingCustomConverter());
-		this.Serializer.RegisterConverter(new NonDocumentingCustomConverter());
+		this.Serializer = this.Serializer with
+		{
+			PreserveReferences = ReferencePreservationMode.RejectCycles,
+			Converters = [new DocumentingCustomConverter(), new NonDocumentingCustomConverter()],
+		};
 		this.Serializer = this.Serializer with { PreserveReferences = ReferencePreservationMode.Off };
 		JsonObject schema = this.Serializer.GetJsonSchema<CustomType>();
 		string schemaString = schema.ToJsonString(new JsonSerializerOptions { WriteIndented = true });


### PR DESCRIPTION
This resolves the mix of thread-safe and non-thread-safe APIs that were previously on the class.