### PR TITLE
Add comprehensive async serialization support for dictionaries

### DIFF
--- a/src/Nerdbank.MessagePack/PolyfillExtensions.cs
+++ b/src/Nerdbank.MessagePack/PolyfillExtensions.cs
@@ -55,6 +55,9 @@ namespace Nerdbank.MessagePack
 	/// </content>
 	internal static partial class PolyfillExtensions
 	{
+		internal static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> pair, out TKey key, out TValue value)
+			=> (key, value) = (pair.Key, pair.Value);
+
 		internal static bool HasAnySet(this BitArray bitArray)
 		{
 			for (int i = 0; i < bitArray.Count; i++)


### PR DESCRIPTION
* Dictionary serialization now supports async.
* ImmutableDictionary *de*serialization now supports async.

Mutable dictionary deserialization already supported async, so this finishes off async support for all dictionary types.

Closes #521