### PR TITLE
Create associated type automatically when `[MessagePackConverter]` is applied to members

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <RoslynVersion>4.14.0</RoslynVersion>
     <RoslynVersionForAnalyzers>4.11.0</RoslynVersionForAnalyzers>
     <CodeAnalysisAnalyzerVersion>3.11.0-beta1.25173.3</CodeAnalysisAnalyzerVersion>
-    <PolyTypeVersion>0.40.1</PolyTypeVersion>
+    <PolyTypeVersion>0.41.1</PolyTypeVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.0" />
@@ -44,7 +44,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)'=='true'">
     <PackageVersion Update="System.Collections.Immutable" Version="9.0.0" />
-    <PackageVersion Update="System.IO.Pipelines" Version="9.0.0" />
+    <PackageVersion Update="System.IO.Pipelines" Version="9.0.5" />
+    <PackageVersion Update="System.Text.Json" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />

--- a/test/Nerdbank.MessagePack.Tests/MessagePackConverterAttributeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackConverterAttributeTests.cs
@@ -36,7 +36,6 @@ public partial class MessagePackConverterAttributeTests(ITestOutputHelper logger
 		this.AssertRoundtrip(new Container() { Value = new(42) });
 	}
 
-	[AssociatedTypeShape(typeof(GenericConverter<>), Requirements = TypeShapeRequirements.Constructor)] // workaround https://github.com/eiriktsarpalis/PolyType/issues/181
 	public record struct GenericData<T>(int Value);
 
 	[GenerateShape]


### PR DESCRIPTION
Bump PolyType and remove workaround