### PR TITLE
Implement `IDeepSecureEqualityComparer<T>` on `MessagePackValue` and `Extension`

### DIFF
--- a/src/Nerdbank.MessagePack/Extension.cs
+++ b/src/Nerdbank.MessagePack/Extension.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Nerdbank.MessagePack.SecureHash;
+
 namespace Nerdbank.MessagePack;
 
 /// <summary>
@@ -8,7 +10,7 @@ namespace Nerdbank.MessagePack;
 /// </summary>
 /// <param name="TypeCode"><inheritdoc cref="ExtensionHeader(sbyte, uint)" path="/param[@name='TypeCode']"/></param>
 /// <param name="Data">The data payload, in whatever format is prescribed by the extension as per the <paramref name="TypeCode"/>.</param>
-public record struct Extension(sbyte TypeCode, ReadOnlySequence<byte> Data)
+public record struct Extension(sbyte TypeCode, ReadOnlySequence<byte> Data) : IDeepSecureEqualityComparer<Extension>
 {
 	/// <summary>
 	/// Initializes a new instance of the <see cref="Extension"/> struct.
@@ -30,4 +32,23 @@ public record struct Extension(sbyte TypeCode, ReadOnlySequence<byte> Data)
 
 	/// <inheritdoc/>
 	public override readonly int GetHashCode() => HashCode.Combine(this.TypeCode, this.Data.Length);
+
+	/// <inheritdoc/>
+	bool IDeepSecureEqualityComparer<Extension>.DeepEquals(Extension other) => this.Equals(other);
+
+	/// <inheritdoc/>
+	long IDeepSecureEqualityComparer<Extension>.GetSecureHashCode()
+	{
+		// We don't have an incremental SipHash implementation, so we have to copy the data to a rented buffer.
+		byte[] rented = ArrayPool<byte>.Shared.Rent(checked((int)this.Data.Length));
+		try
+		{
+			this.Data.CopyTo(rented);
+			return SipHash.Default.Compute(rented.AsSpan(0, (int)this.Data.Length)) + this.TypeCode;
+		}
+		finally
+		{
+			ArrayPool<byte>.Shared.Return(rented);
+		}
+	}
 }

--- a/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
@@ -8,12 +8,9 @@
 #pragma warning disable CS8767 // null ref annotations
 #endif
 
-using System.Collections;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft;
 
@@ -37,6 +34,8 @@ internal static class HashCollisionResistantPrimitives
 
 	internal class BooleanEqualityComparer : CollisionResistantHasherUnmanaged<bool>
 	{
+		internal static readonly BooleanEqualityComparer Instance = new();
+
 		public override long GetSecureHashCode(bool value) => base.GetSecureHashCode(value is true);
 
 		public override bool Equals(bool x, bool y) => x is true == y is true;
@@ -58,6 +57,8 @@ internal static class HashCollisionResistantPrimitives
 
 	internal class SingleEqualityComparer : CollisionResistantHasherUnmanaged<float>
 	{
+		internal static readonly SingleEqualityComparer Instance = new();
+
 		/// <inheritdoc/>
 		public override unsafe long GetSecureHashCode(float value)
 			=> base.GetSecureHashCode(value switch
@@ -70,6 +71,8 @@ internal static class HashCollisionResistantPrimitives
 
 	internal class DoubleEqualityComparer : CollisionResistantHasherUnmanaged<double>
 	{
+		internal static readonly DoubleEqualityComparer Instance = new();
+
 		/// <inheritdoc/>
 		public override unsafe long GetSecureHashCode(double value)
 			=> base.GetSecureHashCode(value switch
@@ -82,6 +85,8 @@ internal static class HashCollisionResistantPrimitives
 
 	internal class DateTimeEqualityComparer : CollisionResistantHasherUnmanaged<DateTime>
 	{
+		internal static readonly DateTimeEqualityComparer Instance = new();
+
 		/// <inheritdoc/>
 		public override unsafe long GetSecureHashCode(DateTime value) => SecureHash(value.Ticks);
 	}
@@ -92,12 +97,12 @@ internal static class HashCollisionResistantPrimitives
 		public override unsafe long GetSecureHashCode(DateTimeOffset value) => SecureHash(value.UtcDateTime.Ticks);
 	}
 
-	internal class StringEqualityComparer : SecureEqualityComparer<string>
+	internal class StringEqualityComparer : SecureEqualityComparer<string?>
 	{
 		internal static readonly StringEqualityComparer Instance = new();
 
 		/// <inheritdoc/>
-		public override long GetSecureHashCode(string value)
+		public override long GetSecureHashCode(string? value)
 		{
 			// The Cast call could result in OverflowException at runtime if value is greater than 1bn chars in length.
 			return SecureHash(MemoryMarshal.Cast<char, byte>(value.AsSpan()));

--- a/test/Nerdbank.MessagePack.Tests/DynamicSerializationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/DynamicSerializationTests.cs
@@ -55,18 +55,25 @@ public class DynamicSerializationTests : MessagePackSerializerTestBase
 	{
 		// C# doesn't offer a way to call this method like other languages would, so we'll call it directly.
 		DynamicObject deserialized = (DynamicObject)this.DeserializeDynamic();
-		Assert.Equal(["Prop1", "Prop2", "deeper"], deserialized.GetDynamicMemberNames());
+		Assert.Equal(["Prop1", "Prop2", "nestedArray", "nestedObject"], deserialized.GetDynamicMemberNames());
 	}
 
 	[Fact]
 	public void ReachIntoArray()
 	{
 		dynamic deserialized = this.DeserializeDynamic();
-		Assert.Equal(4, deserialized.deeper.Length);
-		Assert.Equal(true, deserialized.deeper[0]);
-		Assert.Equal(3.5, deserialized.deeper[1]);
-		Assert.Equal(new Extension(15, new byte[] { 1, 2, 3 }), deserialized.deeper[2]);
-		Assert.Equal<DateTime>(ExpectedDateTime, deserialized.deeper[3]);
+		Assert.Equal(4, deserialized.nestedArray.Length);
+		Assert.Equal(true, deserialized.nestedArray[0]);
+		Assert.Equal(3.5, deserialized.nestedArray[1]);
+		Assert.Equal(new Extension(15, new byte[] { 1, 2, 3 }), deserialized.nestedArray[2]);
+		Assert.Equal<DateTime>(ExpectedDateTime, deserialized.nestedArray[3]);
+	}
+
+	[Fact]
+	public void ReachIntoMap()
+	{
+		dynamic deserialized = this.DeserializeDynamic();
+		Assert.Equal("nestedValue", deserialized.nestedObject.nestedProp);
 	}
 
 	[Fact]
@@ -75,12 +82,12 @@ public class DynamicSerializationTests : MessagePackSerializerTestBase
 		dynamic deserialized = this.DeserializeDynamic();
 		IReadOnlyDictionary<object, object?> dict = (IReadOnlyDictionary<object, object?>)deserialized;
 
-		Assert.Equal(5, dict.Count);
+		Assert.Equal(6, dict.Count);
 
-		Assert.True(dict.ContainsKey("deeper"));
-		Assert.IsType<object?[]>(dict["deeper"]);
-		Assert.True(dict.TryGetValue("deeper", out object? deeper));
-		Assert.IsType<object?[]>(deeper);
+		Assert.True(dict.ContainsKey("nestedArray"));
+		Assert.IsType<object?[]>(dict["nestedArray"]);
+		Assert.True(dict.TryGetValue("nestedArray", out object? nestedArray));
+		Assert.IsType<object?[]>(nestedArray);
 
 		Assert.False(dict.ContainsKey("doesnotexist"));
 		Assert.Throws<KeyNotFoundException>(() => dict["doesnotexist"]);
@@ -89,12 +96,12 @@ public class DynamicSerializationTests : MessagePackSerializerTestBase
 		bool encounteredDeeper = false;
 		foreach (KeyValuePair<object, object?> item in dict)
 		{
-			encounteredDeeper |= item.Key is "deeper";
+			encounteredDeeper |= item.Key is "nestedArray";
 		}
 
 		Assert.True(encounteredDeeper);
 
-		Assert.Equal(["Prop1", "Prop2", "deeper", 45UL, -45L], dict.Keys);
+		Assert.Equal(["Prop1", "Prop2", "nestedArray", 45UL, -45L, "nestedObject"], dict.Keys);
 		Assert.Equal(dict.Count, dict.Values.Count());
 	}
 
@@ -116,18 +123,18 @@ public class DynamicSerializationTests : MessagePackSerializerTestBase
 		Assert.False(dict.Contains(new KeyValuePair<object, object?>("Prop1", "Value2")));
 		Assert.False(dict.Contains(new KeyValuePair<object, object?>("PropX", "Value2")));
 
-		KeyValuePair<object, object?>[] array = new KeyValuePair<object, object?>[6];
+		KeyValuePair<object, object?>[] array = new KeyValuePair<object, object?>[7];
 		dict.CopyTo(array, 1);
 		Assert.Null(array[0].Key);
 		Assert.Equal("Prop1", array[1].Key);
 		Assert.Equal("Value1", array[1].Value);
 
-		Assert.Equal(5, dict.Count);
+		Assert.Equal(6, dict.Count);
 
-		Assert.True(dict.ContainsKey("deeper"));
-		Assert.IsType<object?[]>(dict["deeper"]);
-		Assert.True(dict.TryGetValue("deeper", out object? deeper));
-		Assert.IsType<object?[]>(deeper);
+		Assert.True(dict.ContainsKey("nestedArray"));
+		Assert.IsType<object?[]>(dict["nestedArray"]);
+		Assert.True(dict.TryGetValue("nestedArray", out object? nestedArray));
+		Assert.IsType<object?[]>(nestedArray);
 
 		Assert.False(dict.ContainsKey("doesnotexist"));
 		Assert.Throws<KeyNotFoundException>(() => dict["doesnotexist"]);
@@ -136,12 +143,12 @@ public class DynamicSerializationTests : MessagePackSerializerTestBase
 		bool encounteredDeeper = false;
 		foreach (KeyValuePair<object, object?> item in dict)
 		{
-			encounteredDeeper |= item.Key is "deeper";
+			encounteredDeeper |= item.Key is "nestedArray";
 		}
 
 		Assert.True(encounteredDeeper);
 
-		Assert.Equal(["Prop1", "Prop2", "deeper", 45UL, -45L], dict.Keys);
+		Assert.Equal(["Prop1", "Prop2", "nestedArray", 45UL, -45L, "nestedObject"], dict.Keys);
 		Assert.Equal(dict.Count, dict.Values.Count());
 	}
 
@@ -160,11 +167,13 @@ public class DynamicSerializationTests : MessagePackSerializerTestBase
 		Assert.True(enumerator.MoveNext());
 		Assert.Equal("Prop2", enumerator.Current);
 		Assert.True(enumerator.MoveNext());
-		Assert.Equal("deeper", enumerator.Current);
+		Assert.Equal("nestedArray", enumerator.Current);
 		Assert.True(enumerator.MoveNext());
 		Assert.Equal(45UL, enumerator.Current);
 		Assert.True(enumerator.MoveNext());
 		Assert.Equal(-45L, enumerator.Current);
+		Assert.True(enumerator.MoveNext());
+		Assert.Equal("nestedObject", enumerator.Current);
 		Assert.False(enumerator.MoveNext());
 	}
 
@@ -187,12 +196,12 @@ public class DynamicSerializationTests : MessagePackSerializerTestBase
 	{
 		Sequence<byte> seq = new();
 		MessagePackWriter writer = new(seq);
-		writer.WriteMapHeader(5);
+		writer.WriteMapHeader(6);
 		writer.Write("Prop1");
 		writer.Write("Value1");
 		writer.Write("Prop2");
 		writer.Write(42);
-		writer.Write("deeper");
+		writer.Write("nestedArray");
 		writer.WriteArrayHeader(4);
 		writer.Write(true);
 		writer.Write(3.5);
@@ -202,6 +211,12 @@ public class DynamicSerializationTests : MessagePackSerializerTestBase
 		writer.Write([1, 2, 3]);
 		writer.Write(-45); // negative int key for stretching tests
 		writer.Write(false);
+
+		writer.Write("nestedObject");
+		writer.WriteMapHeader(1);
+		writer.Write("nestedProp");
+		writer.Write("nestedValue");
+
 		writer.Flush();
 
 		this.Logger.WriteLine(MessagePackSerializer.ConvertToJson(seq));

--- a/test/Nerdbank.MessagePack.Tests/ExtensionTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ExtensionTests.cs
@@ -23,4 +23,16 @@ public class ExtensionTests
 		Assert.NotEqual(this.ext1a.GetHashCode(), this.ext2.GetHashCode());
 		Assert.NotEqual(this.ext1a.GetHashCode(), this.ext3.GetHashCode());
 	}
+
+	[Fact]
+	public void GetSecureHashCode_StructuralEquality()
+	{
+		// The secure hash code should be the same for two structurally equal extensions.
+		Assert.Equal(GetSecureHashCode(this.ext1a), GetSecureHashCode(this.ext1b));
+		Assert.NotEqual(GetSecureHashCode(this.ext1a), GetSecureHashCode(this.ext2));
+		Assert.NotEqual(GetSecureHashCode(this.ext1a), GetSecureHashCode(this.ext3));
+	}
+
+	private static long GetSecureHashCode<T>(T expected)
+		where T : IDeepSecureEqualityComparer<T> => expected.GetSecureHashCode();
 }

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
@@ -132,7 +132,15 @@ public abstract class MessagePackSerializerTestBase
 #else
 		T? roundtripped = this.Roundtrip(value, GetShape<T, TProvider>());
 #endif
-		Assert.Equal(value, roundtripped);
+		if (value is IDeepSecureEqualityComparer<T> deepComparer)
+		{
+			Assert.True(deepComparer.DeepEquals(roundtripped), "Roundtripped value does not match the original value by deep equality.");
+		}
+		else
+		{
+			Assert.Equal(value, roundtripped);
+		}
+
 		return this.lastRoundtrippedMsgpack;
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/MessagePackValueTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackValueTests.cs
@@ -456,5 +456,26 @@ public class MessagePackValueTests
 	{
 		MessagePackValue left = 5, right = "hi";
 		Assert.NotEqual(left, right);
+		Assert.NotEqual(left.GetHashCode(), right.GetHashCode());
 	}
+
+	[Fact]
+	public void GetHashCode_Shallow_Deep()
+	{
+		MessagePackValue v1a = new MessagePackValue[] { 1, 2, 3 };
+		MessagePackValue v1b = new MessagePackValue[] { 1, 2, 3 };
+		MessagePackValue v2 = new MessagePackValue[] { 4, 5, 6 };
+
+		// Shallow hash code is based on reference equality.
+		// Secure hash code is based on structural equality.
+		Assert.NotEqual(v1a.GetHashCode(), v1b.GetHashCode());
+		Assert.Equal(GetSecureHashCode(v1a), GetSecureHashCode(v1b));
+
+		// These are structurally distinct.
+		Assert.NotEqual(v1a.GetHashCode(), v2.GetHashCode());
+		Assert.NotEqual(GetSecureHashCode(v1a), GetSecureHashCode(v2));
+	}
+
+	private static long GetSecureHashCode<T>(T expected)
+		where T : IDeepSecureEqualityComparer<T> => expected.GetSecureHashCode();
 }


### PR DESCRIPTION
This also _moves_ structural equality for `MessagePackValue` to the interface implementation. The ordinary `Equals` and `GetHashCode` overrides are now 'shallow' to match typical .NET patterns.

It also implements `GetHashCode` on `MessagePackValue` which previously was _not_ implemented, leading to unexpected hash code vs. Equals results.