### PR TITLE
Add support for `MessagePackConverterAttribute` to appear on enum types

### DIFF
--- a/src/Nerdbank.MessagePack/MessagePackConverterAttribute.cs
+++ b/src/Nerdbank.MessagePack/MessagePackConverterAttribute.cs
@@ -13,7 +13,7 @@ namespace Nerdbank.MessagePack;
 /// A type that implements <see cref="MessagePackConverter{T}"/>
 /// where <c>T</c> is a type argument matching the type to which this attribute is applied.
 /// </param>
-[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 [AssociatedTypeAttribute(nameof(converterType), TypeShapeRequirements.Constructor)]
 public class MessagePackConverterAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type converterType) : Attribute
 {

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -625,9 +625,16 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 
 	/// <inheritdoc/>
 	public override object? VisitEnum<TEnum, TUnderlying>(IEnumTypeShape<TEnum, TUnderlying> enumShape, object? state = null)
-		=> this.owner.SerializeEnumValuesByName
+	{
+		if (this.GetCustomConverter(enumShape, enumShape.AttributeProvider) is MessagePackConverter<TEnum> customConverter)
+		{
+			return customConverter;
+		}
+
+		return this.owner.SerializeEnumValuesByName
 			? new EnumAsStringConverter<TEnum, TUnderlying>(this.GetConverter(enumShape.UnderlyingType), enumShape.Members)
 			: new EnumAsOrdinalConverter<TEnum, TUnderlying>(this.GetConverter(enumShape.UnderlyingType));
+	}
 
 	/// <inheritdoc/>
 	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)


### PR DESCRIPTION
Add support for `MessagePackConverterAttribute` to appear on enum types