### PR TITLE
Avoid loading unneeded assemblies while looking up primitive converters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,11 +69,11 @@ jobs:
         # Allow variance of a small threshold of the expected value.
         # Fail even if it's smaller than anticipated so that the expected window can be shrunk in this file.
         if ($IsLinux) {
-          $ExpectedSize = 8.07
+          $ExpectedSize = 8.18
         } elseif ($IsMacOS) {
-          $ExpectedSize = 7.94
+          $ExpectedSize = 8.04
         } else {
-          $ExpectedSize = 6.88
+          $ExpectedSize = 6.94
         }
         $AllowedVariance = 0.2
         $SizeCheckPassed = [math]::Abs($ActualSize - $ExpectedSize) -le $AllowedVariance

--- a/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.tt
+++ b/src/Nerdbank.MessagePack/Converters/PrimitiveConverterLookup.tt
@@ -11,6 +11,7 @@
 #pragma warning disable SA1309 // Field names should not begin with underscore
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Nerdbank.MessagePack.Converters;
 
@@ -26,7 +27,7 @@ var convertersByType = new List<ConverterInfo>
 	new ConverterInfo("uint", "UInt32Converter"),
 	new ConverterInfo("long", "Int64Converter"),
 	new ConverterInfo("ulong", "UInt64Converter"),
-	new ConverterInfo("System.Numerics.BigInteger", "BigIntegerConverter"),
+	new ConverterInfo("System.Numerics.BigInteger", "BigIntegerConverter") { LazyLoad = true },
 	new ConverterInfo("bool", "BooleanConverter"),
 	new ConverterInfo("float", "SingleConverter"),
 	new ConverterInfo("double", "DoubleConverter"),
@@ -40,8 +41,8 @@ var convertersByType = new List<ConverterInfo>
 	new ConverterInfo("Half", "HalfConverter", "NET"),
 	new ConverterInfo("TimeOnly", "TimeOnlyConverter", "NET"),
 	new ConverterInfo("DateOnly", "DateOnlyConverter", "NET"),
-	new ConverterInfo("System.Drawing.Color", "SystemDrawingColorConverter"),
-	new ConverterInfo("System.Drawing.Point", "SystemDrawingPointConverter"),
+	new ConverterInfo("System.Drawing.Color", "SystemDrawingColorConverter") { LazyLoad = true },
+	new ConverterInfo("System.Drawing.Point", "SystemDrawingPointConverter") { LazyLoad = true },
 	new ConverterInfo("Memory<byte>", "MemoryOfByteConverter"),
 	new ConverterInfo("ReadOnlyMemory<byte>", "ReadOnlyMemoryOfByteConverter"),
 	new ConverterInfo("Guid", "GuidAsBinaryConverter"),
@@ -89,13 +90,12 @@ internal static class PrimitiveConverterLookup
 	/// <returns><see langword="true" /> if a converter was found; <see langword="false" /> otherwise.</returns>
 	internal static bool TryGetPrimitiveConverter<T>(ReferencePreservationMode referencePreserving, [NotNullWhen(true)] out MessagePackConverter<T>? converter)
 	{
-<# foreach (var converterGroup in convertersByType.GroupBy(c => c.PreprocessorCondition)) {
+<# foreach (var converterGroup in convertersByType.Where(c => !c.LazyLoad).GroupBy(c => c.PreprocessorCondition)) {
 	 if (converterGroup.Key is not null) { #>
 #if <#=converterGroup.Key#>
 <#   }
 	 foreach (var converter in converterGroup) {
-		string featureCondition = converter.Feature is not null ? $" && Features.{converter.Feature}" : string.Empty;
-		#>
+		string featureCondition = converter.Feature is not null ? $" && Features.{converter.Feature}" : string.Empty; #>
 		if (typeof(T) == typeof(<#=converter.TypeName#>)<#=featureCondition#>)
 		{
 <#
@@ -103,17 +103,58 @@ internal static class PrimitiveConverterLookup
 #>
 			if (referencePreserving != ReferencePreservationMode.Off)
 			{
-				converter = (MessagePackConverter<T>)(<#=converter.ReferencePreservingFieldName#> ??= new <#=converter.ConverterName#>().WrapWithReferencePreservation());
+				converter = (MessagePackConverter<T>)(<#=converter.ReferencePreservingFieldName#> ??= new <#= converter.ConverterName #>().WrapWithReferencePreservation());
 			}
 			else
 			{
-				converter = (MessagePackConverter<T>)(<#=converter.FieldName#> ??= new <#=converter.ConverterName#>());
+				converter = (MessagePackConverter<T>)(<#=converter.FieldName#> ??= new <#= converter.ConverterName #>());
 			}
 
 <# } else { #>
-			converter = (MessagePackConverter<T>)(<#=converter.FieldName#> ??= new <#=converter.ConverterName#>());
+			converter = (MessagePackConverter<T>)(<#=converter.FieldName#> ??= new <#= converter.ConverterName #>());
 <# } #>
 			return true;
+		}
+
+<#   }
+	 if (converterGroup.Key is not null) { #>
+#endif
+<#   }
+} #>
+
+		string primitiveTypeName = typeof(T).Name;
+		string? primitiveTypeNamespace = null;
+
+<# foreach (var converterGroup in convertersByType.Where(c => c.LazyLoad).GroupBy(c => c.PreprocessorCondition)) {
+	 if (converterGroup.Key is not null) { #>
+#if <#=converterGroup.Key#>
+<#   }
+	 foreach (var converter in converterGroup) {
+		// Type.Name is cheap, but not free.
+		// Type.Namespace is more expensive.
+		// Type.FullName is the most expensive.
+		// Therefore, we only obtain these properties when we must.
+		string leafName = converter.TypeName.Substring(converter.TypeName.LastIndexOf('.') + 1);
+		string ns = converter.TypeName.Substring(0, converter.TypeName.LastIndexOf('.'));
+		string featureCondition = converter.Feature is not null ? $" && Features.{converter.Feature}" : string.Empty; #>
+		if (primitiveTypeName == "<#=leafName#>" && (primitiveTypeNamespace ??= typeof(T).Namespace) == "<#=ns#>"<#=featureCondition#>)
+		{
+<#
+	if (converter.IsRefType) {
+#>
+			if (referencePreserving != ReferencePreservationMode.Off)
+			{
+				converter = (MessagePackConverter<T>?)(<#=converter.ReferencePreservingFieldName#> ??= Create<#=converter.ConverterName#><T>().WrapWithReferencePreservation());
+			}
+			else
+			{
+				converter = (MessagePackConverter<T>?)(<#=converter.FieldName#> ??= Create<#=converter.ConverterName#><T>());
+			}
+
+<# } else { #>
+			converter = (MessagePackConverter<T>?)(<#=converter.FieldName#> ??= Create<#=converter.ConverterName#><T>());
+<# } #>
+			return converter is not null;
 		}
 
 <#   }
@@ -124,11 +165,21 @@ internal static class PrimitiveConverterLookup
 		converter = null;
 		return false;
 	}
+<# foreach (var converter in convertersByType.Where(c => c.LazyLoad)) { 
+    // The runtime type check serves both to ensure type identity beyond string comparison
+    // and (perhaps more importantly) to preserve trimming of unused types, since the trimmer
+    // does not trim based on string comparisons.
+#>
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static IMessagePackConverterInternal? Create<#=converter.ConverterName#><T>() => typeof(T) == typeof(<#=converter.TypeName#>) ? new <#=converter.ConverterName#>() : null;
+<# } #>
 }
 <#+
 record struct ConverterInfo(string TypeName, string ConverterName, string PreprocessorCondition = null, bool IsRefType = false, string Feature = null)
 {
 	internal string FieldName => $"_{ConverterName}";
 	internal string ReferencePreservingFieldName => $"{FieldName}ReferencePreserving";
+	internal bool LazyLoad { get; set; }
 }
 #>

--- a/test/Nerdbank.MessagePack.Tests/AssemblyLoadTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/AssemblyLoadTests.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+public partial class AssemblyLoadTests
+{
+	[Fact]
+	public void SystemNumericsNotLoaded()
+	{
+		Helper(driver => driver.SerializeSomethingSimple(), "System.Numerics");
+	}
+
+	private static void Helper(Action<AppDomainTestDriver> action, params string[] disallowedAssemblies)
+	{
+		AppDomain testDomain = CreateTestAppDomain();
+		try
+		{
+			var driver = (AppDomainTestDriver)testDomain.CreateInstanceAndUnwrap(typeof(AppDomainTestDriver).Assembly.FullName, typeof(AppDomainTestDriver).FullName);
+
+			PrintLoadedAssemblies(driver);
+
+			action(driver);
+
+			PrintLoadedAssemblies(driver);
+			driver.ThrowIfAssembliesLoaded(disallowedAssemblies);
+		}
+		finally
+		{
+			AppDomain.Unload(testDomain);
+		}
+	}
+
+	private static AppDomain CreateTestAppDomain([CallerMemberName] string testMethodName = "") => AppDomain.CreateDomain($"Test: {testMethodName}", null, AppDomain.CurrentDomain.SetupInformation);
+
+	private static IEnumerable<string> PrintLoadedAssemblies(AppDomainTestDriver driver)
+	{
+		var assembliesLoaded = driver.GetLoadedAssemblyList();
+		TestContext.Current.TestOutputHelper?.WriteLine($"Loaded assemblies: {Environment.NewLine}{string.Join(Environment.NewLine, assembliesLoaded.OrderBy(s => s).Select(s => "   " + s))}");
+		return assembliesLoaded;
+	}
+
+	[GenerateShape]
+	internal partial record SomeObject(int Value);
+
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
+	private partial class AppDomainTestDriver : MarshalByRefObject
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+	{
+#pragma warning disable CA1822 // Mark members as static -- all members must be instance for marshalability
+
+		private readonly Dictionary<string, StackTrace> loadingStacks = new Dictionary<string, StackTrace>(StringComparer.OrdinalIgnoreCase);
+
+		public AppDomainTestDriver()
+		{
+			AppDomain.CurrentDomain.AssemblyLoad += (s, e) =>
+			{
+				string simpleName = e.LoadedAssembly.GetName().Name;
+				if (!this.loadingStacks.ContainsKey(simpleName))
+				{
+					this.loadingStacks.Add(simpleName, new StackTrace(skipFrames: 2, fNeedFileInfo: true));
+				}
+			};
+		}
+
+		internal string[] GetLoadedAssemblyList() => AppDomain.CurrentDomain.GetAssemblies().Select(a => a.GetName().Name).ToArray();
+
+		internal void ThrowIfAssembliesLoaded(params string[] assemblyNames)
+		{
+			foreach (string assemblyName in assemblyNames)
+			{
+				if (this.loadingStacks.TryGetValue(assemblyName, out StackTrace? loadingStack))
+				{
+					throw new Exception($"Assembly {assemblyName} was loaded unexpectedly by the test with this stack trace: {Environment.NewLine}{loadingStack}");
+				}
+			}
+		}
+
+		internal void SerializeSomethingSimple()
+		{
+			MessagePackSerializer serializer = new();
+			serializer.Serialize(new SomeObject(42));
+		}
+
+#pragma warning restore CA1822 // Mark members as static
+
+		[GenerateShapeFor<bool>]
+		private partial class Witness;
+	}
+}
+
+#endif


### PR DESCRIPTION
This avoids loading `System.Numerics` and `System.Drawing` during serialization of types that wouldn't require them.

Note that due to https://github.com/eiriktsarpalis/PolyType/issues/252, if either of those assemblies are included in *any* source generated type shapes, they'll be loaded anyway.