### PR TITLE
Offer the `ITypeShape<T>` to converter factories

### DIFF
--- a/samples/cs/CustomConverters.cs
+++ b/samples/cs/CustomConverters.cs
@@ -573,7 +573,7 @@ namespace CustomConverterFactory
 
     class MarshalingConverterFactory(object trackerKey) : IMessagePackConverterFactory
     {
-        public MessagePackConverter<T>? CreateConverter<T>()
+        public MessagePackConverter<T>? CreateConverter<T>(ITypeShape<T> shape)
         {
             if (typeof(T).GetCustomAttribute<MarshalByRefAttribute>() is not null)
             {

--- a/src/Nerdbank.MessagePack/ConverterCache.cs
+++ b/src/Nerdbank.MessagePack/ConverterCache.cs
@@ -164,7 +164,7 @@ internal class ConverterCache(SerializerConfiguration configuration)
 			{
 				foreach (IMessagePackConverterFactory factory in configuration.ConverterFactories)
 				{
-					if ((converter = factory.CreateConverter<T>()) is not null)
+					if ((converter = factory.CreateConverter<T>(typeShape)) is not null)
 					{
 						break;
 					}

--- a/src/Nerdbank.MessagePack/IMessagePackConverterFactory.cs
+++ b/src/Nerdbank.MessagePack/IMessagePackConverterFactory.cs
@@ -12,6 +12,7 @@ public interface IMessagePackConverterFactory
 	/// Creates a converter for the given type if this factory is capable of it.
 	/// </summary>
 	/// <typeparam name="T">The data type.</typeparam>
+	/// <param name="shape">The shape of the type to be serialized.</param>
 	/// <returns>The converter for the data type, or <see langword="null" />.</returns>
-	MessagePackConverter<T>? CreateConverter<T>();
+	MessagePackConverter<T>? CreateConverter<T>(ITypeShape<T> shape);
 }

--- a/test/Nerdbank.MessagePack.Tests/CustomConverterFactoryTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/CustomConverterFactoryTests.cs
@@ -83,7 +83,7 @@ public partial class CustomConverterFactoryTests(ITestOutputHelper logger) : Mes
 
 	internal class MarshaledObjectConverterFactory : IMessagePackConverterFactory
 	{
-		public MessagePackConverter<T>? CreateConverter<T>()
+		public MessagePackConverter<T>? CreateConverter<T>(ITypeShape<T> shape)
 		{
 			if (typeof(T).GetCustomAttribute<RpcMarshaledAttribute>() is null)
 			{
@@ -124,7 +124,7 @@ public partial class CustomConverterFactoryTests(ITestOutputHelper logger) : Mes
 
 	internal class CustomUnionConverterFactory : IMessagePackConverterFactory
 	{
-		public MessagePackConverter<T>? CreateConverter<T>()
+		public MessagePackConverter<T>? CreateConverter<T>(ITypeShape<T> shape)
 		{
 			if (typeof(A).IsAssignableFrom(typeof(T)))
 			{


### PR DESCRIPTION
This is important so that PolyType associated types can be retrieved from the shape.