### PR TITLE
Add Native AOT validation and split out dynamic behavior

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-        - ubuntu-22.04
-        #- macos-14
-        - windows-2022
+        include:
+          - os: ubuntu-22.04
+            rid: linux-x64
+            aotSampleSize: 51.8
+          - os: macos-14
+            rid: osx-arm64
+            aotSampleSize: 46.3
+          - os: windows-2022
+            rid: win-x64
+            aotSampleSize: 36.1
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -49,9 +55,30 @@ jobs:
       run: tools/variables/_define.ps1
       shell: pwsh
     - name: 🛠 build
-      run: dotnet build -t:build,pack --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904 /bl:"${{ runner.temp }}/_artifacts/build_logs/build.binlog"
+      run: dotnet build tools/dirs.proj -t:build,pack,publish --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904 /bl:"${{ runner.temp }}/_artifacts/build_logs/build.binlog"
     - name: 🧪 test
       run: tools/dotnet-test-cloud.ps1 -Configuration ${{ env.BUILDCONFIGURATION }} -Agent ${{ runner.os }}
+      shell: pwsh
+    - name: 🏭 Verify NativeAOT image size
+      run: |
+        Function GetSizeInMB($Path) {
+          if (!($IsMacOS -or $IsLinux)) { $Path += '.exe' }
+          $FileName = Split-Path $Path -Leaf
+          (gci $Path).Length / 1024 / 1024
+        }
+
+        $Path = './bin/AotNativeConsole/${{ env.BUILDCONFIGURATION }}/net9.0/${{ matrix.rid }}/publish/AotNativeConsole'
+        $ActualSize = GetSizeInMB($Path)
+        Write-Host ("$FileName size: {0:0.0} MB" -f $ActualSize)
+
+        # Allow variance of a small threshold of the expected value.
+        # Fail even if it's smaller than anticipated so that the expected window can be shrunk in this file.
+        $ExpectedSize = ${{ matrix.aotSampleSize }}
+        $AllowedVariance = 3
+        if ([math]::Abs($ActualSize - $ExpectedSize) -gt $AllowedVariance) {
+          Write-Error ("NativeAOT image size {0:0.0} MB is outside the expected range of {1:0.0}±{2:0.0} MB." -f $ActualSize, $ExpectedSize, $AllowedVariance)
+          exit 1
+        }
       shell: pwsh
     - name: 💅🏻 Verify formatted code
       run: dotnet format --verify-no-changes --no-restore --exclude ./samples/AnalyzerDocs/NBMsgPack051.cs

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,6 +42,19 @@
     <LangVersion Condition="'$(MSBuildProjectExtension)'=='.vbproj'">16.9</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RidOsPrefix Condition="$([MSBuild]::IsOsPlatform('Windows'))">win</RidOsPrefix>
+    <RidOsPrefix Condition="$([MSBuild]::IsOsPlatform('Linux'))">linux</RidOsPrefix>
+    <RidOsPrefix Condition="$([MSBuild]::IsOsPlatform('OSX'))">osx</RidOsPrefix>
+
+    <RidOsArchitecture Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'x64'">x64</RidOsArchitecture>
+    <RidOsArchitecture Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'ARM64'">arm64</RidOsArchitecture>
+
+    <DefaultRuntimeIdentifier>$(RidOsPrefix)-$(RidOsArchitecture)</DefaultRuntimeIdentifier>
+    <!-- <AvailableRuntimeIdentifiers>$(RidOsPrefix)-arm64;$(RidOsPrefix)-x64</AvailableRuntimeIdentifiers> -->
+    <AvailableRuntimeIdentifiers>$(DefaultRuntimeIdentifier)</AvailableRuntimeIdentifiers>
+  </PropertyGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>

--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -14,4 +14,4 @@
 /m
 /verbosity:minimal
 /clp:Summary;ForceNoAlign
-/graph
+#/graph # MSBuild bug: https://github.com/dotnet/msbuild/issues/11922

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,4 +4,6 @@
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />
   </ItemGroup>
+
+  <Import Project="Directory.Traversal.targets" Condition="'$(IsTraversal)'=='true'" />
 </Project>

--- a/Directory.Traversal.targets
+++ b/Directory.Traversal.targets
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <PackInParallel>true</PackInParallel>
+
+    <TestX64Binaries>false</TestX64Binaries>
+    <TestArm64Binaries>false</TestArm64Binaries>
+    <TestX64Binaries Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'x64'">true</TestX64Binaries>
+    <TestArm64Binaries Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'ARM64'">true</TestArm64Binaries>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- <ProjectReference Include="@(MultiRIDProjectReference)" AdditionalProperties="RuntimeIdentifier=$(RidOsPrefix)-x64" Test="$(TestX64Binaries)" />
+    <ProjectReference Include="@(MultiRIDProjectReference)" AdditionalProperties="RuntimeIdentifier=$(RidOsPrefix)-arm64" Test="$(TestArm64Binaries)" /> -->
+    <ProjectReference Include="@(MultiRIDProjectReference)" AdditionalProperties="RuntimeIdentifier=$(DefaultRuntimeIdentifier)" Test="true" />
+  </ItemGroup>
+</Project>

--- a/Nerdbank.MessagePack.slnx
+++ b/Nerdbank.MessagePack.slnx
@@ -19,11 +19,13 @@
     <File Path="src/Analyzers.props" />
     <File Path="src/Directory.Build.props" />
     <File Path="src/Directory.Build.targets" />
+    <File Path="src/dirs.proj" />
   </Folder>
   <Folder Name="/Solution Items/test/">
     <File Path="test/.editorconfig" />
     <File Path="test/Directory.Build.props" />
     <File Path="test/Directory.Build.targets" />
+    <File Path="test/dirs.proj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Nerdbank.MessagePack.Analyzers.CodeFixes/Nerdbank.MessagePack.Analyzers.CodeFixes.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,7 +1,10 @@
 {
-  "sdk": {
-    "version": "9.0.300",
-    "rollForward": "patch",
-    "allowPrerelease": false
-  }
+	"sdk": {
+		"version": "9.0.300",
+		"rollForward": "patch",
+		"allowPrerelease": false
+	},
+	"msbuild-sdks": {
+		"Microsoft.Build.Traversal": "4.1.82"
+	}
 }

--- a/src/Nerdbank.MessagePack/Converters/ExpandoObjectConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/ExpandoObjectConverter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Text.Json.Nodes;
 
@@ -10,11 +11,24 @@ namespace Nerdbank.MessagePack.Converters;
 /// A converter for <see cref="ExpandoObject"/>.
 /// </summary>
 /// <remarks>
+/// <para>
 /// This can <em>deserialize</em> anything, but can only <em>serialize</em> object graphs for which every runtime type
 /// has a shape available as provided by <see cref="SerializationContext.TypeShapeProvider"/>.
+/// </para>
+/// <para>
+/// This converter is not included by default because it requires dynamic code support in the runtime.
+/// But it is offered as a converter that may be added to <see cref="MessagePackSerializer.Converters"/>
+/// in order to enable <see cref="ExpandoObject"/> serialization.
+/// </para>
 /// </remarks>
-internal class ExpandoObjectConverter : MessagePackConverter<ExpandoObject>
+[RequiresDynamicCode(Reasons.DynamicObject)]
+public class ExpandoObjectConverter : MessagePackConverter<ExpandoObject>
 {
+	/// <summary>
+	/// A reusable, shareable instance of this converter.
+	/// </summary>
+	public static readonly ExpandoObjectConverter Instance = new();
+
 	/// <inheritdoc/>
 	public override ExpandoObject? Read(ref MessagePackReader reader, SerializationContext context)
 	{
@@ -39,7 +53,7 @@ internal class ExpandoObjectConverter : MessagePackConverter<ExpandoObject>
 					throw new NotSupportedException("Null key in map.");
 				}
 
-				object? value = PrimitivesAsObjectConverter.Instance.Read(ref reader, context);
+				object? value = PrimitivesAsDynamicConverter.Instance.Read(ref reader, context);
 				dictionary.Add(key, value);
 			}
 		}

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.cs
@@ -58,8 +58,6 @@ internal static class PrimitiveConverterLookup
 	private static IMessagePackConverterInternal? _JsonElementConverter;
 	private static IMessagePackConverterInternal? _JsonDocumentConverter;
 	private static IMessagePackConverterInternal? _JsonDocumentConverterReferencePreserving;
-	private static IMessagePackConverterInternal? _ExpandoObjectConverter;
-	private static IMessagePackConverterInternal? _ExpandoObjectConverterReferencePreserving;
 	private static IMessagePackConverterInternal? _RawMessagePackConverter;
 	private static IMessagePackConverterInternal? _MessagePackValueConverter;
 #if NET
@@ -297,20 +295,6 @@ internal static class PrimitiveConverterLookup
 			else
 			{
 				converter = (MessagePackConverter<T>)(_JsonDocumentConverter ??= new JsonDocumentConverter());
-			}
-
-			return true;
-		}
-
-		if (typeof(T) == typeof(System.Dynamic.ExpandoObject))
-		{
-			if (referencePreserving != ReferencePreservationMode.Off)
-			{
-				converter = (MessagePackConverter<T>)(_ExpandoObjectConverterReferencePreserving ??= new ExpandoObjectConverter().WrapWithReferencePreservation());
-			}
-			else
-			{
-				converter = (MessagePackConverter<T>)(_ExpandoObjectConverter ??= new ExpandoObjectConverter());
 			}
 
 			return true;

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.tt
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.tt
@@ -52,7 +52,6 @@ var convertersByType = new List<ConverterInfo>
     new ConverterInfo("System.Text.Json.Nodes.JsonNode", "JsonNodeConverter", IsRefType: true),
     new ConverterInfo("System.Text.Json.JsonElement", "JsonElementConverter"),
     new ConverterInfo("System.Text.Json.JsonDocument", "JsonDocumentConverter", IsRefType: true),
-    new ConverterInfo("System.Dynamic.ExpandoObject", "ExpandoObjectConverter", IsRefType: true),
     new ConverterInfo("Nerdbank.MessagePack.RawMessagePack", "RawMessagePackConverter"),
     new ConverterInfo("Nerdbank.MessagePack.MessagePackValue", "MessagePackValueConverter"),
 };

--- a/src/Nerdbank.MessagePack/Converters/PrimitivesAsDynamicConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitivesAsDynamicConverter.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack.Converters;
+
+/// <summary>
+/// A converter that can write msgpack primitives or other convertible values typed as <see cref="object"/>
+/// and reads everything into primitives, dictionaries and arrays.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This converter is not included by default because untyped serialization is not generally desirable.
+/// But it is offered as a converter that may be added to <see cref="MessagePackSerializer.Converters"/>
+/// in order to enable limited untyped serialization.
+/// </para>
+/// <para>
+/// This converter is very similar to <see cref="PrimitivesAsObjectConverter"/>.
+/// What distinguishes this class is that the result can be used with the C# <c>dynamic</c> keyword
+/// to index into maps using string keys as if they were properties.
+/// </para>
+/// <para>
+/// This class's need for dynamic code support in the runtime comes from use of
+/// <see cref="DynamicDictionary"/>, which <em>could</em> be rewritten to remove this requirement.
+/// See the remarks on that class for more information.
+/// That would be a lot of code to copy from the runtime though, so until someone asks for it,
+/// this is simply restricted in its use.
+/// </para>
+/// </remarks>
+[RequiresDynamicCode(Reasons.DynamicObject)]
+public class PrimitivesAsDynamicConverter : PrimitivesAsObjectConverter
+{
+	/// <summary>
+	/// Gets the default instance of the converter.
+	/// </summary>
+	public static new readonly PrimitivesAsDynamicConverter Instance = new();
+
+	/// <inheritdoc/>
+	protected override IReadOnlyDictionary<object, object?> WrapDictionary(IReadOnlyDictionary<object, object?> content)
+		=> new DynamicDictionary(content ?? throw new ArgumentNullException(nameof(content)));
+}

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO.Pipelines;
 using System.Linq.Expressions;
@@ -299,12 +300,13 @@ public partial record MessagePackSerializer
 	/// </para>
 	/// <code source="../../samples/cs/PrimitiveDeserialization.cs" region="DeserializePrimitives" lang="C#" />
 	/// </example>
+	[RequiresDynamicCode(Reasons.DynamicObject)]
 	public dynamic? DeserializeDynamic(ref MessagePackReader reader, CancellationToken cancellationToken = default)
 	{
 		using DisposableSerializationContext context = this.CreateSerializationContext(MsgPackPrimitivesWitness.ShapeProvider, cancellationToken);
 		try
 		{
-			return PrimitivesAsObjectConverter.Instance.Read(ref reader, context.Value);
+			return PrimitivesAsDynamicConverter.Instance.Read(ref reader, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{

--- a/src/Nerdbank.MessagePack/Reasons.cs
+++ b/src/Nerdbank.MessagePack/Reasons.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// Constant strings useful in <see cref="RequiresDynamicCodeAttribute"/>
+/// and <see cref="RequiresUnreferencedCodeAttribute"/> annotations.
+/// </summary>
+internal static class Reasons
+{
+	/// <summary>
+	/// A reference to <see cref="System.Dynamic.DynamicObject"/> is the reason for the dynamic code requirement.
+	/// </summary>
+	internal const string DynamicObject = "System.Dynamic.DynamicObject requires dynamic code.";
+}

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.Build.Traversal">
+  <ItemGroup>
+    <ProjectReference Include="**\*.csproj" Publish="false" />
+  </ItemGroup>
+</Project>

--- a/test/AOT.props
+++ b/test/AOT.props
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <RuntimeIdentifiers>$(AvailableRuntimeIdentifiers)</RuntimeIdentifiers>
+    <RuntimeIdentifier>$(DefaultRuntimeIdentifier)</RuntimeIdentifier>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <!-- Suppress spreading the RID being built here to RID-neutral projects. -->
+      <GlobalPropertiesToRemove>RuntimeIdentifier</GlobalPropertiesToRemove>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+</Project>

--- a/test/AotNativeConsole/AotNativeConsole.csproj
+++ b/test/AotNativeConsole/AotNativeConsole.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="..\AOT.props" />
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
-    <PublishAot>true</PublishAot>
-    <InvariantGlobalization>true</InvariantGlobalization>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 

--- a/test/Nerdbank.MessagePack.Tests/Converters/ExpandoObjectConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/Converters/ExpandoObjectConverterTests.cs
@@ -2,12 +2,22 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Dynamic;
+using Nerdbank.MessagePack.Converters;
 
 namespace Converters;
 
 [Trait("dynamic", "true")]
-public partial class ExpandoObjectConverterTests(ITestOutputHelper logger) : MessagePackSerializerTestBase(logger)
+public partial class ExpandoObjectConverterTests : MessagePackSerializerTestBase
 {
+	public ExpandoObjectConverterTests(ITestOutputHelper logger)
+		: base(logger)
+	{
+		this.Serializer = this.Serializer with
+		{
+			Converters = [.. this.Serializer.Converters, ExpandoObjectConverter.Instance],
+		};
+	}
+
 	[Fact]
 	public void SimplePropertyValues()
 	{

--- a/test/dirs.proj
+++ b/test/dirs.proj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.Build.Traversal">
+  <ItemGroup>
+    <ProjectReference Include="Benchmarks\Benchmarks.csproj" Publish="false" />
+    <ProjectReference Include="Nerdbank.MessagePack.Tests\Nerdbank.MessagePack.Tests.csproj" Publish="false" />
+    <ProjectReference Include="Nerdbank.MessagePack.Analyzers.Tests\Nerdbank.MessagePack.Analyzers.Tests.csproj" Publish="false" />
+
+    <MultiRIDProjectReference Include="AotNativeConsole\AotNativeConsole.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/dirs.proj
+++ b/tools/dirs.proj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.Build.Traversal">
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRootPath)src\dirs.proj" />
+    <ProjectReference Include="$(RepoRootPath)test\dirs.proj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This change takes the approach of moving functionality that (currently) requires dynamic runtime capability to separate APIs that must be invoked separately.
Ideally though, `DynamicDictionary` could be rewritten to be more like `ExpandoObject`, which has no such dependency.

Fixes #405

This works around https://github.com/dotnet/msbuild/issues/11922