### PR TITLE
Remove the Converters sub-namespace

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.12.87" />
+    <PackageVersion Include="NetArchTest.eNhancedEdition" Version="1.4.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageVersion Include="PolyType" Version="$(PolyTypeVersion)" />

--- a/docfx/docs/built-in-converters.md
+++ b/docfx/docs/built-in-converters.md
@@ -40,10 +40,6 @@ Enums, arrays and various dictionary types that utilize these types are implicit
 - @System.TimeOnly
 - @System.TimeSpan
 
-## Complex types
-
-- @System.Dynamic.ExpandoObject
-
 ## Other
 
 - @System.Boolean
@@ -61,6 +57,8 @@ You can activate these converters in code when you need them using the extension
 Data type | API to enable
 --|--
 @System.Guid | <xref:Nerdbank.MessagePack.OptionalConverters.WithGuidConverter*>
+@System.Dynamic.ExpandoObject | <xref:Nerdbank.MessagePack.OptionalConverters.WithExpandoObjectConverter*>
+@System.Object | <xref:Nerdbank.MessagePack.OptionalConverters.WithObjectPrimitiveConverter*> or <xref:Nerdbank.MessagePack.OptionalConverters.WithObjectDynamicConverter*>
 @System.Text.Json.Nodes.JsonNode | <xref:Nerdbank.MessagePack.OptionalConverters.WithSystemTextJsonConverters*>
 @System.Text.Json.JsonElement | <xref:Nerdbank.MessagePack.OptionalConverters.WithSystemTextJsonConverters*>
 @System.Text.Json.JsonDocument | <xref:Nerdbank.MessagePack.OptionalConverters.WithSystemTextJsonConverters*>

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -6,12 +6,12 @@ items:
 - name: Unions
   href: unions.md
 - href: streaming-deserialization.md
+- href: built-in-converters.md
+- name: Custom converters
+  href: custom-converters.md
 - name: Customizing serialization
   href: customizing-serialization.md
 - href: surrogate-types.md
-- name: Custom converters
-  href: custom-converters.md
-- href: built-in-converters.md
 - name: Performance
   href: performance.md
 - name: Security

--- a/src/Nerdbank.MessagePack/Converters/ExpandoObjectConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/ExpandoObjectConverter.cs
@@ -22,12 +22,12 @@ namespace Nerdbank.MessagePack.Converters;
 /// </para>
 /// </remarks>
 [RequiresDynamicCode(Reasons.DynamicObject)]
-public class ExpandoObjectConverter : MessagePackConverter<ExpandoObject>
+internal class ExpandoObjectConverter : MessagePackConverter<ExpandoObject>
 {
 	/// <summary>
 	/// A reusable, shareable instance of this converter.
 	/// </summary>
-	public static readonly ExpandoObjectConverter Instance = new();
+	internal static readonly ExpandoObjectConverter Instance = new();
 
 	/// <inheritdoc/>
 	public override ExpandoObject? Read(ref MessagePackReader reader, SerializationContext context)

--- a/src/Nerdbank.MessagePack/Converters/PrimitivesAsDynamicConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitivesAsDynamicConverter.cs
@@ -29,12 +29,12 @@ namespace Nerdbank.MessagePack.Converters;
 /// </para>
 /// </remarks>
 [RequiresDynamicCode(Reasons.DynamicObject)]
-public class PrimitivesAsDynamicConverter : PrimitivesAsObjectConverter
+internal class PrimitivesAsDynamicConverter : PrimitivesAsObjectConverter
 {
 	/// <summary>
 	/// Gets the default instance of the converter.
 	/// </summary>
-	public static new readonly PrimitivesAsDynamicConverter Instance = new();
+	internal static new readonly PrimitivesAsDynamicConverter Instance = new();
 
 	/// <inheritdoc/>
 	protected override IReadOnlyDictionary<object, object?> WrapDictionary(IReadOnlyDictionary<object, object?> content)

--- a/src/Nerdbank.MessagePack/Converters/PrimitivesAsObjectConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitivesAsObjectConverter.cs
@@ -24,12 +24,12 @@ namespace Nerdbank.MessagePack.Converters;
 /// </para>
 /// </remarks>
 /// <seealso cref="PrimitivesAsDynamicConverter"/>
-public class PrimitivesAsObjectConverter : MessagePackConverter<object?>
+internal class PrimitivesAsObjectConverter : MessagePackConverter<object?>
 {
 	/// <summary>
 	/// Gets the default instance of the converter.
 	/// </summary>
-	public static readonly PrimitivesAsObjectConverter Instance = new();
+	internal static readonly PrimitivesAsObjectConverter Instance = new();
 
 	/// <summary>Reads any one msgpack structure.</summary>
 	/// <param name="reader">The msgpack reader.</param>
@@ -135,7 +135,6 @@ public class PrimitivesAsObjectConverter : MessagePackConverter<object?>
 	}
 
 	/// <inheritdoc />
-	/// <exception cref="NotSupportedException">Always thrown.</exception>
 	public override void Write(ref MessagePackWriter writer, in object? value, SerializationContext context)
 	{
 		switch (value)

--- a/test/Nerdbank.MessagePack.Tests/ArchitectureRules.cs
+++ b/test/Nerdbank.MessagePack.Tests/ArchitectureRules.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET
+
+using NetArchTest.Rules;
+
+public class ArchitectureRules
+{
+	/// <summary>
+	/// Verifies that all optional converters are exposed via <see cref="OptionalConverters"/> rather than being public in the Converters namespace.
+	/// </summary>
+	[Fact]
+	public void NoPublicConvertersNamespace()
+	{
+		Assert.Empty(Types.InAssembly(typeof(MessagePackSerializer).Assembly)
+			.That().ResideInNamespaceMatching($"{typeof(MessagePackSerializer).Namespace}.Converters")
+			.ShouldNot().BePublic()
+			.GetResult().FailingTypes);
+	}
+}
+
+#endif

--- a/test/Nerdbank.MessagePack.Tests/Converters/ExpandoObjectConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/Converters/ExpandoObjectConverterTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Dynamic;
-using Nerdbank.MessagePack.Converters;
 
 namespace Converters;
 
@@ -12,10 +11,7 @@ public partial class ExpandoObjectConverterTests : MessagePackSerializerTestBase
 	public ExpandoObjectConverterTests(ITestOutputHelper logger)
 		: base(logger)
 	{
-		this.Serializer = this.Serializer with
-		{
-			Converters = [.. this.Serializer.Converters, ExpandoObjectConverter.Instance],
-		};
+		this.Serializer = this.Serializer.WithExpandoObjectConverter();
 	}
 
 	[Fact]

--- a/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
+++ b/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
@@ -8,6 +8,8 @@
     <RootNamespace />
     <NoWarn>$(NoWarn);NBMsgPack051</NoWarn>
     <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
+    <!-- Allow references to non-strong named assemblies when the test isn't targeting .NET Framework. -->
+    <NoWarn Condition="'$(TargetFramework)'!='net472'">$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +28,7 @@
     <PackageReference Include="DiffPlex" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Nerdbank.Streams" />
+    <PackageReference Include="NetArchTest.eNhancedEdition" Condition="'$(TargetFrameworkIdentifier)'=='.NETCoreApp'" />
     <PackageReference Include="Newtonsoft.Json.Schema" />
     <PackageReference Include="PolyType.TestCases" />
     <PackageReference Include="Xunit.Combinatorial" />


### PR DESCRIPTION
All optional converters are now accessible exclusively through the `OptionalConverters` class.