### PR TITLE
Serialize tuples as arrays instead of maps

### DIFF
--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -127,7 +127,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			if (property.Accept(this, (matchingConstructorParameter, (IPropertyAssignmentTrackingManager)assignmentTrackingManager)) is PropertyAccessors<T> accessors)
 			{
 				KeyAttribute? keyAttribute = (KeyAttribute?)property.AttributeProvider?.GetCustomAttributes(typeof(KeyAttribute), false).FirstOrDefault();
-				if (keyAttribute is not null || this.owner.PerfOverSchemaStability)
+				if (keyAttribute is not null || this.owner.PerfOverSchemaStability || objectShape.IsTupleType)
 				{
 					propertyAccessors ??= new();
 					int index = keyAttribute?.Index ?? propertyIndex;

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
@@ -319,6 +319,22 @@ public partial class MessagePackSerializerTests(ITestOutputHelper logger) : Mess
 		this.AssertRoundtrip(new ClassWithIndexer { Member = 3 });
 	}
 
+	[Fact]
+	public void TupleSerializedAsArray()
+	{
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip<Tuple<int, bool>, Witness>(new(1, true));
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(2, reader.ReadArrayHeader());
+	}
+
+	[Fact]
+	public void ValueTupleSerializedAsArray()
+	{
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip<(int, bool), Witness>(new(1, true));
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(2, reader.ReadArrayHeader());
+	}
+
 	/// <summary>
 	/// Carefully writes a msgpack-encoded array of bytes.
 	/// </summary>
@@ -549,6 +565,8 @@ public partial class MessagePackSerializerTests(ITestOutputHelper logger) : Mess
 	[GenerateShape<byte[]>]
 	[GenerateShape<Memory<byte>>]
 	[GenerateShape<ReadOnlyMemory<byte>>]
+	[GenerateShape<Tuple<int, bool>>]
+	[GenerateShape<(int, bool)>]
 	internal partial class Witness;
 
 	private class CustomStringConverter : MessagePackConverter<string>


### PR DESCRIPTION
Instead of serializing a `Tuple<int, bool>` or `ValueTuple<int, bool>` as:

```json
{ "Item1": 42, "Item2": true }
```

They will serialize as simply:

```json
[42, true]
```