### PR TITLE
Add support for `[MessagePackConverter]` to be applied to properties and fields

### DIFF
--- a/samples/cs/CustomConverters.cs
+++ b/samples/cs/CustomConverters.cs
@@ -303,7 +303,7 @@ namespace WitnessForArray
     }
 }
 
-namespace CustomConverterRegistration
+namespace CustomConverterTypeRegistration
 {
     #region CustomConverterByAttribute
     [MessagePackConverter(typeof(MyCustomTypeConverter))]
@@ -332,6 +332,27 @@ namespace CustomConverterRegistration
             serializer = serializer with { Converters = [new MyCustomTypeConverter()] };
             #endregion
         }
+    }
+}
+
+namespace CustomConverterMemberRegistration
+{
+    #region CustomConverterByAttributeOnMember
+    public class MyCustomType
+    {
+        [MessagePackConverter(typeof(EncryptingIntegerConverter))]
+        public int Value { get; set; }
+    }
+    #endregion
+
+    /// <summary>
+    /// Simple XOR encryption for demonstration.
+    /// </summary>
+    public class EncryptingIntegerConverter : MessagePackConverter<int>
+    {
+        public override int Read(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt32() ^ 0x12345678;
+
+        public override void Write(ref MessagePackWriter writer, in int value, SerializationContext context) => writer.Write(value ^ 0x12345678); // Simple XOR encryption for demonstration
     }
 }
 

--- a/src/Nerdbank.MessagePack/MessagePackConverterAttribute.cs
+++ b/src/Nerdbank.MessagePack/MessagePackConverterAttribute.cs
@@ -13,7 +13,7 @@ namespace Nerdbank.MessagePack;
 /// A type that implements <see cref="MessagePackConverter{T}"/>
 /// where <c>T</c> is a type argument matching the type to which this attribute is applied.
 /// </param>
-[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 [AssociatedTypeAttribute(nameof(converterType), TypeShapeRequirements.Constructor)]
 public class MessagePackConverterAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type converterType) : Attribute
 {

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/MessagePackConverterAttributeAnalyzerTests.cs
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/MessagePackConverterAttributeAnalyzerTests.cs
@@ -17,6 +17,12 @@ public class MessagePackConverterAttributeAnalyzerTests
 			{
 			}
 
+			public class Members
+			{
+				[MessagePackConverter(typeof(MyTypeConverter))]
+				public MyType Value { get; set; }
+			}
+
 			public class MyTypeConverter : MessagePackConverter<MyType>
 			{
 				public override MyType Read(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
@@ -39,6 +45,18 @@ public class MessagePackConverterAttributeAnalyzerTests
 			{
 			}
 
+			public class MemberOf<T>
+			{
+				[MessagePackConverter(typeof(MyTypeConverter<>))]
+				public MyType<T> Value { get; set; }
+			}
+
+			public class MemberOf
+			{
+				[MessagePackConverter(typeof(MyTypeConverter<>))]
+				public MyType<int> Value { get; set; }
+			}
+
 			public class MyTypeConverter<T> : MessagePackConverter<MyType<T>>
 			{
 				public override MyType<T> Read(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
@@ -59,6 +77,12 @@ public class MessagePackConverterAttributeAnalyzerTests
 			[MessagePackConverter({|NBMsgPack021:typeof(MyTypeConverter)|})]
 			public class MyType
 			{
+			}
+
+			public class MemberApplied
+			{
+				[MessagePackConverter({|NBMsgPack021:typeof(MyTypeConverter)|})]
+				public MyType Value { get; set; }
 			}
 
 			public class MyTypeConverter : MessagePackConverter<MyType>
@@ -84,6 +108,12 @@ public class MessagePackConverterAttributeAnalyzerTests
 			{
 			}
 
+			public class MemberApplied
+			{
+				[MessagePackConverter({|NBMsgPack020:typeof(MyTypeConverter)|})]
+				public MyType Value { get; set; }
+			}
+
 			public class MyTypeConverter
 			{
 				public MyType Read(ref MessagePackReader reader, SerializationContext context) => throw new System.NotImplementedException();
@@ -104,6 +134,12 @@ public class MessagePackConverterAttributeAnalyzerTests
 			[MessagePackConverter({|NBMsgPack020:typeof(IntConverter)|})]
 			public class MyType
 			{
+			}
+
+			public class MemberApplied
+			{
+				[MessagePackConverter({|NBMsgPack020:typeof(IntConverter)|})]
+				public string Value { get; set; }
 			}
 
 			public class IntConverter : MessagePackConverter<int>

--- a/test/Nerdbank.MessagePack.Tests/MessagePackConverterAttributeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackConverterAttributeTests.cs
@@ -9,6 +9,52 @@ public partial class MessagePackConverterAttributeTests(ITestOutputHelper logger
 		this.AssertRoundtrip(new CustomType() { InternalProperty = "some value" });
 	}
 
+	[Fact]
+	public void TypeWithCustomConvertedMembers()
+	{
+		var instance = new TypeWithCustomMembers()
+		{
+			EncryptedField = 12,
+			OrdinaryField = 24,
+			EncryptedProperty = 48,
+			OrdinaryProperty = 96,
+		};
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip(instance);
+
+		// Assert that the serialized data is encrypted.
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(4, reader.ReadArrayHeader());
+		Assert.NotEqual(12, reader.ReadInt32());
+		Assert.Equal(24, reader.ReadInt32());
+		Assert.NotEqual(48, reader.ReadInt32());
+		Assert.Equal(96, reader.ReadInt32());
+	}
+
+	[Fact]
+	public void GenericConverterOnMemberOfGenericType()
+	{
+		this.AssertRoundtrip(new Container() { Value = new(42) });
+	}
+
+	[AssociatedTypeShape(typeof(GenericConverter<>), Requirements = TypeShapeRequirements.Constructor)] // workaround https://github.com/eiriktsarpalis/PolyType/issues/181
+	public record struct GenericData<T>(int Value);
+
+	[GenerateShape]
+	public partial record TypeWithCustomMembers
+	{
+		[Key(0), MessagePackConverter(typeof(EncryptingIntegerConverter))]
+		public int EncryptedField;
+
+		[Key(1)]
+		public int OrdinaryField;
+
+		[Key(2), MessagePackConverter(typeof(EncryptingIntegerConverter))]
+		public int EncryptedProperty { get; set; }
+
+		[Key(3)]
+		public int OrdinaryProperty { get; set; }
+	}
+
 	[GenerateShape] // to allow use as a direct serialization argument
 	[MessagePackConverter(typeof(CustomTypeConverter))]
 	public partial record CustomType
@@ -18,6 +64,13 @@ public partial class MessagePackConverterAttributeTests(ITestOutputHelper logger
 		internal string? InternalProperty { get; set; }
 
 		public override string ToString() => this.InternalProperty ?? "(null)";
+	}
+
+	[GenerateShape]
+	public partial record Container
+	{
+		[MessagePackConverter(typeof(GenericConverter<>))]
+		public GenericData<int> Value { get; set; }
 	}
 
 	public class CustomTypeConverter : MessagePackConverter<CustomType>
@@ -31,5 +84,22 @@ public partial class MessagePackConverterAttributeTests(ITestOutputHelper logger
 		{
 			writer.Write(value?.InternalProperty);
 		}
+	}
+
+	/// <summary>
+	/// Simple XOR encryption for demonstration.
+	/// </summary>
+	public class EncryptingIntegerConverter : MessagePackConverter<int>
+	{
+		public override int Read(ref MessagePackReader reader, SerializationContext context) => reader.ReadInt32() ^ 0x12345678;
+
+		public override void Write(ref MessagePackWriter writer, in int value, SerializationContext context) => writer.Write(value ^ 0x12345678); // Simple XOR encryption for demonstration
+	}
+
+	public class GenericConverter<T> : MessagePackConverter<GenericData<T>>
+	{
+		public override GenericData<T> Read(ref MessagePackReader reader, SerializationContext context) => new(reader.ReadInt32());
+
+		public override void Write(ref MessagePackWriter writer, in GenericData<T> value, SerializationContext context) => writer.Write(value.Value);
 	}
 }


### PR DESCRIPTION
This includes a workaround for https://github.com/eiriktsarpalis/PolyType/issues/181

Closes #420