### PR TITLE
Bump NetArchTest.eNhancedEdition to 1.4.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.12.87" />
-    <PackageVersion Include="NetArchTest.eNhancedEdition" Version="1.4.4" />
+    <PackageVersion Include="NetArchTest.eNhancedEdition" Version="1.4.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageVersion Include="PolyType" Version="$(PolyTypeVersion)" />

--- a/test/Nerdbank.MessagePack.Tests/ArchitectureRules.cs
+++ b/test/Nerdbank.MessagePack.Tests/ArchitectureRules.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET
-
 using NetArchTest.Rules;
 
 public class ArchitectureRules
@@ -19,5 +17,3 @@ public class ArchitectureRules
 			.GetResult().FailingTypes);
 	}
 }
-
-#endif

--- a/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
+++ b/test/Nerdbank.MessagePack.Tests/Nerdbank.MessagePack.Tests.csproj
@@ -8,8 +8,6 @@
     <RootNamespace />
     <NoWarn>$(NoWarn);NBMsgPack051</NoWarn>
     <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
-    <!-- Allow references to non-strong named assemblies when the test isn't targeting .NET Framework. -->
-    <NoWarn Condition="'$(TargetFramework)'!='net472'">$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,7 +26,7 @@
     <PackageReference Include="DiffPlex" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Nerdbank.Streams" />
-    <PackageReference Include="NetArchTest.eNhancedEdition" Condition="'$(TargetFrameworkIdentifier)'=='.NETCoreApp'" />
+    <PackageReference Include="NetArchTest.eNhancedEdition" />
     <PackageReference Include="Newtonsoft.Json.Schema" />
     <PackageReference Include="PolyType.TestCases" />
     <PackageReference Include="Xunit.Combinatorial" />


### PR DESCRIPTION
This is now strong named, so we can use it in our net472 targeted test project.