### PR TITLE
Add `DeserializeDynamic` method for typeless deserialization

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersion)" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="17.13.9" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />

--- a/docfx/docs/built-in-converters.md
+++ b/docfx/docs/built-in-converters.md
@@ -1,0 +1,57 @@
+# Built-in converters
+
+The following types have explicit support built into the library because they are primitives or complex.
+
+Most other types build on this list and will typically default to "Just Work" with this library without additional attributes.
+
+Although these types have built-in support, a [type shape](type-shapes.md) is always required for the top-level type being serialized.
+
+## Numbers
+
+- @System.Byte
+- @System.SByte
+- @System.UInt16
+- @System.Int16
+- @System.UInt32
+- @System.Int32
+- @System.UInt64
+- @System.Int64
+- @System.Half
+- @System.Single
+- @System.Double
+- @System.Decimal
+- @System.Int128
+- @System.UInt128
+- @System.Numerics.BigInteger
+
+## Text
+
+- @System.String
+- @System.Text.Rune
+- @System.Char
+
+## Time
+
+- @System.DateTime
+- @System.DateTimeOffset
+- @System.DateOnly
+- @System.TimeOnly
+- @System.TimeSpan
+
+## Complex types
+
+- @System.Text.Json.Nodes.JsonNode
+- @System.Text.Json.JsonElement
+- @System.Text.Json.JsonDocument
+
+## Other
+
+- @System.Boolean
+- @System.Nullable`1
+- @System.Drawing.Color
+- @System.Version
+- @System.Uri
+- @System.Guid
+- @Nerdbank.MessagePack.RawMessagePack
+
+Enums, arrays and various dictionary types that utilize these types are implicitly supported.

--- a/docfx/docs/built-in-converters.md
+++ b/docfx/docs/built-in-converters.md
@@ -43,6 +43,7 @@ Although these types have built-in support, a [type shape](type-shapes.md) is al
 - @System.Text.Json.Nodes.JsonNode
 - @System.Text.Json.JsonElement
 - @System.Text.Json.JsonDocument
+- @System.Dynamic.ExpandoObject
 
 ## Other
 

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -74,3 +74,23 @@ In particular the following limitations apply:
 The exact JSON emitted, especially for the msgpack-only tokens, is subject to change in future versions of this library.
 You should *not* write programs that are expected to parse the JSON produced by this diagnostic method.
 Use a JSON serialization library if you want interop-safe, machine-parseable JSON.
+
+## Deserialize to dynamic
+
+When you do not have types declared that resemble the msgpack schema you need to deserialize, you can use the @Nerdbank.MessagePack.MessagePackSerializer.DeserializeDynamic*?displayProperty=nameWithType method.
+
+[!code-csharp[](../../samples/cs/PrimitiveDeserialization.cs#DeserializePrimitives)]
+
+A built-in @System.Dynamic.ExpandoObject converter is included in the library as well.
+It will deserialize any msgpack structure into primitives and simple structures.
+Serializing an `ExpandoObject` requires that serialization start with a shape provider that can describe every runtime type in the object graph.
+
+# [.NET](#tab/net)
+
+[!code-csharp[](../../samples/cs/PrimitiveDeserialization.cs#DeserializeExpandoObjectNET)]
+
+# [.NET Standard](#tab/netfx)
+
+[!code-csharp[](../../samples/cs/PrimitiveDeserialization.cs#DeserializeExpandoObjectNETFX)]
+
+---

--- a/docfx/docs/migrating.md
+++ b/docfx/docs/migrating.md
@@ -19,6 +19,7 @@ Attributed data types     | [✅](customizing-serialization.md) | [✅](https://
 Polymorphic serialization | [✅](unions.md) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#union)[^4] |
 F# union type support     | [✅](fsharp.md) | ❌ |
 Typeless serialization    | ❌ | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#typeless) |
+`dynamic` serialization    | [✅](getting-started.md#deserialize-to-dynamic) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp/blob/master/doc/ExpandoObject.md)
 Skip serializing default values | [✅](xref:Nerdbank.MessagePack.MessagePackSerializer.SerializeDefaultValues) | [❌](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/678) |
 Dynamically use maps or arrays for most compact format | [✅](customizing-serialization.md#array-or-map) | [❌](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/1953) |
 Surrogate types for automatic serialization of unserializable types | [✅](surrogate-types.md) | ❌ |

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -11,6 +11,7 @@ items:
 - href: surrogate-types.md
 - name: Custom converters
   href: custom-converters.md
+- href: built-in-converters.md
 - name: Performance
   href: performance.md
 - name: Security

--- a/samples/cs/PrimitiveDeserialization.cs
+++ b/samples/cs/PrimitiveDeserialization.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace PrimitiveDeserialization
+{
+    internal partial class PrimitiveDeserialization
+    {
+        void DeserializeDynamic(MessagePackSerializer serializer, ref MessagePackReader reader)
+        {
+            #region DeserializePrimitives
+            dynamic? deserialized = serializer.DeserializeDynamic(ref reader);
+            string prop1 = deserialized!.Prop1;
+            int prop2 = deserialized.Prop2;
+            bool deeperBool = deserialized.deeper.IsAdult;
+            int age = deserialized.People[3].Age;
+
+            // Did we miss anything? Dump out all the keys and their values.
+            foreach (object key in deserialized)
+            {
+                Console.WriteLine($"{key}: {deserialized[key]}");
+            }
+            #endregion
+        }
+
+#if NET
+        partial class DeserializeExpandoObjectNET
+        {
+            #region DeserializeExpandoObjectNET
+            void DeserializeExpandoObject(MessagePackSerializer serializer, byte[] msgpack)
+            {
+                dynamic? deserialized = serializer.Deserialize<ExpandoObject, Witness>(msgpack);
+                string prop1 = deserialized!.Prop1;
+                int prop2 = deserialized.Prop2;
+                bool deeperBool = deserialized.deeper.IsAdult;
+                int age = deserialized.People[3].Age;
+
+                // Did we miss anything? Dump out all the keys and their values.
+                foreach (object key in deserialized)
+                {
+                    Console.WriteLine($"{key}: {deserialized[key]}");
+                }
+            }
+
+            [GenerateShape<ExpandoObject>]
+            partial class Witness;
+            #endregion
+        }
+#else
+        partial class DeserializeExpandoObjectNETFX
+        {
+            #region DeserializeExpandoObjectNETFX
+            void DeserializeExpandoObject(MessagePackSerializer serializer, byte[] msgpack)
+            {
+                dynamic? deserialized = serializer.Deserialize<ExpandoObject>(msgpack, Witness.ShapeProvider);
+                string prop1 = deserialized!.Prop1;
+                int prop2 = deserialized.Prop2;
+                bool deeperBool = deserialized.deeper.IsAdult;
+                int age = deserialized.People[3].Age;
+
+                // Did we miss anything? Dump out all the keys and their values.
+                foreach (object key in deserialized)
+                {
+                    Console.WriteLine($"{key}: {deserialized[key]}");
+                }
+            }
+
+            [GenerateShape<ExpandoObject>]
+            partial class Witness;
+            #endregion
+        }
+#endif
+    }
+}

--- a/samples/cs/Samples.csproj
+++ b/samples/cs/Samples.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Nerdbank.Streams" />
   </ItemGroup>
 

--- a/src/Nerdbank.MessagePack/Converters/ExpandoObjectConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/ExpandoObjectConverter.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+
+namespace Nerdbank.MessagePack.Converters;
+
+/// <summary>
+/// A converter for <see cref="ExpandoObject"/>.
+/// </summary>
+/// <remarks>
+/// This can <em>deserialize</em> anything, but can only <em>serialize</em> object graphs for which every runtime type
+/// has a shape available as provided by <see cref="SerializationContext.TypeShapeProvider"/>.
+/// </remarks>
+internal class ExpandoObjectConverter : MessagePackConverter<ExpandoObject>
+{
+	/// <inheritdoc/>
+	public override ExpandoObject? Read(ref MessagePackReader reader, SerializationContext context)
+	{
+		if (reader.TryReadNil())
+		{
+			return null;
+		}
+
+		ExpandoObject result = new();
+		int count = reader.ReadMapHeader();
+		if (count > 0)
+		{
+			MessagePackConverter<string> keyFormatter = context.GetConverter<string>(MsgPackPrimitivesWitness.ShapeProvider);
+			IDictionary<string, object?> dictionary = result;
+
+			context.DepthStep();
+			for (int i = 0; i < count; i++)
+			{
+				string? key = keyFormatter.Read(ref reader, context);
+				if (key is null)
+				{
+					throw new NotSupportedException("Null key in map.");
+				}
+
+				object? value = PrimitivesOnlyReader.Instance.Read(ref reader, context);
+				dictionary.Add(key, value);
+			}
+		}
+
+		return result;
+	}
+
+	/// <inheritdoc/>
+	public override void Write(ref MessagePackWriter writer, in ExpandoObject? value, SerializationContext context)
+	{
+		if (value is null)
+		{
+			writer.WriteNil();
+			return;
+		}
+
+		IDictionary<string, object?> dict = value;
+		MessagePackConverter<string> keyFormatter = context.GetConverter<string>(MsgPackPrimitivesWitness.ShapeProvider);
+
+		writer.WriteMapHeader(dict.Count);
+		foreach (KeyValuePair<string, object?> item in dict)
+		{
+			keyFormatter.Write(ref writer, item.Key, context);
+			if (item.Value is null)
+			{
+				writer.WriteNil();
+			}
+			else
+			{
+				context.GetConverter(item.Value.GetType(), null).WriteObject(ref writer, item.Value, context);
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public override JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape) => CreateUndocumentedSchema(this.GetType());
+}

--- a/src/Nerdbank.MessagePack/Converters/JsonDocumentConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/JsonDocumentConverter.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Nerdbank.MessagePack.Converters;
+
+/// <summary>
+/// A converter for the <see cref="JsonDocument"/> type.
+/// </summary>
+/// <remarks>
+/// This converter only writes these objects. It throws <see cref="NotSupportedException"/> when reading them.
+/// </remarks>
+[GenerateShape<JsonElement>]
+internal partial class JsonDocumentConverter : MessagePackConverter<JsonDocument>
+{
+	/// <inheritdoc/>
+	public override JsonDocument? Read(ref MessagePackReader reader, SerializationContext context)
+	{
+		if (reader.TryReadNil())
+		{
+			return null;
+		}
+
+		Sequence<byte> seq = new();
+		Utf8JsonWriter writer = new(seq);
+		JsonNode? node = context.GetConverter<JsonNode>(ShapeProvider).Read(ref reader, context);
+		if (node is null)
+		{
+			throw new NotSupportedException("Null value cannot be made into a JsonElement.");
+		}
+
+		node.WriteTo(writer);
+		writer.Flush();
+
+		return JsonDocument.Parse(seq);
+	}
+
+	/// <inheritdoc/>
+	public override void Write(ref MessagePackWriter writer, in JsonDocument? value, SerializationContext context)
+	{
+		if (value is null)
+		{
+			writer.WriteNil();
+			return;
+		}
+
+		context.GetConverter<JsonElement>(ShapeProvider).Write(ref writer, value.RootElement, context);
+	}
+
+	/// <inheritdoc/>
+	public override JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape) => null;
+}

--- a/src/Nerdbank.MessagePack/Converters/JsonElementConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/JsonElementConverter.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Nerdbank.MessagePack.Converters;
+
+/// <summary>
+/// A converter for the <see cref="JsonElement"/> type.
+/// </summary>
+/// <remarks>
+/// This converter only writes these objects. It throws <see cref="NotSupportedException"/> when reading them.
+/// </remarks>
+[GenerateShape<JsonNode>]
+internal partial class JsonElementConverter : MessagePackConverter<JsonElement>
+{
+	/// <inheritdoc/>
+	public override JsonElement Read(ref MessagePackReader reader, SerializationContext context)
+	{
+		Sequence<byte> seq = new();
+		Utf8JsonWriter writer = new(seq);
+		JsonNode? node = context.GetConverter<JsonNode>(ShapeProvider).Read(ref reader, context);
+		if (node is null)
+		{
+			throw new NotSupportedException("Null value cannot be made into a JsonElement.");
+		}
+
+		node.WriteTo(writer);
+		writer.Flush();
+
+		Utf8JsonReader utf8Reader = new(seq);
+		return JsonElement.ParseValue(ref utf8Reader);
+	}
+
+	/// <inheritdoc/>
+	public override void Write(ref MessagePackWriter writer, in JsonElement value, SerializationContext context)
+	{
+		switch (value.ValueKind)
+		{
+			case JsonValueKind.Object:
+				context.DepthStep();
+				int count = 0;
+				foreach (JsonProperty property in value.EnumerateObject())
+				{
+					count++;
+				}
+
+				writer.WriteMapHeader(count);
+				foreach (JsonProperty property in value.EnumerateObject())
+				{
+					writer.Write(property.Name);
+					this.Write(ref writer, property.Value, context);
+				}
+
+				break;
+			case JsonValueKind.Array:
+				context.DepthStep();
+				writer.WriteArrayHeader(value.GetArrayLength());
+				foreach (JsonElement element in value.EnumerateArray())
+				{
+					this.Write(ref writer, element, context);
+				}
+
+				break;
+			case JsonValueKind.String:
+				writer.Write(value.GetString());
+				break;
+			case JsonValueKind.Number:
+				if (value.TryGetUInt64(out ulong unsigned))
+				{
+					writer.Write(unsigned);
+				}
+				else if (value.TryGetInt64(out long signed))
+				{
+					writer.Write(signed);
+				}
+				else if (value.TryGetDouble(out double floatingPoint))
+				{
+					writer.Write(floatingPoint);
+				}
+				else
+				{
+					throw new NotSupportedException("Unsupported number.");
+				}
+
+				break;
+			case JsonValueKind.True:
+				writer.Write(true);
+				break;
+			case JsonValueKind.False:
+				writer.Write(false);
+				break;
+			case JsonValueKind.Null:
+				writer.WriteNil();
+				break;
+			default:
+				throw new NotSupportedException($"Unsupported JSON value kind: {value.ValueKind}");
+		}
+	}
+
+	/// <inheritdoc/>
+	public override JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape) => null;
+}

--- a/src/Nerdbank.MessagePack/Converters/JsonNodeConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/JsonNodeConverter.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable NBMsgPack031 // Read exactly one value - analyzer is mis-firing.
+
+using System.Text.Json.Nodes;
+
+namespace Nerdbank.MessagePack.Converters;
+
+/// <summary>
+/// A converter for the <see cref="JsonNode"/> type.
+/// </summary>
+internal class JsonNodeConverter : MessagePackConverter<JsonNode>
+{
+	/// <inheritdoc/>
+	public override JsonNode? Read(ref MessagePackReader reader, SerializationContext context)
+	{
+		return reader.NextMessagePackType switch
+		{
+			MessagePackType.Integer => MessagePackCode.IsSignedInteger(reader.NextCode) ? JsonValue.Create(reader.ReadInt64()) : JsonValue.Create(reader.ReadUInt64()),
+			MessagePackType.Nil => JsonValue.Create((string?)null),
+			MessagePackType.Boolean => JsonValue.Create(reader.ReadBoolean()),
+			MessagePackType.Float => JsonValue.Create(reader.ReadDouble()),
+			MessagePackType.String => JsonValue.Create(reader.ReadString()),
+			MessagePackType.Binary => JsonValue.Create(Convert.ToBase64String(reader.ReadBytes()!.Value.ToArray())),
+			MessagePackType.Array => ReadArray(ref reader, context),
+			MessagePackType.Map => ReadMap(ref reader, context),
+			MessagePackType.Extension => throw new NotSupportedException("msgpack extensions cannot be represented in JSON."),
+			_ => throw new NotSupportedException("Unsupported msgpack token."),
+		};
+
+		JsonNode ReadArray(ref MessagePackReader reader, SerializationContext context)
+		{
+			context.DepthStep();
+			JsonNode?[] array = new JsonNode[reader.ReadArrayHeader()];
+			for (int i = 0; i < array.Length; i++)
+			{
+				array[i] = this.Read(ref reader, context);
+			}
+
+			return new JsonArray(array);
+		}
+
+		JsonNode ReadMap(ref MessagePackReader reader, SerializationContext context)
+		{
+			context.DepthStep();
+			JsonObject obj = new();
+			int count = reader.ReadMapHeader();
+			for (int i = 0; i < count; i++)
+			{
+				string key = reader.ReadString() ?? throw new NotSupportedException("Map keys must be strings.");
+				obj[key] = this.Read(ref reader, context);
+			}
+
+			return obj;
+		}
+	}
+
+	/// <inheritdoc/>
+	public override void Write(ref MessagePackWriter writer, in JsonNode? value, SerializationContext context)
+	{
+		if (value is null)
+		{
+			writer.WriteNil();
+			return;
+		}
+
+		switch (value.GetValueKind())
+		{
+			case System.Text.Json.JsonValueKind.Object:
+				context.DepthStep();
+				JsonObject obj = value.AsObject();
+				writer.WriteMapHeader(obj.Count);
+				foreach (KeyValuePair<string, JsonNode?> item in obj)
+				{
+					writer.Write(item.Key);
+					this.Write(ref writer, item.Value, context);
+				}
+
+				break;
+			case System.Text.Json.JsonValueKind.Array:
+				context.DepthStep();
+				JsonArray arr = value.AsArray();
+				writer.WriteArrayHeader(arr.Count);
+				foreach (JsonNode? item in arr)
+				{
+					this.Write(ref writer, item, context);
+				}
+
+				break;
+			case System.Text.Json.JsonValueKind.String:
+				writer.Write(value.GetValue<string>());
+				break;
+			case System.Text.Json.JsonValueKind.Number:
+				if (value.AsValue().TryGetValue<ulong>(out ulong unsigned))
+				{
+					writer.Write(unsigned);
+				}
+				else
+				{
+					writer.Write(value.GetValue<long>());
+				}
+
+				break;
+			case System.Text.Json.JsonValueKind.True:
+				writer.Write(true);
+				break;
+			case System.Text.Json.JsonValueKind.False:
+				writer.Write(false);
+				break;
+			case System.Text.Json.JsonValueKind.Null:
+				writer.WriteNil();
+				break;
+			default:
+				throw new NotSupportedException($"Unrecognized JSON node kind {value.GetValueKind()}.");
+		}
+	}
+
+	/// <inheritdoc/>
+	public override JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape) => null;
+}

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.cs
@@ -57,6 +57,8 @@ internal static class PrimitiveConverterLookup
 	private static IMessagePackConverterInternal? _JsonElementConverter;
 	private static IMessagePackConverterInternal? _JsonDocumentConverter;
 	private static IMessagePackConverterInternal? _JsonDocumentConverterReferencePreserving;
+	private static IMessagePackConverterInternal? _ExpandoObjectConverter;
+	private static IMessagePackConverterInternal? _ExpandoObjectConverterReferencePreserving;
 #if NET
 	private static IMessagePackConverterInternal? _RuneConverter;
 	private static IMessagePackConverterInternal? _Int128Converter;
@@ -286,6 +288,20 @@ internal static class PrimitiveConverterLookup
 			else
 			{
 				converter = (MessagePackConverter<T>)(_JsonDocumentConverter ??= new JsonDocumentConverter());
+			}
+
+			return true;
+		}
+
+		if (typeof(T) == typeof(System.Dynamic.ExpandoObject))
+		{
+			if (referencePreserving != ReferencePreservationMode.Off)
+			{
+				converter = (MessagePackConverter<T>)(_ExpandoObjectConverterReferencePreserving ??= new ExpandoObjectConverter().WrapWithReferencePreservation());
+			}
+			else
+			{
+				converter = (MessagePackConverter<T>)(_ExpandoObjectConverter ??= new ExpandoObjectConverter());
 			}
 
 			return true;

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.cs
@@ -52,6 +52,11 @@ internal static class PrimitiveConverterLookup
 	private static IMessagePackConverterInternal? _UriConverterReferencePreserving;
 	private static IMessagePackConverterInternal? _ByteArrayConverter;
 	private static IMessagePackConverterInternal? _ByteArrayConverterReferencePreserving;
+	private static IMessagePackConverterInternal? _JsonNodeConverter;
+	private static IMessagePackConverterInternal? _JsonNodeConverterReferencePreserving;
+	private static IMessagePackConverterInternal? _JsonElementConverter;
+	private static IMessagePackConverterInternal? _JsonDocumentConverter;
+	private static IMessagePackConverterInternal? _JsonDocumentConverterReferencePreserving;
 #if NET
 	private static IMessagePackConverterInternal? _RuneConverter;
 	private static IMessagePackConverterInternal? _Int128Converter;
@@ -247,6 +252,40 @@ internal static class PrimitiveConverterLookup
 			else
 			{
 				converter = (MessagePackConverter<T>)(_ByteArrayConverter ??= new ByteArrayConverter());
+			}
+
+			return true;
+		}
+
+		if (typeof(T) == typeof(System.Text.Json.Nodes.JsonNode))
+		{
+			if (referencePreserving != ReferencePreservationMode.Off)
+			{
+				converter = (MessagePackConverter<T>)(_JsonNodeConverterReferencePreserving ??= new JsonNodeConverter().WrapWithReferencePreservation());
+			}
+			else
+			{
+				converter = (MessagePackConverter<T>)(_JsonNodeConverter ??= new JsonNodeConverter());
+			}
+
+			return true;
+		}
+
+		if (typeof(T) == typeof(System.Text.Json.JsonElement))
+		{
+			converter = (MessagePackConverter<T>)(_JsonElementConverter ??= new JsonElementConverter());
+			return true;
+		}
+
+		if (typeof(T) == typeof(System.Text.Json.JsonDocument))
+		{
+			if (referencePreserving != ReferencePreservationMode.Off)
+			{
+				converter = (MessagePackConverter<T>)(_JsonDocumentConverterReferencePreserving ??= new JsonDocumentConverter().WrapWithReferencePreservation());
+			}
+			else
+			{
+				converter = (MessagePackConverter<T>)(_JsonDocumentConverter ??= new JsonDocumentConverter());
 			}
 
 			return true;

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.tt
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.tt
@@ -51,6 +51,7 @@ var convertersByType = new List<ConverterInfo>
     new ConverterInfo("System.Text.Json.Nodes.JsonNode", "JsonNodeConverter", IsRefType: true),
     new ConverterInfo("System.Text.Json.JsonElement", "JsonElementConverter"),
     new ConverterInfo("System.Text.Json.JsonDocument", "JsonDocumentConverter", IsRefType: true),
+    new ConverterInfo("System.Dynamic.ExpandoObject", "ExpandoObjectConverter", IsRefType: true),
 };
 #>
 /// <summary>

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.tt
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.tt
@@ -48,6 +48,9 @@ var convertersByType = new List<ConverterInfo>
 	new ConverterInfo("Version", "VersionConverter", IsRefType: true),
 	new ConverterInfo("Uri", "UriConverter", IsRefType: true),
 	new ConverterInfo("byte[]", "ByteArrayConverter", IsRefType: true),
+    new ConverterInfo("System.Text.Json.Nodes.JsonNode", "JsonNodeConverter", IsRefType: true),
+    new ConverterInfo("System.Text.Json.JsonElement", "JsonElementConverter"),
+    new ConverterInfo("System.Text.Json.JsonDocument", "JsonDocumentConverter", IsRefType: true),
 };
 #>
 /// <summary>

--- a/src/Nerdbank.MessagePack/Converters/PrimitivesOnlyReader.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitivesOnlyReader.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable NBMsgPack031
+
+using System.Text.Json.Nodes;
+
+namespace Nerdbank.MessagePack.Converters;
+
+/// <summary>
+/// A read-only converter that reads everything into primitives, dictionaries and arrays.
+/// </summary>
+internal class PrimitivesOnlyReader : MessagePackConverter<object?>
+{
+	/// <summary>
+	/// Gets the default instance of the converter.
+	/// </summary>
+	internal static readonly PrimitivesOnlyReader Instance = new PrimitivesOnlyReader();
+
+	/// <summary>Reads any one msgpack structure.</summary>
+	/// <param name="reader">The msgpack reader.</param>
+	/// <param name="context">The serialization context.</param>
+	/// <returns>A <see langword="null"/>, <see cref="string"/>, <see cref="long" />, <see cref="ulong" />, <see cref="float"/>, <see cref="double"/>, <see cref="DateTime"/>, <see cref="IReadOnlyDictionary{TKey, TValue}"/> with <see cref="object"/> keys and values, an array of <see cref="object"/>s, or an <see cref="Extension"/>.</returns>
+	/// <exception cref="NotSupportedException">Thrown if a msgpack map includes a <see langword="null" /> key.</exception>
+	/// <remarks>
+	/// <para>
+	/// The resulting object is designed to work conveniently with the C# <c>dynamic</c> type.
+	/// </para>
+	/// <para>
+	/// Maps become dynamic objects whose members are named after the keys in the maps.
+	/// When maps do not use string keys, the values are still accessible by using the indexer on the object.
+	/// Attempts to access values with keys that do not exist on the original msgpack object result in throwing a <see cref="KeyNotFoundException"/>.
+	/// All members on maps are discoverable using <see langword="foreach" />, which enumerates the keys on the object.
+	/// Maps also implement <see cref="IReadOnlyDictionary{TKey, TValue}"/> with <see cref="object" /> keys and values.
+	/// </para>
+	/// <para>
+	/// Keep in mind when using integers that msgpack doesn't preserve integer length information.
+	/// This method deserializes all integers as <see cref="ulong"/> (or <see cref="long"/> if the value is negative).
+	/// Integer length stretching is automatically applied when using integers as keys in maps so that they can match.
+	/// </para>
+	/// <para>
+	/// All arrays are instances of <c>object?[]</c>.
+	/// </para>
+	/// <para>
+	/// Msgpack binary data is represented as a <c>byte[]</c> object.
+	/// </para>
+	/// <para>
+	/// Msgpack extensions are represented by <see cref="Extension"/> values.
+	/// </para>
+	/// </remarks>
+	public override object? Read(ref MessagePackReader reader, SerializationContext context)
+	{
+		return ReadOneObject(ref reader, context);
+
+		static object? ReadOneObject(ref MessagePackReader reader, SerializationContext context)
+			=> reader.NextMessagePackType switch
+			{
+				MessagePackType.Nil => reader.ReadNil(),
+				MessagePackType.Integer => MessagePackCode.IsSignedInteger(reader.NextCode) ? NonNonNegativeSignedInt(reader.ReadInt64()) : reader.ReadUInt64(),
+				MessagePackType.Boolean => reader.ReadBoolean(),
+				MessagePackType.Float => reader.NextCode == MessagePackCode.Float32 ? reader.ReadSingle() : (dynamic)reader.ReadDouble(),
+				MessagePackType.String => reader.ReadString(),
+				MessagePackType.Array => ReadArray(ref reader, context),
+				MessagePackType.Map => ReadMap(ref reader, context),
+				MessagePackType.Binary => reader.ReadBytes()!.Value.ToArray(),
+				MessagePackType.Extension when TryReadDateTime(ref reader, out DateTime? dateTime) => dateTime,
+				MessagePackType.Extension => reader.ReadExtension(),
+				_ => throw new NotImplementedException($"{reader.NextMessagePackType} not yet implemented."),
+			};
+
+		static object NonNonNegativeSignedInt(long value) => value < 0 ? value : (ulong)value;
+
+		static bool TryReadDateTime(ref MessagePackReader reader, out DateTime? dateTime)
+		{
+			MessagePackReader peekReader = reader;
+			ExtensionHeader header = peekReader.ReadExtensionHeader();
+			if (header.TypeCode != ReservedMessagePackExtensionTypeCode.DateTime)
+			{
+				dateTime = null;
+				return false;
+			}
+
+			dateTime = peekReader.ReadDateTime(header);
+			reader = peekReader;
+			return true;
+		}
+
+		static object?[] ReadArray(ref MessagePackReader reader, SerializationContext context)
+		{
+			context.DepthStep();
+			object?[] array = new object?[reader.ReadArrayHeader()];
+			for (int i = 0; i < array.Length; i++)
+			{
+				context.CancellationToken.ThrowIfCancellationRequested();
+				array[i] = ReadOneObject(ref reader, context);
+			}
+
+			return array;
+		}
+
+		static object? ReadMap(ref MessagePackReader reader, SerializationContext context)
+		{
+			context.DepthStep();
+			int count = reader.ReadMapHeader();
+			Dictionary<object, object?> map = new(count);
+			for (int i = 0; i < count; i++)
+			{
+				context.CancellationToken.ThrowIfCancellationRequested();
+				object? key = ReadOneObject(ref reader, context);
+				if (key is null)
+				{
+					throw new NotSupportedException("Null key in map cannot be represented in a .NET object graph.");
+				}
+
+				object? value = ReadOneObject(ref reader, context);
+				map[key] = value;
+			}
+
+			return new DynamicDictionary(map);
+		}
+	}
+
+	/// <inheritdoc />
+	/// <exception cref="NotSupportedException">Always thrown.</exception>
+	public override void Write(ref MessagePackWriter writer, in object? value, SerializationContext context) => throw new NotSupportedException();
+
+	/// <inheritdoc/>
+	public override JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape) => CreateUndocumentedSchema(this.GetType());
+}

--- a/src/Nerdbank.MessagePack/DynamicDictionary.cs
+++ b/src/Nerdbank.MessagePack/DynamicDictionary.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Dynamic;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// A schema-less dictionary deserialized from msgpack, optimized to work great with the C# <c>dynamic</c> keyword.
+/// </summary>
+/// <param name="underlying">The underlying dictionary.</param>
+internal class DynamicDictionary(IReadOnlyDictionary<object, object?> underlying) : DynamicObject, IReadOnlyDictionary<object, object?>, IEnumerable
+{
+	/// <inheritdoc/>
+	IEnumerable<object> IReadOnlyDictionary<object, object?>.Keys => underlying.Keys;
+
+	/// <inheritdoc/>
+	IEnumerable<object?> IReadOnlyDictionary<object, object?>.Values => underlying.Values;
+
+	/// <inheritdoc/>
+	int IReadOnlyCollection<KeyValuePair<object, object?>>.Count => underlying.Count;
+
+	/// <inheritdoc/>
+	object? IReadOnlyDictionary<object, object?>.this[object key] => underlying[StretchInteger(key)];
+
+	/// <inheritdoc/>
+	public override bool TryGetMember(GetMemberBinder binder, out object? result)
+	{
+		result = underlying[binder.Name];
+		return true;
+	}
+
+	/// <inheritdoc/>
+	public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object? result)
+	{
+		if (indexes.Length != 1)
+		{
+			result = null;
+			return false;
+		}
+
+		result = underlying[StretchInteger(indexes[0])];
+		return true;
+	}
+
+	/// <inheritdoc/>
+	public override IEnumerable<string> GetDynamicMemberNames() => underlying.Keys.OfType<string>();
+
+	/// <inheritdoc/>
+	public IEnumerator GetEnumerator() => underlying.Keys.GetEnumerator();
+
+	/// <inheritdoc/>
+	bool IReadOnlyDictionary<object, object?>.ContainsKey(object key) => underlying.ContainsKey(StretchInteger(key));
+
+	/// <inheritdoc/>
+	bool IReadOnlyDictionary<object, object?>.TryGetValue(object key, [MaybeNullWhen(false)] out object? value) => underlying.TryGetValue(StretchInteger(key), out value);
+
+	/// <inheritdoc/>
+	IEnumerator<KeyValuePair<object, object?>> IEnumerable<KeyValuePair<object, object?>>.GetEnumerator() => underlying.GetEnumerator();
+
+	private static object StretchInteger(object key)
+		=> key switch
+		{
+			sbyte v => v < 0 ? (long)v : (ulong)v,
+			short v => v < 0 ? (long)v : (ulong)v,
+			int v => v < 0 ? (long)v : (ulong)v,
+			byte v => (ulong)v,
+			ushort v => (ulong)v,
+			uint v => (ulong)v,
+			_ => key,
+		};
+}

--- a/src/Nerdbank.MessagePack/MessagePackReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackReader.cs
@@ -132,12 +132,15 @@ public ref partial struct MessagePackReader
 	/// <summary>
 	/// Reads a <see cref="MessagePackCode.Nil"/> value.
 	/// </summary>
-	public void ReadNil()
+	/// <returns>
+	/// Always a <see langword="null"/> value.
+	/// </returns>
+	public object? ReadNil()
 	{
 		switch (this.streamingReader.TryReadNil())
 		{
 			case MessagePackPrimitives.DecodeResult.Success:
-				return;
+				return null;
 			case MessagePackPrimitives.DecodeResult.TokenMismatch:
 				throw ThrowInvalidCode(this.NextCode);
 			default:

--- a/src/Nerdbank.MessagePack/MsgPackPrimitivesWitness.cs
+++ b/src/Nerdbank.MessagePack/MsgPackPrimitivesWitness.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// A shape provider for all msgpack primitive types.
+/// </summary>
+[GenerateShape<string>]
+[GenerateShape<sbyte>]
+[GenerateShape<byte>]
+[GenerateShape<short>]
+[GenerateShape<ushort>]
+[GenerateShape<uint>]
+[GenerateShape<int>]
+[GenerateShape<long>]
+[GenerateShape<ulong>]
+[GenerateShape<float>]
+[GenerateShape<double>]
+[GenerateShape<byte[]>]
+[GenerateShape<DateTime>]
+[GenerateShape<Extension>]
+internal partial class MsgPackPrimitivesWitness;

--- a/test/Nerdbank.MessagePack.Tests/Converters/ExpandoObjectConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/Converters/ExpandoObjectConverterTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Converters;
+
+[Trait("dynamic", "true")]
+public partial class ExpandoObjectConverterTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	[Fact]
+	public void SimplePropertyValues()
+	{
+		dynamic e = new ExpandoObject();
+		e.a = 5;
+		e.b = "hi";
+		e.Nothing = null;
+
+		dynamic? e2 = this.Roundtrip<ExpandoObject, Witness>(e);
+		Assert.Equal(5, (int)e2!.a);
+		Assert.Equal("hi", (string?)e2.b);
+		Assert.Null(e2!.Nothing);
+	}
+
+	[Fact]
+	public void Depth()
+	{
+		dynamic e = new ExpandoObject();
+		e.a = new byte[] { 1, 2 };
+		e.b = new ExpandoObject();
+		e.b.c = "bah";
+
+		dynamic? e2 = this.Roundtrip<ExpandoObject, Witness>(e);
+		Assert.Equal<byte>([1, 2], (byte[])e2.a);
+		Assert.Equal("bah", e2.b.c);
+	}
+
+	[Fact]
+	public void Null()
+	{
+		Assert.Null(this.Roundtrip<ExpandoObject, Witness>(null));
+	}
+
+	[GenerateShape<int>]
+	[GenerateShape<ExpandoObject>]
+	private partial class Witness;
+}

--- a/test/Nerdbank.MessagePack.Tests/Converters/JsonDocumentConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/Converters/JsonDocumentConverterTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Converters;
+
+public partial class JsonDocumentConverterTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	private const string Json = """
+		{"a":1,"b":[2,3],"c":{"d":"e"},"f":null}
+		""";
+
+	[Fact]
+	public void RoundtripDOM()
+	{
+		JsonDocument el = JsonDocument.Parse(Json);
+		JsonDocument? deserialized = this.Roundtrip<JsonDocument, Witness>(el);
+		Assert.NotNull(deserialized);
+		JsonElement root = deserialized.RootElement;
+		Assert.True(root.TryGetProperty("a", out JsonElement a));
+		Assert.Equal(1ul, a.GetUInt64());
+
+		Assert.True(root.TryGetProperty("b", out JsonElement b));
+		Assert.Equal(2, b.GetArrayLength());
+
+		Assert.True(root.TryGetProperty("c", out JsonElement c));
+		Assert.Equal("e", c.GetProperty("d").GetString());
+
+		Assert.Equal(JsonValueKind.Null, root.GetProperty("f").ValueKind);
+	}
+
+	[Fact]
+	public void Write()
+	{
+		JsonDocument el = JsonDocument.Parse(Json);
+		byte[] msgpack = this.Serializer.Serialize<JsonDocument, Witness>(el, TestContext.Current.CancellationToken);
+		this.LogMsgPack(msgpack);
+
+		string converted = MessagePackSerializer.ConvertToJson(msgpack);
+		Assert.Equal(Json, converted);
+	}
+
+	[GenerateShape<JsonDocument>]
+	private partial class Witness;
+}

--- a/test/Nerdbank.MessagePack.Tests/Converters/JsonElementConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/Converters/JsonElementConverterTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using System.Text.Json;
+
+namespace Converters;
+
+public partial class JsonElementConverterTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	private const string Json = """
+		{"a":1,"b":[2,3],"c":{"d":"e"},"f":null}
+		""";
+
+	private static readonly ReadOnlyMemory<byte> JsonUtf8 = Encoding.UTF8.GetBytes(Json);
+
+	[Fact]
+	public void RoundtripDOM()
+	{
+		Utf8JsonReader reader = new(JsonUtf8.Span);
+		JsonElement el = JsonElement.ParseValue(ref reader);
+		JsonElement deserialized = this.Roundtrip<JsonElement, Witness>(el);
+		Assert.True(deserialized.TryGetProperty("a", out JsonElement a));
+		Assert.Equal(1ul, a.GetUInt64());
+
+		Assert.True(deserialized.TryGetProperty("b", out JsonElement b));
+		Assert.Equal(2, b.GetArrayLength());
+
+		Assert.True(deserialized.TryGetProperty("c", out JsonElement c));
+		Assert.Equal("e", c.GetProperty("d").GetString());
+
+		Assert.Equal(JsonValueKind.Null, deserialized.GetProperty("f").ValueKind);
+	}
+
+	[Fact]
+	public void Write()
+	{
+		Utf8JsonReader reader = new(JsonUtf8.Span);
+		JsonElement el = JsonElement.ParseValue(ref reader);
+		byte[] msgpack = this.Serializer.Serialize<JsonElement, Witness>(el, TestContext.Current.CancellationToken);
+		this.LogMsgPack(msgpack);
+
+		string converted = MessagePackSerializer.ConvertToJson(msgpack);
+		Assert.Equal(Json, converted);
+	}
+
+	[GenerateShape<JsonElement>]
+	private partial class Witness;
+}

--- a/test/Nerdbank.MessagePack.Tests/Converters/JsonNodeConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/Converters/JsonNodeConverterTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Converters;
+
+public partial class JsonNodeConverterTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	[Fact]
+	public void Roundtrip_JsonNode()
+	{
+		JsonNode node = JsonNode.Parse("""
+			{"a":1,"b":[2,3],"c":{"d":"e"},"f":null}
+			""")!;
+		JsonNode? deserialized = this.Roundtrip<JsonNode, Witness>(node);
+		Assert.NotNull(deserialized);
+		Assert.Equal(1ul, deserialized["a"]?.GetValue<ulong>());
+		Assert.Equal(2ul, deserialized["b"]?[0]?.GetValue<ulong>());
+		Assert.Equal(3ul, deserialized["b"]?[1]?.GetValue<ulong>());
+		Assert.Equal("e", deserialized["c"]?["d"]?.GetValue<string>());
+		Assert.Null(deserialized["f"]);
+	}
+
+	[GenerateShape<JsonNode>]
+	private partial class Witness;
+}

--- a/test/Nerdbank.MessagePack.Tests/DynamicSerializationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/DynamicSerializationTests.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Dynamic;
+using Microsoft.CSharp.RuntimeBinder;
+
+[Trait("dynamic", "true")]
+public class DynamicSerializationTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+{
+	private static readonly DateTime ExpectedDateTime = new(2023, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+
+	[Fact]
+	public void PositiveIntKeyStretching()
+	{
+		dynamic deserialized = this.DeserializeDynamic();
+		Assert.IsType<byte[]>(deserialized[45]);
+		Assert.IsType<byte[]>(deserialized[45UL]);
+		Assert.IsType<byte[]>(deserialized[(byte)45]);
+		Assert.IsType<byte[]>(deserialized[(sbyte)45]);
+		Assert.IsType<byte[]>(deserialized[(short)45]);
+		Assert.IsType<byte[]>(deserialized[(ushort)45]);
+		Assert.IsType<byte[]>(deserialized[45u]);
+	}
+
+	[Fact]
+	public void NegativeIntKeyStretching()
+	{
+		dynamic deserialized = this.DeserializeDynamic();
+		Assert.IsType<bool>(deserialized[-45]);
+		Assert.IsType<bool>(deserialized[-45L]);
+		Assert.IsType<bool>(deserialized[(sbyte)-45]);
+		Assert.IsType<bool>(deserialized[(short)-45]);
+	}
+
+	[Fact]
+	public void SimpleValuesByMember()
+	{
+		dynamic deserialized = this.DeserializeDynamic();
+		Assert.NotNull(deserialized);
+		Assert.Equal("Value1", deserialized.Prop1);
+		Assert.Equal(42, (int)deserialized.Prop2);
+	}
+
+	[Fact]
+	public void SimpleValuesByIndex()
+	{
+		dynamic deserialized = this.DeserializeDynamic();
+		Assert.Equal(new byte[] { 1, 2, 3 }, deserialized[45]);
+		Assert.Throws<RuntimeBinderException>(() => deserialized[45, 1]);
+	}
+
+	[Fact]
+	public void GetDynamicMemberNames()
+	{
+		// C# doesn't offer a way to call this method like other languages would, so we'll call it directly.
+		DynamicObject deserialized = (DynamicObject)this.DeserializeDynamic();
+		Assert.Equal(["Prop1", "Prop2", "deeper"], deserialized.GetDynamicMemberNames());
+	}
+
+	[Fact]
+	public void ReachIntoArray()
+	{
+		dynamic deserialized = this.DeserializeDynamic();
+		Assert.Equal(4, deserialized.deeper.Length);
+		Assert.Equal(true, deserialized.deeper[0]);
+		Assert.Equal(3.5, deserialized.deeper[1]);
+		Assert.Equal(new Extension(15, new byte[] { 1, 2, 3 }), deserialized.deeper[2]);
+		Assert.Equal<DateTime>(ExpectedDateTime, deserialized.deeper[3]);
+	}
+
+	[Fact]
+	public void IReadOnlyDictionary()
+	{
+		dynamic deserialized = this.DeserializeDynamic();
+		IReadOnlyDictionary<object, object?> dict = (IReadOnlyDictionary<object, object?>)deserialized;
+
+		Assert.Equal(5, dict.Count);
+
+		Assert.True(dict.ContainsKey("deeper"));
+		Assert.IsType<object?[]>(dict["deeper"]);
+		Assert.True(dict.TryGetValue("deeper", out object? deeper));
+		Assert.IsType<object?[]>(deeper);
+
+		Assert.False(dict.ContainsKey("doesnotexist"));
+		Assert.Throws<KeyNotFoundException>(() => dict["doesnotexist"]);
+		Assert.False(dict.TryGetValue("doesnotexist", out _));
+
+		bool encounteredDeeper = false;
+		foreach (KeyValuePair<object, object?> item in dict)
+		{
+			encounteredDeeper |= item.Key is "deeper";
+		}
+
+		Assert.True(encounteredDeeper);
+
+		Assert.Equal(["Prop1", "Prop2", "deeper", 45UL, -45L], dict.Keys);
+		Assert.Equal(dict.Count, dict.Values.Count());
+	}
+
+	[Fact]
+	public void Enumerate()
+	{
+		dynamic deserialized = this.DeserializeDynamic();
+		foreach (object key in deserialized)
+		{
+			this.Logger.WriteLine($"{key} ({key.GetType().Name}) = {deserialized[key]}");
+		}
+
+		IEnumerator enumerator = ((IEnumerable)deserialized).GetEnumerator();
+		Assert.True(enumerator.MoveNext());
+		Assert.Equal("Prop1", enumerator.Current);
+		Assert.True(enumerator.MoveNext());
+		Assert.Equal("Prop2", enumerator.Current);
+		Assert.True(enumerator.MoveNext());
+		Assert.Equal("deeper", enumerator.Current);
+		Assert.True(enumerator.MoveNext());
+		Assert.Equal(45UL, enumerator.Current);
+		Assert.True(enumerator.MoveNext());
+		Assert.Equal(-45L, enumerator.Current);
+		Assert.False(enumerator.MoveNext());
+	}
+
+	[Fact]
+	public void MissingMembers()
+	{
+		dynamic deserialized = this.DeserializeDynamic();
+		Assert.Throws<KeyNotFoundException>(() => deserialized.nonexistent);
+		Assert.Throws<KeyNotFoundException>(() => deserialized[88]);
+	}
+
+	private dynamic DeserializeDynamic()
+	{
+		MessagePackReader reader = this.ConstructReader();
+		dynamic deserialized = this.Serializer.DeserializeDynamic(ref reader, TestContext.Current.CancellationToken)!;
+		return deserialized;
+	}
+
+	private MessagePackReader ConstructReader()
+	{
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.WriteMapHeader(5);
+		writer.Write("Prop1");
+		writer.Write("Value1");
+		writer.Write("Prop2");
+		writer.Write(42);
+		writer.Write("deeper");
+		writer.WriteArrayHeader(4);
+		writer.Write(true);
+		writer.Write(3.5);
+		writer.Write(new Extension(15, new byte[] { 1, 2, 3 }));
+		writer.Write(ExpectedDateTime);
+		writer.Write(45); // int key for stretching tests
+		writer.Write([1, 2, 3]);
+		writer.Write(-45); // negative int key for stretching tests
+		writer.Write(false);
+		writer.Flush();
+
+		this.Logger.WriteLine(MessagePackSerializer.ConvertToJson(seq));
+		return new MessagePackReader(seq);
+	}
+}

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
@@ -209,6 +209,8 @@ public abstract class MessagePackSerializerTestBase
 		}
 	}
 
+	protected void LogMsgPack(ReadOnlyMemory<byte> msgPack) => this.LogMsgPack(new ReadOnlySequence<byte>(msgPack));
+
 	protected void LogMsgPack(ReadOnlySequence<byte> msgPack)
 	{
 		this.logger.WriteLine(MessagePackSerializer.ConvertToJson(msgPack));

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Linq.Expressions;
 using Xunit.Sdk;
 
 public partial class MessagePackSerializerTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
@@ -264,7 +263,7 @@ public partial class MessagePackSerializerTests(ITestOutputHelper logger) : Mess
 	{
 		this.Serializer = this.Serializer with { Converters = [new CustomStringConverter()] };
 		byte[] msgpack = this.Serializer.Serialize<string, Witness>("Hello", TestContext.Current.CancellationToken);
-		this.LogMsgPack(new(msgpack));
+		this.LogMsgPack(msgpack);
 		Assert.Equal("HelloWR", this.Serializer.Deserialize<string, Witness>(msgpack, TestContext.Current.CancellationToken));
 	}
 
@@ -273,7 +272,7 @@ public partial class MessagePackSerializerTests(ITestOutputHelper logger) : Mess
 	{
 		this.Serializer = this.Serializer with { Converters = [new CustomStringConverter()] };
 		byte[] msgpack = this.Serializer.Serialize(new OtherPrimitiveTypes("Hello", false, 0, 0), TestContext.Current.CancellationToken);
-		this.LogMsgPack(new(msgpack));
+		this.LogMsgPack(msgpack);
 		Assert.Equal("HelloWR", this.Serializer.Deserialize<OtherPrimitiveTypes>(msgpack, TestContext.Current.CancellationToken)?.AString);
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/ReflectionShapeProviderTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ReflectionShapeProviderTests.cs
@@ -9,7 +9,7 @@ public class ReflectionShapeProviderTests(ITestOutputHelper logger) : MessagePac
 		Person person = new("Andrew", "Arnott");
 		ITypeShape<Person> shape = PolyType.ReflectionProvider.ReflectionTypeShapeProvider.Default.GetShape<Person>();
 		byte[] msgpack = this.Serializer.Serialize(person, shape, TestContext.Current.CancellationToken);
-		this.LogMsgPack(new(msgpack));
+		this.LogMsgPack(msgpack);
 		Person? deserialized = this.Serializer.Deserialize(msgpack, shape, TestContext.Current.CancellationToken);
 		Assert.Equal(person, deserialized);
 	}

--- a/test/Nerdbank.MessagePack.Tests/SharedTestCases.cs
+++ b/test/Nerdbank.MessagePack.Tests/SharedTestCases.cs
@@ -20,7 +20,7 @@ public class SharedTestCases(ITestOutputHelper logger) : MessagePackSerializerTe
 		{
 			ITypeShape<T> shape = testCase.DefaultShape;
 			byte[] msgpack = this.Serializer.Serialize(testCase.Value, shape, TestContext.Current.CancellationToken);
-			this.LogMsgPack(new(msgpack));
+			this.LogMsgPack(msgpack);
 
 			if (IsDeserializable(testCase))
 			{

--- a/test/Nerdbank.MessagePack.Tests/StreamingEnumerableTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StreamingEnumerableTests.cs
@@ -175,7 +175,7 @@ public partial class StreamingEnumerableTests(ITestOutputHelper logger) : Messag
 	{
 		SimpleStreamingContainerKeyed[] array = [new(), new()];
 		byte[] msgpack = this.Serializer.Serialize<SimpleStreamingContainerKeyed[], Witness>(array, TestContext.Current.CancellationToken);
-		this.LogMsgPack(new(msgpack));
+		this.LogMsgPack(msgpack);
 
 		PipeReader reader = PipeReader.Create(new(msgpack));
 		MessagePackSerializer.StreamingEnumerationOptions<SimpleStreamingContainerKeyed[], SimpleStreamingContainerKeyed> options = new(a => a);
@@ -195,7 +195,7 @@ public partial class StreamingEnumerableTests(ITestOutputHelper logger) : Messag
 		this.Serializer = this.Serializer with { PreserveReferences = ReferencePreservationMode.RejectCycles };
 		SimpleStreamingContainerKeyed original = new();
 		byte[] msgpack = this.Serializer.Serialize<SimpleStreamingContainerKeyed[], Witness>([original, original], TestContext.Current.CancellationToken);
-		this.LogMsgPack(new(msgpack));
+		this.LogMsgPack(msgpack);
 
 		PipeReader reader = PipeReader.Create(new(msgpack));
 		MessagePackSerializer.StreamingEnumerationOptions<SimpleStreamingContainerKeyed[], SimpleStreamingContainerKeyed> options = new(a => a);


### PR DESCRIPTION
Adds the following method to `MessagePackSerializer` for typeless deserialization:

```cs
public static dynamic? DeserializeDynamic(ref MessagePackReader reader)
```

This allows for javascript-like decoding:

```cs
dynamic deserialized = MessagePackSerializer.DeserializeDynamic(ref reader)!;
Assert.NotNull(deserialized);
Assert.Equal("Value1", deserialized.Prop1);
Assert.Equal(42, (int)deserialized.Prop2);
Assert.Equal(3, deserialized.deeper.Length);
Assert.Equal(true, deserialized.deeper[0]);
Assert.Equal(3.5, deserialized.deeper[1]);
Assert.Equal(new Extension(15, new byte[] { 1, 2, 3 }), deserialized.deeper[2]);
Assert.Equal(new byte[] { 1, 2, 3 }, deserialized[45UL]);
```

Closes #330