### PR TITLE
Make `ConvertToJson` instance methods

### DIFF
--- a/samples/cs/CustomConverters.cs
+++ b/samples/cs/CustomConverters.cs
@@ -501,7 +501,7 @@ namespace Stateful
             SpecialType original = new(5);
             Console.WriteLine($"Original value: {original}");
             byte[] msgpack = serializer.Serialize(original);
-            Console.WriteLine(MessagePackSerializer.ConvertToJson(msgpack));
+            Console.WriteLine(serializer.ConvertToJson(msgpack));
             SpecialType deserialized = serializer.Deserialize<SpecialType>(msgpack);
             Console.WriteLine($"Deserialized value: {deserialized}");
         }
@@ -543,7 +543,7 @@ namespace Stateful
             SpecialType original = new(5);
             Console.WriteLine($"Original value: {original}");
             byte[] msgpack = serializer.Serialize(original, Witness.ShapeProvider);
-            Console.WriteLine(MessagePackSerializer.ConvertToJson(msgpack));
+            Console.WriteLine(serializer.ConvertToJson(msgpack));
             SpecialType deserialized = serializer.Deserialize<SpecialType>(msgpack, Witness.ShapeProvider);
             Console.WriteLine($"Deserialized value: {deserialized}");
         }

--- a/samples/fs/Program.fs
+++ b/samples/fs/Program.fs
@@ -21,7 +21,7 @@ let msgpack =
     let refableValue = farm // need to pass by reference
     serializer.Serialize(&refableValue, ReflectionTypeShapeProvider.Default)
 
-MessagePackSerializer.ConvertToJson(msgpack) |> printfn "Farm as JSON: %s"
+serializer.ConvertToJson(msgpack) |> printfn "Farm as JSON: %s"
 
 let newFarm = serializer.Deserialize<Farm>(msgpack, ReflectionTypeShapeProvider.Default)
 

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -524,7 +524,7 @@ public partial record MessagePackSerializer
 		=> this.DeserializeAsync(Requires.NotNull(reader), Requires.NotNull(provider), this.ConverterCache.GetOrAddConverter<T>(provider), cancellationToken);
 
 	/// <inheritdoc cref="ConvertToJson(in ReadOnlySequence{byte}, JsonOptions?)"/>
-	public static string ConvertToJson(ReadOnlyMemory<byte> msgpack, JsonOptions? options = null) => ConvertToJson(new ReadOnlySequence<byte>(msgpack), options);
+	public string ConvertToJson(ReadOnlyMemory<byte> msgpack, JsonOptions? options = null) => this.ConvertToJson(new ReadOnlySequence<byte>(msgpack), options);
 
 	/// <summary>
 	/// Converts a msgpack sequence into equivalent JSON.
@@ -538,13 +538,13 @@ public partial record MessagePackSerializer
 	/// As such, this method is intended for debugging purposes rather than for production use.
 	/// </para>
 	/// </remarks>
-	public static string ConvertToJson(in ReadOnlySequence<byte> msgpack, JsonOptions? options = null)
+	public string ConvertToJson(in ReadOnlySequence<byte> msgpack, JsonOptions? options = null)
 	{
 		using StringWriter jsonWriter = new();
 		MessagePackReader reader = new(msgpack);
 		while (!reader.End)
 		{
-			ConvertToJson(ref reader, jsonWriter, options);
+			this.ConvertToJson(ref reader, jsonWriter, options);
 		}
 
 		return jsonWriter.ToString();
@@ -556,7 +556,7 @@ public partial record MessagePackSerializer
 	/// <param name="reader">A reader of the msgpack stream.</param>
 	/// <param name="jsonWriter">The writer that will receive JSON text.</param>
 	/// <param name="options">Options to customize how the JSON is written.</param>
-	public static void ConvertToJson(ref MessagePackReader reader, TextWriter jsonWriter, JsonOptions? options = null)
+	public void ConvertToJson(ref MessagePackReader reader, TextWriter jsonWriter, JsonOptions? options = null)
 	{
 		Requires.NotNull(jsonWriter);
 

--- a/test/AotNativeConsole/StreamingTree.cs
+++ b/test/AotNativeConsole/StreamingTree.cs
@@ -18,7 +18,7 @@ internal static class StreamingTree
 
 		byte[] bytes = serializer.Serialize(tree);
 
-		Console.WriteLine(MessagePackSerializer.ConvertToJson(bytes));
+		Console.WriteLine(serializer.ConvertToJson(bytes));
 
 		// synchronous deserialization
 		Tree deserializedTree = serializer.Deserialize<Tree>(bytes)!;

--- a/test/Nerdbank.MessagePack.SignalR.Tests/SerializationTests.cs
+++ b/test/Nerdbank.MessagePack.SignalR.Tests/SerializationTests.cs
@@ -10,15 +10,17 @@ using Xunit;
 
 public partial class SerializationTests
 {
+	protected MessagePackSerializer Serializer { get; } = new();
+
 	[Fact]
 	public void PingMessage_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 		PingMessage pingMessage = PingMessage.Instance;
 		ReadOnlyMemory<byte> bytes = protocol.GetMessageBytes(pingMessage);
 
 		ReadOnlySequence<byte> serializedSequence = new(bytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, new MockInvocationBinder(), out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -28,12 +30,12 @@ public partial class SerializationTests
 	[Fact]
 	public void CloseMessage_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 		CloseMessage closeMessage = new("test error", true);
 		ReadOnlyMemory<byte> bytes = protocol.GetMessageBytes(closeMessage);
 
 		ReadOnlySequence<byte> serializedSequence = new(bytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, new MockInvocationBinder(), out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -45,7 +47,7 @@ public partial class SerializationTests
 	[Fact]
 	public void InvocationMessage_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 
 		InvocationMessage invocationMessage = new("123", "TestMethod", new object[] { "hello", 42 });
 		ReadOnlyMemory<byte> invocationBytes = protocol.GetMessageBytes(invocationMessage);
@@ -59,7 +61,7 @@ public partial class SerializationTests
 			},
 		};
 		ReadOnlySequence<byte> serializedSequence = new(invocationBytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, binder, out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -74,7 +76,7 @@ public partial class SerializationTests
 	[Fact]
 	public void StreamInvocationMessage_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 
 		StreamInvocationMessage streamInvocationMessage = new("456", "StreamMethod", new object[] { "param1", 123 });
 		ReadOnlyMemory<byte> streamInvocationBytes = protocol.GetMessageBytes(streamInvocationMessage);
@@ -88,7 +90,7 @@ public partial class SerializationTests
 			},
 		};
 		ReadOnlySequence<byte> serializedSequence = new(streamInvocationBytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, binder, out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -103,7 +105,7 @@ public partial class SerializationTests
 	[Fact]
 	public void StreamItemMessage_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 
 		StreamItemMessage streamItemMessage = new("789", "stream item data");
 		ReadOnlyMemory<byte> streamItemBytes = protocol.GetMessageBytes(streamItemMessage);
@@ -117,7 +119,7 @@ public partial class SerializationTests
 			},
 		};
 		ReadOnlySequence<byte> serializedSequence = new(streamItemBytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, binder, out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -129,7 +131,7 @@ public partial class SerializationTests
 	[Fact]
 	public void CompletionMessage_WithResult_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 
 		CompletionMessage completionMessage = CompletionMessage.WithResult("101", "completion result");
 		ReadOnlyMemory<byte> completionBytes = protocol.GetMessageBytes(completionMessage);
@@ -143,7 +145,7 @@ public partial class SerializationTests
 			},
 		};
 		ReadOnlySequence<byte> serializedSequence = new(completionBytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, binder, out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -157,7 +159,7 @@ public partial class SerializationTests
 	[Fact]
 	public void CompletionMessage_WithError_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 
 		CompletionMessage completionMessage = CompletionMessage.WithError("102", "Something went wrong");
 		ReadOnlyMemory<byte> completionBytes = protocol.GetMessageBytes(completionMessage);
@@ -165,7 +167,7 @@ public partial class SerializationTests
 
 		MockInvocationBinder binder = new();
 		ReadOnlySequence<byte> serializedSequence = new(completionBytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, binder, out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -179,7 +181,7 @@ public partial class SerializationTests
 	[Fact]
 	public void CompletionMessage_Empty_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 
 		CompletionMessage completionMessage = CompletionMessage.Empty("103");
 		ReadOnlyMemory<byte> completionBytes = protocol.GetMessageBytes(completionMessage);
@@ -187,7 +189,7 @@ public partial class SerializationTests
 
 		MockInvocationBinder binder = new();
 		ReadOnlySequence<byte> serializedSequence = new(completionBytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, binder, out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -201,7 +203,7 @@ public partial class SerializationTests
 	[Fact]
 	public void CancelInvocationMessage_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 
 		CancelInvocationMessage cancelInvocationMessage = new("201");
 		ReadOnlyMemory<byte> cancelInvocationBytes = protocol.GetMessageBytes(cancelInvocationMessage);
@@ -209,7 +211,7 @@ public partial class SerializationTests
 
 		MockInvocationBinder binder = new();
 		ReadOnlySequence<byte> serializedSequence = new(cancelInvocationBytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, binder, out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -220,7 +222,7 @@ public partial class SerializationTests
 	[Fact]
 	public void AckMessage_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 
 		AckMessage ackMessage = new(42);
 		ReadOnlyMemory<byte> ackBytes = protocol.GetMessageBytes(ackMessage);
@@ -228,7 +230,7 @@ public partial class SerializationTests
 
 		MockInvocationBinder binder = new();
 		ReadOnlySequence<byte> serializedSequence = new(ackBytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, binder, out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -239,7 +241,7 @@ public partial class SerializationTests
 	[Fact]
 	public void SequenceMessage_Serialization()
 	{
-		IHubProtocol protocol = CreateProtocol();
+		IHubProtocol protocol = this.CreateProtocol();
 
 		SequenceMessage sequenceMessage = new(99);
 		ReadOnlyMemory<byte> sequenceBytes = protocol.GetMessageBytes(sequenceMessage);
@@ -247,7 +249,7 @@ public partial class SerializationTests
 
 		MockInvocationBinder binder = new();
 		ReadOnlySequence<byte> serializedSequence = new(sequenceBytes);
-		LogMsgPack(serializedSequence);
+		this.LogMsgPack(serializedSequence);
 		Assert.True(protocol.TryParseMessage(ref serializedSequence, binder, out HubMessage? message));
 		Assert.True(serializedSequence.IsEmpty);
 
@@ -255,14 +257,14 @@ public partial class SerializationTests
 		Assert.Equal(99, sequence.SequenceId);
 	}
 
-	private static void LogMsgPack(ReadOnlySequence<byte> payload)
+	private void LogMsgPack(ReadOnlySequence<byte> payload)
 	{
 		Assumes.True(BinaryMessageFormatter.TryParseMessage(ref payload, out ReadOnlySequence<byte> msgpack));
-		TestContext.Current.TestOutputHelper?.WriteLine(MessagePackSerializer.ConvertToJson(msgpack));
+		TestContext.Current.TestOutputHelper?.WriteLine(this.Serializer.ConvertToJson(msgpack));
 	}
 
-	private static IHubProtocol CreateProtocol(MessagePackSerializer? serializer = null)
-		=> TestUtilities.CreateHubProtocol(Witness.ShapeProvider, serializer);
+	private IHubProtocol CreateProtocol()
+		=> TestUtilities.CreateHubProtocol(Witness.ShapeProvider, this.Serializer);
 
 	[GenerateShapeFor<string>]
 	[GenerateShapeFor<int>]

--- a/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 {
 	[Fact]
@@ -21,7 +19,7 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 	/// Verifies the behavior of the simpler method that takes a buffer and returns a string.
 	/// </summary>
 	[Fact]
-	public void Sequence() => Assert.Equal("null", MessagePackSerializer.ConvertToJson(new([0xc0])));
+	public void Sequence() => Assert.Equal("null", this.Serializer.ConvertToJson(new([0xc0])));
 
 	[Fact]
 	public void Indented_Object_Tabs()
@@ -172,7 +170,7 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 #endif
 		using StringWriter jsonWriter = new();
 		MessagePackReader reader = new(sequence);
-		MessagePackSerializer.ConvertToJson(ref reader, jsonWriter, options);
+		this.Serializer.ConvertToJson(ref reader, jsonWriter, options);
 		return jsonWriter.ToString();
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/Converters/JsonDocumentConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/Converters/JsonDocumentConverterTests.cs
@@ -42,7 +42,7 @@ public partial class JsonDocumentConverterTests : MessagePackSerializerTestBase
 		byte[] msgpack = this.Serializer.Serialize<JsonDocument, Witness>(el, TestContext.Current.CancellationToken);
 		this.LogMsgPack(msgpack);
 
-		string converted = MessagePackSerializer.ConvertToJson(msgpack);
+		string converted = this.Serializer.ConvertToJson(msgpack);
 		Assert.Equal(Json, converted);
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/Converters/JsonElementConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/Converters/JsonElementConverterTests.cs
@@ -45,7 +45,7 @@ public partial class JsonElementConverterTests : MessagePackSerializerTestBase
 		byte[] msgpack = this.Serializer.Serialize<JsonElement, Witness>(el, TestContext.Current.CancellationToken);
 		this.LogMsgPack(msgpack);
 
-		string converted = MessagePackSerializer.ConvertToJson(msgpack);
+		string converted = this.Serializer.ConvertToJson(msgpack);
 		Assert.Equal(Json, converted);
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/DerivedTypeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/DerivedTypeTests.cs
@@ -92,7 +92,7 @@ public partial class DerivedTypeTests : MessagePackSerializerTestBase
 		// and the class cannot be deserialized because the constructor doesn't take a collection.
 		EnumerableDerived value = new(3) { BaseClassProperty = 5 };
 		byte[] msgpack = this.Serializer.Serialize<BaseClass>(value, TestContext.Current.CancellationToken);
-		this.Logger.WriteLine(MessagePackSerializer.ConvertToJson(msgpack));
+		this.Logger.WriteLine(this.Serializer.ConvertToJson(msgpack));
 	}
 
 	[Fact]

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
@@ -241,7 +241,7 @@ public abstract class MessagePackSerializerTestBase
 		JsonObject schema = this.Serializer.GetJsonSchema(shape);
 		string schemaString = SchemaToString(schema);
 		JSchema parsedSchema = JSchema.Parse(schemaString);
-		string json = MessagePackSerializer.ConvertToJson(msgpack);
+		string json = this.Serializer.ConvertToJson(msgpack);
 		var parsed = JsonNode.Parse(json);
 		try
 		{
@@ -259,6 +259,6 @@ public abstract class MessagePackSerializerTestBase
 
 	protected void LogMsgPack(ReadOnlySequence<byte> msgPack)
 	{
-		this.Logger.WriteLine(MessagePackSerializer.ConvertToJson(msgPack));
+		this.Logger.WriteLine(this.Serializer.ConvertToJson(msgPack));
 	}
 }

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
@@ -139,7 +139,7 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 	{
 		RecordWithReadOnlyProperties_NoConstructor obj = new(1, 2);
 		byte[] msgpack = this.Serializer.Serialize(obj, TestContext.Current.CancellationToken);
-		this.Logger.WriteLine(MessagePackSerializer.ConvertToJson(msgpack));
+		this.Logger.WriteLine(this.Serializer.ConvertToJson(msgpack));
 		MessagePackReader reader = new(msgpack);
 
 		// The Sum field should not be serialized.

--- a/test/Nerdbank.MessagePack.Tests/PrimitivesDerializationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/PrimitivesDerializationTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;
-using Microsoft.CSharp.RuntimeBinder;
 
 public partial class PrimitivesDerializationTests : MessagePackSerializerTestBase
 {
@@ -204,7 +203,7 @@ public partial class PrimitivesDerializationTests : MessagePackSerializerTestBas
 
 		writer.Flush();
 
-		this.Logger.WriteLine(MessagePackSerializer.ConvertToJson(seq));
+		this.Logger.WriteLine(this.Serializer.ConvertToJson(seq));
 		return new MessagePackReader(seq);
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/SchemaTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/SchemaTests.cs
@@ -15,7 +15,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.RegularExpressions;
 using DiffPlex;
 using DiffPlex.DiffBuilder;
 using DiffPlex.DiffBuilder.Model;
@@ -300,7 +299,7 @@ public partial class SchemaTests : MessagePackSerializerTestBase
 			foreach (T? item in sampleData)
 			{
 				byte[] msgpack = this.Serializer.Serialize(item);
-				string json = MessagePackSerializer.ConvertToJson(msgpack);
+				string json = this.Serializer.ConvertToJson(msgpack);
 				this.Logger.WriteLine($"Sample data {++sampleCounter}:");
 				var parsed = JsonNode.Parse(json);
 				this.Logger.WriteLine(parsed is null ? "null" : parsed.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));


### PR DESCRIPTION
As `static` methods, they cannot access the `MessagePackSerializer.LibraryExtensionTypeCodes` property. That's not important right _now_, but it will likely be important down the road.

Closes #577