### PR TITLE
Use custom msgpack extensions for .NET "primitive" types

### DIFF
--- a/docfx/docs/migrating.md
+++ b/docfx/docs/migrating.md
@@ -215,7 +215,7 @@ LE and BE refer to Little Endian and Big Endian, respectively.
 
 Data type | MessagePack-CSharp | Nerdbank.MessagePack
 --|--|--
-<xref:System.Guid> | 16-byte bin LE or string | 16-byte [Ext](xref:Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.GuidLittleEndian) LE or string
+<xref:System.Guid> | 16-byte bin LE or string | 16-byte [Ext](xref:Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.Guid) BE or string
 <xref:System.Int128> | 16-byte bin LE | int format if it fits, otherwise 16-byte [Ext](xref:Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.Int128) BE
 <xref:System.UInt128> | 16-byte bin LE | int format if it fits, otherwise 16-byte [Ext](xref:Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.UInt128) BE
 <xref:System.Decimal> | 16-byte bin LE, [MS-OAUT 2.2.26 DECIMAL](https://learn.microsoft.com/openspecs/windows_protocols/ms-oaut/b5493025-e447-4109-93a8-ac29c48d018d) | 16-byte [Ext](xref:Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.Decimal) LE, [MS-OAUT 2.2.26 DECIMAL](https://learn.microsoft.com/openspecs/windows_protocols/ms-oaut/b5493025-e447-4109-93a8-ac29c48d018d)

--- a/docfx/docs/migrating.md
+++ b/docfx/docs/migrating.md
@@ -219,7 +219,7 @@ Data type | MessagePack-CSharp | Nerdbank.MessagePack
 <xref:System.Int128> | 16-byte bin LE | int format if it fits, otherwise 16-byte [Ext](xref:Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.Int128) BE
 <xref:System.UInt128> | 16-byte bin LE | int format if it fits, otherwise 16-byte [Ext](xref:Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.UInt128) BE
 <xref:System.Decimal> | 16-byte bin LE, [MS-OAUT 2.2.26 DECIMAL](https://learn.microsoft.com/openspecs/windows_protocols/ms-oaut/b5493025-e447-4109-93a8-ac29c48d018d) | 16-byte [Ext](xref:Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.Decimal) LE, [MS-OAUT 2.2.26 DECIMAL](https://learn.microsoft.com/openspecs/windows_protocols/ms-oaut/b5493025-e447-4109-93a8-ac29c48d018d)
-<xref:System.Numerics.BigInteger> | Bin LE with twos-complement bytes, using the fewest number of bytes possible | int format if it fits, otherwise [Ext](xref:Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.BigIntegerLittleEndian) LE with twos-complement bytes, using the fewest number of bytes possible
+<xref:System.Numerics.BigInteger> | Bin LE with twos-complement bytes, using the fewest number of bytes possible | int format if it fits, otherwise [Ext](xref:Nerdbank.MessagePack.LibraryReservedMessagePackExtensionTypeCode.BigInteger) BE with twos-complement bytes, using the fewest number of bytes possible
 
 ### .NET classes and structs with members
 

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
@@ -947,7 +947,8 @@ internal class GuidAsLittleEndianBinaryConverter : MessagePackConverter<Guid>
 	public override Guid Read(ref MessagePackReader reader, SerializationContext context)
 	{
 		sbyte typeCode = LibraryReservedMessagePackExtensionTypeCode.ToByte(context.ExtensionTypeCodes.GuidLittleEndian);
-		ReadOnlySequence<byte> bytes = reader.ReadExtension(typeCode);
+		ReadOnlySequence<byte> bytes = reader.NextMessagePackType == MessagePackType.Binary
+			? reader.ReadBytes()!.Value : reader.ReadExtension(typeCode);
 
 		if (bytes.IsSingleSegment)
 		{

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
@@ -599,7 +599,8 @@ internal class BigIntegerConverter : MessagePackConverter<BigInteger>
 			return MessagePackCode.IsSignedInteger(reader.NextCode) ? (BigInteger)reader.ReadInt64() : (BigInteger)reader.ReadUInt64();
 		}
 
-		ReadOnlySequence<byte> bytes = reader.ReadExtension(typeCode);
+		ReadOnlySequence<byte> bytes = reader.NextMessagePackType == MessagePackType.Binary
+			? reader.ReadBytes()!.Value : reader.ReadExtension(typeCode);
 #if NET
 		if (bytes.IsSingleSegment)
 		{

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
@@ -478,9 +478,9 @@ internal class Int128Converter : MessagePackConverter<Int128>
 		}
 
 		ReadOnlySequence<byte> sequence = reader.ReadExtension(typeCode);
-		if (sequence.Length != sizeof(ulong) * 2)
+		if (sequence.Length != Size)
 		{
-			throw new MessagePackSerializationException($"Expected {sizeof(ulong) * 2} bytes but got {sequence.Length}.");
+			throw new MessagePackSerializationException($"Expected {Size} bytes but got {sequence.Length}.");
 		}
 
 		if (sequence.IsSingleSegment)
@@ -489,7 +489,7 @@ internal class Int128Converter : MessagePackConverter<Int128>
 		}
 		else
 		{
-			Span<byte> bytesSpan = stackalloc byte[sizeof(ulong) * 2];
+			Span<byte> bytesSpan = stackalloc byte[Size];
 			sequence.CopyTo(bytesSpan);
 			return BinaryPrimitives.ReadInt128BigEndian(bytesSpan);
 		}
@@ -517,10 +517,9 @@ internal class Int128Converter : MessagePackConverter<Int128>
 		}
 
 #pragma warning disable NBMsgPack031 // only write one structure
-		writer.Write(new ExtensionHeader(typeCode, sizeof(ulong) * 2));
-		Span<byte> span = writer.GetSpan(sizeof(ulong) * 2);
-		BinaryPrimitives.WriteInt128BigEndian(span, value);
-		writer.Advance(span.Length);
+		writer.Write(new ExtensionHeader(typeCode, Size));
+		BinaryPrimitives.WriteInt128BigEndian(writer.GetSpan(Size), value);
+		writer.Advance(Size);
 #pragma warning restore NBMsgPack031 // only write one structure
 	}
 
@@ -591,12 +590,12 @@ internal class UInt128Converter : MessagePackConverter<UInt128>
 		}
 
 		ReadOnlySequence<byte> sequence = reader.ReadExtension(typeCode);
-		if (sequence.Length != sizeof(ulong) * 2)
+		if (sequence.Length != Size)
 		{
-			throw new MessagePackSerializationException($"Expected {sizeof(ulong) * 2} bytes but got {sequence.Length}.");
+			throw new MessagePackSerializationException($"Expected {Size} bytes but got {sequence.Length}.");
 		}
 
-		Span<byte> bytesSpan = stackalloc byte[sizeof(ulong) * 2];
+		Span<byte> bytesSpan = stackalloc byte[Size];
 		sequence.CopyTo(bytesSpan);
 		UInt128 value = MemoryMarshal.Cast<byte, UInt128>(bytesSpan)[0];
 		return BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value;
@@ -618,7 +617,7 @@ internal class UInt128Converter : MessagePackConverter<UInt128>
 
 		ReadOnlySpan<UInt128> valueAsSpan = BitConverter.IsLittleEndian ? [BinaryPrimitives.ReverseEndianness(value)] : [value];
 #pragma warning disable NBMsgPack031 // only write one structure
-		writer.Write(new ExtensionHeader(typeCode, sizeof(ulong) * 2));
+		writer.Write(new ExtensionHeader(typeCode, Size));
 		writer.WriteRaw(MemoryMarshal.Cast<UInt128, byte>(valueAsSpan));
 #pragma warning restore NBMsgPack031 // only write one structure
 	}

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverters.cs
@@ -514,7 +514,7 @@ internal class BigIntegerConverter : MessagePackConverter<BigInteger>
 	{
 		// Fail fast if the user hasn't reserved a type code these values,
 		// even if this particular value might fit in a native integer type.
-		sbyte typeCode = LibraryReservedMessagePackExtensionTypeCode.ToByte(context.ExtensionTypeCodes.BigInteger);
+		sbyte typeCode = LibraryReservedMessagePackExtensionTypeCode.ToByte(context.ExtensionTypeCodes.BigIntegerLittleEndian);
 
 		if (reader.NextMessagePackType == MessagePackType.Integer)
 		{
@@ -550,7 +550,7 @@ internal class BigIntegerConverter : MessagePackConverter<BigInteger>
 	{
 		// Fail fast if the user hasn't reserved a type code these values,
 		// even if this particular value might fit in a native integer type.
-		sbyte typeCode = LibraryReservedMessagePackExtensionTypeCode.ToByte(context.ExtensionTypeCodes.BigInteger);
+		sbyte typeCode = LibraryReservedMessagePackExtensionTypeCode.ToByte(context.ExtensionTypeCodes.BigIntegerLittleEndian);
 
 		// Prefer to write out BigInteger values as integers if they fit.
 		if (value >= long.MinValue && value <= long.MaxValue)
@@ -579,7 +579,7 @@ internal class BigIntegerConverter : MessagePackConverter<BigInteger>
 	public override JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape) => new JsonObject
 	{
 		["oneOf"] = new JsonArray(
-			CreateMsgPackExtensionSchema(LibraryReservedMessagePackExtensionTypeCode.ToByte(context.ExtensionTypeCodes.BigInteger)),
+			CreateMsgPackExtensionSchema(LibraryReservedMessagePackExtensionTypeCode.ToByte(context.ExtensionTypeCodes.BigIntegerLittleEndian)),
 			new JsonObject() { ["type"] = "integer" }),
 		["description"] = "A BigInteger",
 	};

--- a/src/Nerdbank.MessagePack/JsonSchemaContext.cs
+++ b/src/Nerdbank.MessagePack/JsonSchemaContext.cs
@@ -21,15 +21,22 @@ public class JsonSchemaContext
 	/// Initializes a new instance of the <see cref="JsonSchemaContext"/> class.
 	/// </summary>
 	/// <param name="cache">The <see cref="ConverterCache"/> object from which the JSON schema is being retrieved.</param>
-	internal JsonSchemaContext(ConverterCache cache)
+	/// <param name="extensionTypeCodes">The extension type codes to use for library-reserved extension types.</param>
+	internal JsonSchemaContext(ConverterCache cache, LibraryReservedMessagePackExtensionTypeCode extensionTypeCodes)
 	{
 		this.cache = cache;
+		this.ExtensionTypeCodes = extensionTypeCodes;
 	}
 
 	/// <summary>
 	/// Gets the referenceable schema definitions that should be included in the top-level schema.
 	/// </summary>
 	internal IReadOnlyDictionary<string, JsonObject> SchemaDefinitions => this.schemaDefinitions;
+
+	/// <summary>
+	/// Gets the extension type codes to use for library-reserved extension types.
+	/// </summary>
+	internal LibraryReservedMessagePackExtensionTypeCode ExtensionTypeCodes { get; }
 
 	/// <summary>
 	/// Obtains the JSON schema for a given type.

--- a/src/Nerdbank.MessagePack/MessagePackCode.cs
+++ b/src/Nerdbank.MessagePack/MessagePackCode.cs
@@ -283,7 +283,13 @@ public static class ReservedMessagePackExtensionTypeCode
 /// to avoid conflicting with those defined by the application or another library.
 /// </summary>
 /// <remarks>
+/// <para>
 /// All values must be non-negative to avoid conflicting with the official extension type codes as described in <see cref="ReservedMessagePackExtensionTypeCode"/>.
+/// </para>
+/// <para>
+/// A <see langword="null"/> value will disable the use of that extension type code,
+/// leading the library to either prefer a msgpack standardized encoding for the data type or fail when that data type is used.
+/// </para>
 /// </remarks>
 public record LibraryReservedMessagePackExtensionTypeCode
 {
@@ -296,7 +302,7 @@ public record LibraryReservedMessagePackExtensionTypeCode
 	/// Gets the extension type code for a reference to an object that has already been serialized in the same stream.
 	/// </summary>
 	/// <value>The default value is 1.</value>
-	public sbyte ObjectReference { get; init; } = 1;
+	public sbyte? ObjectReference { get; init; } = 1;
 }
 
 internal static class MessagePackRange

--- a/src/Nerdbank.MessagePack/MessagePackCode.cs
+++ b/src/Nerdbank.MessagePack/MessagePackCode.cs
@@ -340,6 +340,40 @@ public record LibraryReservedMessagePackExtensionTypeCode
 	/// </remarks>
 	public sbyte? Decimal { get; init; } = 4;
 
+#if NET
+	/// <summary>
+	/// Gets the extension type code for a <see cref="Int128" /> value.
+	/// </summary>
+	/// <remarks>
+	/// The encoding is a big endian 128-bit signed integer.
+	/// </remarks>
+#else
+	/// <summary>
+	/// Gets the extension type code for a Int128 value.
+	/// </summary>
+	/// <remarks>
+	/// The encoding is a big endian 128-bit signed integer.
+	/// </remarks>
+#endif
+	public sbyte? Int128 { get; init; } = 5;
+
+#if NET
+	/// <summary>
+	/// Gets the extension type code for a <see cref="UInt128" /> value.
+	/// </summary>
+	/// <remarks>
+	/// The encoding is a big endian 128-bit unsigned integer.
+	/// </remarks>
+#else
+	/// <summary>
+	/// Gets the extension type code for a UInt128 value.
+	/// </summary>
+	/// <remarks>
+	/// The encoding is a big endian 128-bit unsigned integer.
+	/// </remarks>
+#endif
+	public sbyte? UInt128 { get; init; } = 6;
+
 	internal static sbyte ToByte(sbyte? value) => value ?? throw new InvalidOperationException("This extension type code is disabled.");
 }
 

--- a/src/Nerdbank.MessagePack/MessagePackCode.cs
+++ b/src/Nerdbank.MessagePack/MessagePackCode.cs
@@ -305,13 +305,13 @@ public record LibraryReservedMessagePackExtensionTypeCode
 	public sbyte? ObjectReference { get; init; } = 1;
 
 	/// <summary>
-	/// Gets the extension type code for a <see cref="Guid" /> value.
+	/// Gets the extension type code for a <see cref="System.Guid" /> value.
 	/// </summary>
 	/// <value>The default value is 2.</value>
 	/// <remarks>
-	/// Encoded in a little endian binary format.
+	/// Encoded in a big endian binary format.
 	/// </remarks>
-	public sbyte? GuidLittleEndian { get; init; } = 2;
+	public sbyte? Guid { get; init; } = 2;
 
 	/// <summary>
 	/// Gets the extension type code for a <see cref="System.Numerics.BigInteger" /> value.

--- a/src/Nerdbank.MessagePack/MessagePackCode.cs
+++ b/src/Nerdbank.MessagePack/MessagePackCode.cs
@@ -303,6 +303,17 @@ public record LibraryReservedMessagePackExtensionTypeCode
 	/// </summary>
 	/// <value>The default value is 1.</value>
 	public sbyte? ObjectReference { get; init; } = 1;
+
+	/// <summary>
+	/// Gets the extension type code for a <see cref="Guid" /> value.
+	/// </summary>
+	/// <value>The default value is 2.</value>
+	/// <remarks>
+	/// Encoded in a little endian binary format.
+	/// </remarks>
+	public sbyte? GuidLittleEndian { get; init; } = 2;
+
+	internal static sbyte ToByte(sbyte? value) => value ?? throw new InvalidOperationException("This extension type code is disabled.");
 }
 
 internal static class MessagePackRange

--- a/src/Nerdbank.MessagePack/MessagePackCode.cs
+++ b/src/Nerdbank.MessagePack/MessagePackCode.cs
@@ -328,15 +328,8 @@ public record LibraryReservedMessagePackExtensionTypeCode
 	/// </summary>
 	/// <value>The default value is 4.</value>
 	/// <remarks>
-	/// The encoding is an integer array with four elements (encoded as 16 bytes with little endian encoding).
-	/// Elements 0, 1, and 2 contain the low,
-	/// middle, and high 32 bits of the 96-bit integer part of the Decimal.
-	/// Element 3 contains the scale factor and sign of the Decimal: bits 0-15
-	/// (the lower word) are unused; bits 16-23 contain a value between 0 and
-	/// 28, indicating the power of 10 to divide the 96-bit integer part by to
-	/// produce the Decimal value; bits 24-30 are unused; and finally bit 31
-	/// indicates the sign of the Decimal value, 0 meaning positive and 1
-	/// meaning negative.
+	/// The encoding matches <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-oaut/b5493025-e447-4109-93a8-ac29c48d018d">the MS-OAUT 2.2.26 DECIMAL specification</see>,
+	/// constrained to always use little-endian byte order.
 	/// </remarks>
 	public sbyte? Decimal { get; init; } = 4;
 

--- a/src/Nerdbank.MessagePack/MessagePackCode.cs
+++ b/src/Nerdbank.MessagePack/MessagePackCode.cs
@@ -321,7 +321,7 @@ public record LibraryReservedMessagePackExtensionTypeCode
 	/// The value is encoded as little-endian twos-complement bytes, using the fewest number of bytes possible.
 	/// If the value is zero, outputs one byte whose element is 0x00.
 	/// </remarks>
-	public sbyte? BigInteger { get; init; } = 3;
+	public sbyte? BigIntegerLittleEndian { get; init; } = 3;
 
 	/// <summary>
 	/// Gets the extension type code for a <see cref="decimal" /> value.

--- a/src/Nerdbank.MessagePack/MessagePackCode.cs
+++ b/src/Nerdbank.MessagePack/MessagePackCode.cs
@@ -313,6 +313,16 @@ public record LibraryReservedMessagePackExtensionTypeCode
 	/// </remarks>
 	public sbyte? GuidLittleEndian { get; init; } = 2;
 
+	/// <summary>
+	/// Gets the extension type code for a <see cref="System.Numerics.BigInteger" /> value.
+	/// </summary>
+	/// <value>The default value is 3.</value>
+	/// <remarks>
+	/// The value is encoded as little-endian twos-complement bytes, using the fewest number of bytes possible.
+	/// If the value is zero, outputs one byte whose element is 0x00.
+	/// </remarks>
+	public sbyte? BigInteger { get; init; } = 3;
+
 	internal static sbyte ToByte(sbyte? value) => value ?? throw new InvalidOperationException("This extension type code is disabled.");
 }
 

--- a/src/Nerdbank.MessagePack/MessagePackCode.cs
+++ b/src/Nerdbank.MessagePack/MessagePackCode.cs
@@ -323,6 +323,23 @@ public record LibraryReservedMessagePackExtensionTypeCode
 	/// </remarks>
 	public sbyte? BigInteger { get; init; } = 3;
 
+	/// <summary>
+	/// Gets the extension type code for a <see cref="decimal" /> value.
+	/// </summary>
+	/// <value>The default value is 4.</value>
+	/// <remarks>
+	/// The encoding is an integer array with four elements (encoded as 16 bytes with little endian encoding).
+	/// Elements 0, 1, and 2 contain the low,
+	/// middle, and high 32 bits of the 96-bit integer part of the Decimal.
+	/// Element 3 contains the scale factor and sign of the Decimal: bits 0-15
+	/// (the lower word) are unused; bits 16-23 contain a value between 0 and
+	/// 28, indicating the power of 10 to divide the 96-bit integer part by to
+	/// produce the Decimal value; bits 24-30 are unused; and finally bit 31
+	/// indicates the sign of the Decimal value, 0 meaning positive and 1
+	/// meaning negative.
+	/// </remarks>
+	public sbyte? Decimal { get; init; } = 4;
+
 	internal static sbyte ToByte(sbyte? value) => value ?? throw new InvalidOperationException("This extension type code is disabled.");
 }
 

--- a/src/Nerdbank.MessagePack/MessagePackCode.cs
+++ b/src/Nerdbank.MessagePack/MessagePackCode.cs
@@ -318,10 +318,10 @@ public record LibraryReservedMessagePackExtensionTypeCode
 	/// </summary>
 	/// <value>The default value is 3.</value>
 	/// <remarks>
-	/// The value is encoded as little-endian twos-complement bytes, using the fewest number of bytes possible.
+	/// The value is encoded as big-endian twos-complement bytes, using the fewest number of bytes possible.
 	/// If the value is zero, outputs one byte whose element is 0x00.
 	/// </remarks>
-	public sbyte? BigIntegerLittleEndian { get; init; } = 3;
+	public sbyte? BigInteger { get; init; } = 3;
 
 	/// <summary>
 	/// Gets the extension type code for a <see cref="decimal" /> value.

--- a/src/Nerdbank.MessagePack/MessagePackSerializationException.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializationException.cs
@@ -69,6 +69,17 @@ public class MessagePackSerializationException : Exception
 		/// Deserialization failed because the data specified multiple values for a single property.
 		/// </summary>
 		DoublePropertyAssignment,
+
+		/// <summary>
+		/// Deserialization failed because the data contained a token that was not expected at this time.
+		/// </summary>
+		UnexpectedToken,
+
+		/// <summary>
+		/// Deserialization failed because a <see cref="ExtensionHeader.TypeCode"/> was encountered
+		/// that the deserializer was not expecting.
+		/// </summary>
+		UnexpectedExtensionTypeCode,
 	}
 
 	/// <summary>

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.GetSchema.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.GetSchema.cs
@@ -55,16 +55,16 @@ public partial record MessagePackSerializer
 			throw new NotSupportedException($"Schema generation is not supported when {nameof(this.PreserveReferences)} is enabled.");
 		}
 
-		return new JsonSchemaGenerator(this.ConverterCache).GenerateSchema(typeShape);
+		return new JsonSchemaGenerator(this.ConverterCache, this.LibraryExtensionTypeCodes).GenerateSchema(typeShape);
 	}
 
 	private sealed class JsonSchemaGenerator : ITypeShapeFunc
 	{
 		private readonly JsonSchemaContext context;
 
-		internal JsonSchemaGenerator(ConverterCache cache)
+		internal JsonSchemaGenerator(ConverterCache cache, LibraryReservedMessagePackExtensionTypeCode extensionTypeCodes)
 		{
-			this.context = new JsonSchemaContext(cache);
+			this.context = new JsonSchemaContext(cache, extensionTypeCodes);
 		}
 
 		object? ITypeShapeFunc.Invoke<T>(ITypeShape<T> typeShape, object? state) => this.context.GetJsonSchema(typeShape);

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -684,7 +684,7 @@ public partial record MessagePackSerializer
 							break;
 						}
 
-						if (extensionHeader.TypeCode == extensionTypeCodes.BigIntegerLittleEndian)
+						if (extensionHeader.TypeCode == extensionTypeCodes.BigInteger)
 						{
 							jsonWriter.Write(BigIntegerConverter.Instance.Read(ref reader, context).ToString());
 							break;

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -695,6 +695,20 @@ public partial record MessagePackSerializer
 							jsonWriter.Write(MessagePack.Converters.DecimalConverter.Instance.Read(ref reader, context).ToString(CultureInfo.InvariantCulture));
 							break;
 						}
+
+#if NET
+						if (extensionHeader.TypeCode == extensionTypeCodes.Int128)
+						{
+							jsonWriter.Write(MessagePack.Converters.Int128Converter.Instance.Read(ref reader, context).ToString(CultureInfo.InvariantCulture));
+							break;
+						}
+
+						if (extensionHeader.TypeCode == extensionTypeCodes.UInt128)
+						{
+							jsonWriter.Write(MessagePack.Converters.UInt128Converter.Instance.Read(ref reader, context).ToString(CultureInfo.InvariantCulture));
+							break;
+						}
+#endif
 					}
 
 					Extension extension = reader.ReadExtension();

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -671,13 +671,18 @@ public partial record MessagePackSerializer
 					jsonWriter.Write('\"');
 					break;
 				case MessagePackType.Extension:
+					SerializationContext context = new() { ExtensionTypeCodes = extensionTypeCodes };
 					MessagePackReader peek = reader.CreatePeekReader();
 					ExtensionHeader extensionHeader = peek.ReadExtensionHeader();
 					if (extensionHeader.TypeCode == extensionTypeCodes.GuidLittleEndian)
 					{
 						jsonWriter.Write('\"');
-						jsonWriter.Write(GuidAsLittleEndianBinaryConverter.Instance.Read(ref reader, new SerializationContext { ExtensionTypeCodes = extensionTypeCodes }).ToString("D"));
+						jsonWriter.Write(GuidAsLittleEndianBinaryConverter.Instance.Read(ref reader, context).ToString("D"));
 						jsonWriter.Write('\"');
+					}
+					else if (extensionHeader.TypeCode == extensionTypeCodes.BigInteger)
+					{
+						jsonWriter.Write(BigIntegerConverter.Instance.Read(ref reader, context).ToString());
 					}
 					else
 					{

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -684,7 +684,7 @@ public partial record MessagePackSerializer
 							break;
 						}
 
-						if (extensionHeader.TypeCode == extensionTypeCodes.BigInteger)
+						if (extensionHeader.TypeCode == extensionTypeCodes.BigIntegerLittleEndian)
 						{
 							jsonWriter.Write(BigIntegerConverter.Instance.Read(ref reader, context).ToString());
 							break;

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -676,10 +676,10 @@ public partial record MessagePackSerializer
 					ExtensionHeader extensionHeader = peek.ReadExtensionHeader();
 					if (!options.IgnoreKnownExtensions)
 					{
-						if (extensionHeader.TypeCode == extensionTypeCodes.GuidLittleEndian)
+						if (extensionHeader.TypeCode == extensionTypeCodes.Guid)
 						{
 							jsonWriter.Write('\"');
-							jsonWriter.Write(GuidAsLittleEndianBinaryConverter.Instance.Read(ref reader, context).ToString("D"));
+							jsonWriter.Write(GuidAsBinaryConverter.Instance.Read(ref reader, context).ToString("D"));
 							jsonWriter.Write('\"');
 							break;
 						}

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -684,6 +684,10 @@ public partial record MessagePackSerializer
 					{
 						jsonWriter.Write(BigIntegerConverter.Instance.Read(ref reader, context).ToString());
 					}
+					else if (extensionHeader.TypeCode == extensionTypeCodes.Decimal)
+					{
+						jsonWriter.Write(MessagePack.Converters.DecimalConverter.Instance.Read(ref reader, context).ToString(CultureInfo.InvariantCulture));
+					}
 					else
 					{
 						Extension extension = reader.ReadExtension();

--- a/src/Nerdbank.MessagePack/OptionalConverters.cs
+++ b/src/Nerdbank.MessagePack/OptionalConverters.cs
@@ -101,7 +101,10 @@ public static class OptionalConverters
 	/// Adds a converter for <see cref="Guid"/> to the specified serializer.
 	/// </summary>
 	/// <param name="serializer">The serializer to add converters to.</param>
-	/// <param name="format">The format in which the <see cref="Guid"/> should be written.</param>
+	/// <param name="format">
+	/// The format in which the <see cref="Guid"/> should be written.
+	/// All string-based formats can <em>read</em> all other string-based formats.
+	/// </param>
 	/// <returns>The modified serializer.</returns>
 	/// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="format"/> is not one of the allowed values.</exception>
 	/// <exception cref="ArgumentException">Thrown if a converter for <see cref="Guid"/> has already been added.</exception>

--- a/src/Nerdbank.MessagePack/OptionalConverters.cs
+++ b/src/Nerdbank.MessagePack/OptionalConverters.cs
@@ -66,12 +66,12 @@ public static class OptionalConverters
 		StringX,
 
 		/// <summary>
-		/// The <see cref="Guid"/> will be stored in a compact 16 byte binary representation, in little endian order.
+		/// The <see cref="Guid"/> will be stored in a compact 16 byte binary representation.
 		/// </summary>
 		/// <remarks>
-		/// This is encoded as a messagepack extension using the type code specified in <see cref="LibraryReservedMessagePackExtensionTypeCode.GuidLittleEndian"/>.
+		/// This is encoded as a messagepack extension using the type code specified in <see cref="LibraryReservedMessagePackExtensionTypeCode.Guid"/>.
 		/// </remarks>
-		LittleEndian,
+		Binary,
 	}
 
 	/// <summary>
@@ -111,7 +111,7 @@ public static class OptionalConverters
 	/// <remarks>
 	/// The <see cref="Guid"/> converter is optimized to avoid allocating strings during the conversion.
 	/// </remarks>
-	public static MessagePackSerializer WithGuidConverter(this MessagePackSerializer serializer, GuidFormat format = GuidFormat.LittleEndian)
+	public static MessagePackSerializer WithGuidConverter(this MessagePackSerializer serializer, GuidFormat format = GuidFormat.Binary)
 	{
 		Requires.NotNull(serializer, nameof(serializer));
 		return serializer with
@@ -124,7 +124,7 @@ public static class OptionalConverters
 					GuidFormat.StringB => new GuidAsStringConverter { Format = 'B' },
 					GuidFormat.StringP => new GuidAsStringConverter { Format = 'P' },
 					GuidFormat.StringX => new GuidAsStringConverter { Format = 'X' },
-					GuidFormat.LittleEndian => GuidAsLittleEndianBinaryConverter.Instance,
+					GuidFormat.Binary => GuidAsBinaryConverter.Instance,
 					_ => throw new ArgumentOutOfRangeException(nameof(format), format, null),
 				},
 			],

--- a/src/Nerdbank.MessagePack/OptionalConverters.cs
+++ b/src/Nerdbank.MessagePack/OptionalConverters.cs
@@ -68,7 +68,10 @@ public static class OptionalConverters
 		/// <summary>
 		/// The <see cref="Guid"/> will be stored in a compact 16 byte binary representation, in little endian order.
 		/// </summary>
-		BinaryLittleEndian,
+		/// <remarks>
+		/// This is encoded as a messagepack extension using the type code specified in <see cref="LibraryReservedMessagePackExtensionTypeCode.GuidLittleEndian"/>.
+		/// </remarks>
+		LittleEndian,
 	}
 
 	/// <summary>
@@ -105,7 +108,7 @@ public static class OptionalConverters
 	/// <remarks>
 	/// The <see cref="Guid"/> converter is optimized to avoid allocating strings during the conversion.
 	/// </remarks>
-	public static MessagePackSerializer WithGuidConverter(this MessagePackSerializer serializer, GuidFormat format = GuidFormat.BinaryLittleEndian)
+	public static MessagePackSerializer WithGuidConverter(this MessagePackSerializer serializer, GuidFormat format = GuidFormat.LittleEndian)
 	{
 		Requires.NotNull(serializer, nameof(serializer));
 		return serializer with
@@ -118,7 +121,7 @@ public static class OptionalConverters
 					GuidFormat.StringB => new GuidAsStringConverter { Format = 'B' },
 					GuidFormat.StringP => new GuidAsStringConverter { Format = 'P' },
 					GuidFormat.StringX => new GuidAsStringConverter { Format = 'X' },
-					GuidFormat.BinaryLittleEndian => GuidAsLittleEndianBinaryConverter.Instance,
+					GuidFormat.LittleEndian => GuidAsLittleEndianBinaryConverter.Instance,
 					_ => throw new ArgumentOutOfRangeException(nameof(format), format, null),
 				},
 			],

--- a/src/Nerdbank.MessagePack/SerializationContext.cs
+++ b/src/Nerdbank.MessagePack/SerializationContext.cs
@@ -23,6 +23,7 @@ namespace Nerdbank.MessagePack;
 public record struct SerializationContext
 {
 	private ImmutableDictionary<object, object?> specialState = ImmutableDictionary<object, object?>.Empty;
+	private LibraryReservedMessagePackExtensionTypeCode? extensionTypeCodes;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="SerializationContext"/> struct.
@@ -61,6 +62,15 @@ public record struct SerializationContext
 	/// Gets the type shape provider that applies to the serialization operation.
 	/// </summary>
 	public ITypeShapeProvider? TypeShapeProvider { get; internal init; }
+
+	/// <summary>
+	/// Gets the extension type codes to use for library-reserved extension types.
+	/// </summary>
+	internal LibraryReservedMessagePackExtensionTypeCode ExtensionTypeCodes
+	{
+		get => this.extensionTypeCodes ?? throw new InvalidOperationException();
+		init => this.extensionTypeCodes = value;
+	}
 
 	/// <summary>
 	/// Gets the <see cref="MessagePackSerializer"/> that owns this context.
@@ -248,6 +258,7 @@ public record struct SerializationContext
 		return this with
 		{
 			Cache = cache,
+			ExtensionTypeCodes = owner.LibraryExtensionTypeCodes,
 			ReferenceEqualityTracker = cache.PreserveReferences != ReferencePreservationMode.Off ? ReusableObjectPool<ReferenceEqualityTracker>.Take(owner) : null,
 			TypeShapeProvider = provider,
 			CancellationToken = cancellationToken,

--- a/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
@@ -274,7 +274,7 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 	public void Guid_FromBin()
 	{
 		Assert.SkipUnless(BitConverter.IsLittleEndian, "This test is written assuming little-endian.");
-		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.LittleEndian);
+		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.Binary);
 
 		Span<Guid> valueSpan = [System.Guid.NewGuid()];
 		Sequence<byte> seq = new();

--- a/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
@@ -47,7 +47,34 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 	public void Decimal() => this.AssertRoundtrip(new HasDecimal(1.2m));
 
 	[Fact]
-	public void BigInteger() => this.AssertRoundtrip(new HasBigInteger(1));
+	public void BigInteger()
+	{
+		this.AssertRoundtrip(new HasBigInteger(1));
+		AssertType(MessagePackType.Integer);
+
+		this.AssertRoundtrip(new HasBigInteger(ulong.MaxValue));
+		AssertType(MessagePackType.Integer);
+
+		this.AssertRoundtrip(new HasBigInteger(ulong.MinValue));
+		AssertType(MessagePackType.Integer);
+
+		this.AssertRoundtrip(new HasBigInteger(long.MaxValue));
+		AssertType(MessagePackType.Integer);
+
+		this.AssertRoundtrip(new HasBigInteger(long.MinValue));
+		AssertType(MessagePackType.Integer);
+
+		this.AssertRoundtrip(new HasBigInteger(new BigInteger(ulong.MaxValue) * 3));
+		AssertType(MessagePackType.Extension);
+
+		void AssertType(MessagePackType expectedType)
+		{
+			MessagePackReader reader = new(this.lastRoundtrippedMsgpack);
+			reader.ReadMapHeader();
+			reader.ReadString();
+			Assert.Equal(expectedType, reader.NextMessagePackType);
+		}
+	}
 
 	[Theory, PairwiseData]
 	public void Guid(OptionalConverters.GuidFormat format)

--- a/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
@@ -141,6 +141,23 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 		this.AssertType(MessagePackType.Extension);
 	}
 
+	/// <summary>
+	/// Verifies that we can read <see cref="decimal"/> values that use the Bin header, which is what MessagePack-CSharp's "native" formatter uses.
+	/// </summary>
+	[Fact]
+	public void BigInteger_FromBin()
+	{
+		BigInteger value = new BigInteger(ulong.MaxValue) * 3;
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.WriteMapHeader(1);
+		writer.Write(nameof(HasBigInteger.Value));
+		writer.Write(value.ToByteArray());
+		writer.Flush();
+
+		Assert.Equal(value, this.Serializer.Deserialize<HasBigInteger>(seq, TestContext.Current.CancellationToken)!.Value);
+	}
+
 	[Theory, PairwiseData]
 	public void Guid(OptionalConverters.GuidFormat format)
 	{

--- a/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
@@ -29,10 +29,42 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 #if NET
 
 	[Fact]
-	public void Int128() => this.AssertRoundtrip(new HasInt128(new Int128(1, 2)));
+	public void Int128()
+	{
+		this.AssertRoundtrip(new HasInt128(0));
+		this.AssertType(MessagePackType.Integer);
+
+		this.AssertRoundtrip(new HasInt128(long.MaxValue));
+		this.AssertType(MessagePackType.Integer);
+
+		this.AssertRoundtrip(new HasInt128(long.MinValue));
+		this.AssertType(MessagePackType.Integer);
+
+		this.AssertRoundtrip(new HasInt128(new Int128(1, 2)));
+		this.AssertType(MessagePackType.Extension);
+
+		this.AssertRoundtrip(new HasInt128(System.Int128.MaxValue));
+		this.AssertType(MessagePackType.Extension);
+
+		this.AssertRoundtrip(new HasInt128(System.Int128.MinValue));
+		this.AssertType(MessagePackType.Extension);
+	}
 
 	[Fact]
-	public void UInt128() => this.AssertRoundtrip(new HasUInt128(new UInt128(1, 2)));
+	public void UInt128()
+	{
+		this.AssertRoundtrip(new HasUInt128(0));
+		this.AssertType(MessagePackType.Integer);
+
+		this.AssertRoundtrip(new HasInt128(ulong.MaxValue));
+		this.AssertType(MessagePackType.Integer);
+
+		this.AssertRoundtrip(new HasUInt128(new UInt128(1, 2)));
+		this.AssertType(MessagePackType.Extension);
+
+		this.AssertRoundtrip(new HasUInt128(System.UInt128.MaxValue));
+		this.AssertType(MessagePackType.Extension);
+	}
 
 #endif
 
@@ -55,30 +87,22 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 	public void BigInteger()
 	{
 		this.AssertRoundtrip(new HasBigInteger(1));
-		AssertType(MessagePackType.Integer);
+		this.AssertType(MessagePackType.Integer);
 
 		this.AssertRoundtrip(new HasBigInteger(ulong.MaxValue));
-		AssertType(MessagePackType.Integer);
+		this.AssertType(MessagePackType.Integer);
 
 		this.AssertRoundtrip(new HasBigInteger(ulong.MinValue));
-		AssertType(MessagePackType.Integer);
+		this.AssertType(MessagePackType.Integer);
 
 		this.AssertRoundtrip(new HasBigInteger(long.MaxValue));
-		AssertType(MessagePackType.Integer);
+		this.AssertType(MessagePackType.Integer);
 
 		this.AssertRoundtrip(new HasBigInteger(long.MinValue));
-		AssertType(MessagePackType.Integer);
+		this.AssertType(MessagePackType.Integer);
 
 		this.AssertRoundtrip(new HasBigInteger(new BigInteger(ulong.MaxValue) * 3));
-		AssertType(MessagePackType.Extension);
-
-		void AssertType(MessagePackType expectedType)
-		{
-			MessagePackReader reader = new(this.lastRoundtrippedMsgpack);
-			reader.ReadMapHeader();
-			reader.ReadString();
-			Assert.Equal(expectedType, reader.NextMessagePackType);
-		}
+		this.AssertType(MessagePackType.Extension);
 	}
 
 	[Theory, PairwiseData]
@@ -183,6 +207,14 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 		this.LogMsgPack(msgpack);
 		Guid deserialized = deserializer.Deserialize<Guid>(msgpack, Witness.ShapeProvider, TestContext.Current.CancellationToken);
 		return (original, deserialized);
+	}
+
+	private void AssertType(MessagePackType expectedType)
+	{
+		MessagePackReader reader = new(this.lastRoundtrippedMsgpack);
+		reader.ReadMapHeader();
+		reader.ReadString();
+		Assert.Equal(expectedType, reader.NextMessagePackType);
 	}
 
 	[GenerateShape]

--- a/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
@@ -44,7 +44,12 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 #endif
 
 	[Fact]
-	public void Decimal() => this.AssertRoundtrip(new HasDecimal(1.2m));
+	public void Decimal()
+	{
+		this.AssertRoundtrip(new HasDecimal(1.2m));
+		this.AssertRoundtrip(new HasDecimal(new decimal(ulong.MaxValue) * 1000));
+		this.AssertRoundtrip(new HasDecimal(new decimal(ulong.MaxValue) * -1000));
+	}
 
 	[Fact]
 	public void BigInteger()

--- a/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
@@ -209,7 +209,7 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 		MessagePackWriter writer = new(seq);
 		writer.WriteMapHeader(1);
 		writer.Write(nameof(HasBigInteger.Value));
-		writer.Write(value.ToByteArray());
+		writer.Write(value.ToByteArray()); // Always in LE order even on BE machines.
 		writer.Flush();
 
 		Assert.Equal(value, this.Serializer.Deserialize<HasBigInteger>(seq, TestContext.Current.CancellationToken)!.Value);

--- a/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Numerics;
+
 public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 {
 	[Fact]
@@ -31,6 +33,17 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 			{"Value":"{{guid:D}}"}
 			""",
 			new GuidWrapper(guid));
+	}
+
+	[Fact]
+	public void BigInteger()
+	{
+		BigInteger value = new BigInteger(ulong.MaxValue) * 3;
+		this.AssertConvertToJson(
+			$$"""
+			{"Value":{{value}}}
+			""",
+			new BigIntegerWrapper(value));
 	}
 
 	[Fact]
@@ -194,6 +207,9 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 
 	[GenerateShape]
 	public partial record GuidWrapper(Guid Value);
+
+	[GenerateShape]
+	public partial record BigIntegerWrapper(BigInteger Value);
 
 	[GenerateShape]
 	public partial record NestingObject(NestingObject? Nested = null, NestingObject[]? Array = null, string? Value = null);

--- a/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using System.Numerics;
 
 public partial class ConvertToJsonTests : MessagePackSerializerTestBase
@@ -56,6 +57,34 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 			""",
 			new DecimalWrapper(value));
 	}
+
+#if NET
+	[Fact]
+	public void Int128()
+	{
+		foreach (Int128 value in new[] { System.Int128.MinValue, 0, System.Int128.MaxValue })
+		{
+			this.AssertConvertToJson(
+				$$"""
+			{"Value":{{value.ToString(CultureInfo.InvariantCulture)}}}
+			""",
+				new Int128Wrapper(value));
+		}
+	}
+
+	[Fact]
+	public void UInt128()
+	{
+		foreach (UInt128 value in new[] { System.UInt128.MinValue, System.UInt128.MaxValue })
+		{
+			this.AssertConvertToJson(
+				$$"""
+			{"Value":{{value.ToString(CultureInfo.InvariantCulture)}}}
+			""",
+				new UInt128Wrapper(value));
+		}
+	}
+#endif
 
 	[Fact]
 	public void Indented_Object_Tabs()
@@ -224,6 +253,14 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 
 	[GenerateShape]
 	public partial record DecimalWrapper(decimal Value);
+
+#if NET
+	[GenerateShape]
+	public partial record Int128Wrapper(Int128 Value);
+
+	[GenerateShape]
+	public partial record UInt128Wrapper(UInt128 Value);
+#endif
 
 	[GenerateShape]
 	public partial record NestingObject(NestingObject? Nested = null, NestingObject[]? Array = null, string? Value = null);

--- a/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
@@ -27,7 +27,7 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 	[Fact]
 	public void Guid_LittleEndian()
 	{
-		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.LittleEndian);
+		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.Binary);
 		Guid guid = Guid.NewGuid();
 		this.AssertConvertToJson(
 			$$"""

--- a/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
@@ -22,6 +22,18 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 	public void Sequence() => Assert.Equal("null", this.Serializer.ConvertToJson(new([0xc0])));
 
 	[Fact]
+	public void Guid_LittleEndian()
+	{
+		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.LittleEndian);
+		Guid guid = Guid.NewGuid();
+		this.AssertConvertToJson(
+			$$"""
+			{"Value":"{{guid:D}}"}
+			""",
+			new GuidWrapper(guid));
+	}
+
+	[Fact]
 	public void Indented_Object_Tabs()
 	{
 		this.AssertConvertToJson(
@@ -179,6 +191,9 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 
 	[GenerateShape]
 	public partial record ArrayWrapper(params int[] IntArray);
+
+	[GenerateShape]
+	public partial record GuidWrapper(Guid Value);
 
 	[GenerateShape]
 	public partial record NestingObject(NestingObject? Nested = null, NestingObject[]? Array = null, string? Value = null);

--- a/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
@@ -47,6 +47,17 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 	}
 
 	[Fact]
+	public void Decimal()
+	{
+		decimal value = new decimal(ulong.MaxValue) * 3;
+		this.AssertConvertToJson(
+			$$"""
+			{"Value":{{value}}}
+			""",
+			new DecimalWrapper(value));
+	}
+
+	[Fact]
 	public void Indented_Object_Tabs()
 	{
 		this.AssertConvertToJson(
@@ -210,6 +221,9 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 
 	[GenerateShape]
 	public partial record BigIntegerWrapper(BigInteger Value);
+
+	[GenerateShape]
+	public partial record DecimalWrapper(decimal Value);
 
 	[GenerateShape]
 	public partial record NestingObject(NestingObject? Nested = null, NestingObject[]? Array = null, string? Value = null);

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
@@ -241,7 +241,11 @@ public abstract class MessagePackSerializerTestBase
 		JsonObject schema = this.Serializer.GetJsonSchema(shape);
 		string schemaString = SchemaToString(schema);
 		JSchema parsedSchema = JSchema.Parse(schemaString);
-		string json = this.Serializer.ConvertToJson(msgpack);
+
+		// We ignore known extensions while writing to JSON because that's what will lead the emitted JSON
+		// to match the JSON schema, which really describes the msgpack schema.
+		string json = this.Serializer.ConvertToJson(msgpack, new() { IgnoreKnownExtensions = true });
+
 		var parsed = JsonNode.Parse(json);
 		try
 		{

--- a/test/Nerdbank.MessagePack.Tests/OptionalConvertersTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/OptionalConvertersTests.cs
@@ -7,13 +7,13 @@ public class OptionalConvertersTests : MessagePackSerializerTestBase
 	public void NullCheck()
 	{
 		Assert.Throws<ArgumentNullException>("serializer", () => OptionalConverters.WithSystemTextJsonConverters(null!));
-		Assert.Throws<ArgumentNullException>("serializer", () => OptionalConverters.WithGuidConverter(null!, OptionalConverters.GuidFormat.LittleEndian));
+		Assert.Throws<ArgumentNullException>("serializer", () => OptionalConverters.WithGuidConverter(null!, OptionalConverters.GuidFormat.Binary));
 	}
 
 	[Fact]
 	public void DoubleAddThrows()
 	{
-		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.LittleEndian);
+		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.Binary);
 		Assert.Throws<ArgumentException>(() => this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.StringN));
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/OptionalConvertersTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/OptionalConvertersTests.cs
@@ -7,13 +7,13 @@ public class OptionalConvertersTests : MessagePackSerializerTestBase
 	public void NullCheck()
 	{
 		Assert.Throws<ArgumentNullException>("serializer", () => OptionalConverters.WithSystemTextJsonConverters(null!));
-		Assert.Throws<ArgumentNullException>("serializer", () => OptionalConverters.WithGuidConverter(null!, OptionalConverters.GuidFormat.BinaryLittleEndian));
+		Assert.Throws<ArgumentNullException>("serializer", () => OptionalConverters.WithGuidConverter(null!, OptionalConverters.GuidFormat.LittleEndian));
 	}
 
 	[Fact]
 	public void DoubleAddThrows()
 	{
-		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.BinaryLittleEndian);
+		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.LittleEndian);
 		Assert.Throws<ArgumentException>(() => this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.StringN));
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/SharedTestCases.cs
+++ b/test/Nerdbank.MessagePack.Tests/SharedTestCases.cs
@@ -21,7 +21,7 @@ public class SharedTestCases : MessagePackSerializerTestBase
 		this.Serializer = this.Serializer with { ComparerProvider = null };
 
 		// Add our optional converters to support types that are in this exhaustive test suite.
-		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.LittleEndian);
+		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.Binary);
 
 		// The PolyType test cases don't consistently specify DateTimeKind.
 		// Make an assumption for Kind so we can get through them all.

--- a/test/Nerdbank.MessagePack.Tests/SharedTestCases.cs
+++ b/test/Nerdbank.MessagePack.Tests/SharedTestCases.cs
@@ -21,7 +21,7 @@ public class SharedTestCases : MessagePackSerializerTestBase
 		this.Serializer = this.Serializer with { ComparerProvider = null };
 
 		// Add our optional converters to support types that are in this exhaustive test suite.
-		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.BinaryLittleEndian);
+		this.Serializer = this.Serializer.WithGuidConverter(OptionalConverters.GuidFormat.LittleEndian);
 
 		// The PolyType test cases don't consistently specify DateTimeKind.
 		// Make an assumption for Kind so we can get through them all.

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.8-rc",
+  "version": "0.9-rc",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$",


### PR DESCRIPTION
- Future proof the design of library extension type codes
- Encode `Int128` and `UInt128` as Bnative integers if they fit, otherwise as a BE msgpack extension. Allow decoding a LE Bin for compatibility with MessagePack-CSharp.
- Write `BigInteger` as an ordinary integer if it fits, otherwise use an extension. Allow decoding a Bin for compatibility with MessagePack-CSharp.
- Encode `decimal` as a msgpack extension instead of as a string. Allow decoding a string for compatibility with MessagePack-CSharp.
- Switch binary Guid encoding over to a msgpack extension
- Document the encodings in the MessagePack-CSharp migration section.

Closes #579
Closes #574