### PR TITLE
Throw a more helpful exception when serializing certain invalid types

### DIFF
--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -480,7 +480,11 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 							continue;
 						}
 
-						int index = propertyIndexesByName[parameter.Name];
+						if (!propertyIndexesByName.TryGetValue(parameter.Name, out int index))
+						{
+							throw new NotSupportedException($"{constructorShape.DeclaringType.Type.FullName} has a constructor parameter named '{parameter.Name}' that does not match any property on the type. This is not supported. Adjust the parameters and/or properties or write a custom converter for this type.");
+						}
+
 						parameters[index] = (DeserializableProperty<TArgumentState>)parameter.Accept(this)!;
 					}
 

--- a/test/Nerdbank.MessagePack.Tests/OddShapeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/OddShapeTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public partial class OddShapeTests : MessagePackSerializerTestBase
+{
+	/// <summary>
+	/// Verifies that serializing an object with mismatched constructor parameters and properties throws a
+	/// <see cref="MessagePackSerializationException"/> with a <see cref="NotSupportedException"/> as the inner exception.
+	/// </summary>
+	/// <remarks>
+	/// This test ensures that the serializer correctly detects and reports cases where the object's
+	/// constructor parameters do not align with its settable properties, which is not supported by the serialization
+	/// framework.
+	/// </remarks>
+	[Fact]
+	public void OddShapeWithParameterAndPropertyMismatch()
+	{
+		ClassWithParameterAndPropertyMismatch instance = new(42) { Comparer = 1 };
+		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Serialize(instance, TestContext.Current.CancellationToken));
+		NotSupportedException baseException = Assert.IsType<NotSupportedException>(ex.GetBaseException());
+		this.Logger.WriteLine(baseException.Message);
+	}
+
+	[GenerateShape]
+	public partial class ClassWithParameterAndPropertyMismatch
+	{
+		public ClassWithParameterAndPropertyMismatch(int capacity)
+		{
+		}
+
+		[Key(0)]
+		public int Comparer { get; init; }
+	}
+}


### PR DESCRIPTION
Instead of throwing a `KeyNotFoundException` which looks like an internal serializer bug, throw an exception with a message that explains exactly what's wrong with the target type and what the user can do about it.
