### PR TITLE
Fix enumeration of `DerivedTypeMappingCollection`

### DIFF
--- a/src/Nerdbank.MessagePack/DerivedTypeMappingCollection.cs
+++ b/src/Nerdbank.MessagePack/DerivedTypeMappingCollection.cs
@@ -26,6 +26,7 @@ public class DerivedTypeMappingCollection : IReadOnlyCollection<DerivedTypeMappi
 	private DerivedTypeMappingCollection(FrozenDictionary<Type, FrozenDictionary<DerivedTypeIdentifier, ITypeShape>> map, ImmutableArray<DerivedTypeMapping> mappings)
 	{
 		this.Map = map;
+		this.derivedTypeMappings = mappings;
 	}
 
 	/// <inheritdoc/>

--- a/test/Nerdbank.MessagePack.Tests/DerivedTypeMappingTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/DerivedTypeMappingTests.cs
@@ -166,6 +166,19 @@ public partial class DerivedTypeMappingTests(ITestOutputHelper logger)
 		Assert.Equal(typeof(MyDerivedA), mapping["A"]);
 	}
 
+	[Fact]
+	[SuppressMessage("Assertions", "xUnit2013:Do not use equality check to check for collection size.", Justification = "The whole point of this test is to ensure that the Count property matches what the enumerator would produce.")]
+	public void EnumerateMappings()
+	{
+		MessagePackSerializer serializer = new();
+		Assert.Equal(0, serializer.DerivedTypeMappings.Count);
+		Assert.Equal(serializer.DerivedTypeMappings.Count, serializer.DerivedTypeMappings.Count());
+
+		serializer = serializer with { DerivedTypeMappings = [new DerivedTypeMapping<MyBase>(Witness.ShapeProvider) { [1] = typeof(MyDerivedA) }] };
+		Assert.Equal(1, serializer.DerivedTypeMappings.Count);
+		Assert.Equal(serializer.DerivedTypeMappings.Count, serializer.DerivedTypeMappings.Count());
+	}
+
 	[GenerateShape]
 	internal partial class MyBase;
 

--- a/test/Nerdbank.MessagePack.Tests/Usings.cs
+++ b/test/Nerdbank.MessagePack.Tests/Usings.cs
@@ -3,6 +3,7 @@
 
 global using System.Buffers;
 global using System.Collections.Immutable;
+global using System.Diagnostics.CodeAnalysis;
 global using System.IO.Pipelines;
 global using Nerdbank.MessagePack;
 global using Nerdbank.Streams;


### PR DESCRIPTION
This bug led to NRE being thrown from DerivedTypeMappingCollection when users use collection literals syntax that adds mappings to a non-empty mappings collection.

Fixes #361