### PR TITLE
Bump PolyType to 0.60.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <RoslynVersion>4.14.0</RoslynVersion>
     <RoslynVersionForAnalyzers>4.11.0</RoslynVersionForAnalyzers>
     <CodeAnalysisAnalyzerVersion>3.11.0-beta1.25173.3</CodeAnalysisAnalyzerVersion>
-    <PolyTypeVersion>0.59.1</PolyTypeVersion>
+    <PolyTypeVersion>0.60.1</PolyTypeVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />

--- a/src/Nerdbank.MessagePack/SecureHash/SecureVisitor.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecureVisitor.cs
@@ -111,6 +111,10 @@ internal class SecureVisitor(TypeGenerationContext context) : TypeShapeVisitor, 
 	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
 		=> new SurrogateSecureEqualityComparer<T, TSurrogate>(surrogateShape.Marshaler, this.GetEqualityComparer(surrogateShape.SurrogateType, state));
 
+	/// <inheritdoc/>
+	public override object? VisitFunction<TFunction, TArgumentState, TResult>(IFunctionTypeShape<TFunction, TArgumentState, TResult> functionShape, object? state = null)
+		=> throw new NotSupportedException("Delegate typed properties cannot be compared.");
+
 	/// <summary>
 	/// Gets or creates an equality comparer for the given type shape.
 	/// </summary>

--- a/src/Nerdbank.MessagePack/SecureHash/StructuralVisitor.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/StructuralVisitor.cs
@@ -101,6 +101,10 @@ internal class StructuralVisitor(TypeGenerationContext context) : TypeShapeVisit
 	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
 		=> new SurrogateEqualityComparer<T, TSurrogate>(surrogateShape.Marshaler, this.GetEqualityComparer(surrogateShape.SurrogateType, state));
 
+	/// <inheritdoc/>
+	public override object? VisitFunction<TFunction, TArgumentState, TResult>(IFunctionTypeShape<TFunction, TArgumentState, TResult> functionShape, object? state = null)
+		=> throw new NotSupportedException("Delegate typed properties cannot be compared.");
+
 	/// <summary>
 	/// Gets or creates an equality comparer for the given type shape.
 	/// </summary>

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -735,6 +735,10 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
 		=> new SurrogateConverter<T, TSurrogate>(surrogateShape, this.GetConverter(surrogateShape.SurrogateType, state: state));
 
+	/// <inheritdoc/>
+	public override object? VisitFunction<TFunction, TArgumentState, TResult>(IFunctionTypeShape<TFunction, TArgumentState, TResult> functionShape, object? state = null)
+		=> throw new NotSupportedException("Delegate types cannot be serialized.");
+
 	/// <summary>
 	/// Gets or creates a converter for the given type shape.
 	/// </summary>


### PR DESCRIPTION
Throw any time we're asked to serialize or compare object graphs that include delegates