### PR TITLE
Dispose `StringWriter` when done with it

### DIFF
--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -540,7 +540,7 @@ public partial record MessagePackSerializer
 	/// </remarks>
 	public static string ConvertToJson(in ReadOnlySequence<byte> msgpack, JsonOptions? options = null)
 	{
-		StringWriter jsonWriter = new();
+		using StringWriter jsonWriter = new();
 		MessagePackReader reader = new(msgpack);
 		while (!reader.End)
 		{

--- a/src/Nerdbank.MessagePack/Sequence`1.cs
+++ b/src/Nerdbank.MessagePack/Sequence`1.cs
@@ -18,7 +18,7 @@ namespace Nerdbank.MessagePack;
 /// Instance members are not thread-safe.
 /// </remarks>
 [DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
-internal class Sequence<T> : IBufferWriter<T>, IDisposable
+internal sealed class Sequence<T> : IBufferWriter<T>, IDisposable
 {
 	private const int MaximumAutoGrowSize = 32 * 1024;
 

--- a/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
@@ -170,7 +170,7 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 #else
 		this.Serializer.Serialize(sequence, value, Witness.ShapeProvider);
 #endif
-		StringWriter jsonWriter = new();
+		using StringWriter jsonWriter = new();
 		MessagePackReader reader = new(sequence);
 		MessagePackSerializer.ConvertToJson(ref reader, jsonWriter, options);
 		return jsonWriter.ToString();


### PR DESCRIPTION
Thank you @Bykiev who found and shared a fix for a similar bug in MessagePack-CSharp/MessagePack-CSharp#2224.

Also mark `Sequence<T>` as sealed as a micro-optimization.