### PR TITLE
Add duck typed unions

### DIFF
--- a/docfx/docs/features.md
+++ b/docfx/docs/features.md
@@ -29,6 +29,7 @@ Optimized for high performance | [✅](performance.md) | [✅](https://github.co
 Contractless data types   | [✅](getting-started.md)[^1] | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#object-serialization) | ❌ |
 Attributed data types     | [✅](customizing-serialization.md) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#object-serialization) | [✅](https://serdedotnet.github.io/generator/options.html)
 Polymorphic serialization | [✅](unions.md) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#union)[^4] | [✅](https://serdedotnet.github.io/data-model.html)
+Duck-typed polymorphic serialization | [✅](unions.md#duck-typing) | ❌ | ❌ |
 F# union type support     | [✅](fsharp.md) | ❌ | ❌ |
 Typeless serialization    | [✅](xref:Nerdbank.MessagePack.OptionalConverters.WithObjectConverter*) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp?tab=readme-ov-file#typeless) | ❌ |
 `dynamic` serialization    | [✅](getting-started.md#untyped-deserialization) | [✅](https://github.com/MessagePack-CSharp/MessagePack-CSharp/blob/master/doc/ExpandoObject.md) | ❌ |

--- a/docfx/docs/unions.md
+++ b/docfx/docs/unions.md
@@ -200,6 +200,39 @@ Consider the following example where a type hierarchy is registered without usin
 
 ---
 
+### Duck typing
+
+Shape-based unions allow you to participate in a union based on the *shape* (the publicly serializable members) of a type rather than requiring a type header.
+This enables scenarios sometimes described as "duck typing": if the object "looks like" (matches the required members of) a known union case, it can be deserialized as that case.
+
+Use <xref:Nerdbank.MessagePack.DerivedTypeDuckTyping> to identify a set of types that should be discernable at deserialization time by their shape.
+
+Unions employing the duck typing strategy will deserialize more slowly than typical unions because deserializing the value requires matching the schema of the data against a known union case, while typical unions can immediately identify the target type based on the type identifier.
+A good case for duck typing is when protocol compatibility is required, and a union header was not established in the original protocol but multiple types now need to be supported.
+
+Note that duck typing requires there to be enough unique properties between the cases to narrow the possibilities down to exactly one match for deserialization to succeed.
+
+Consider this animal hierarchy:
+
+[!code-csharp[](../../samples/cs/Unions.cs#DuckTyping)]
+
+Serializing a dog or cat might produce this data:
+
+```json
+{ "Name": "Rover", "BarkVolume": 10 }
+{ "Name": "Whiskers", "MeowPitch": 13 }
+```
+
+Note there is no type header added.
+When deserializing, the presence of the `BarkVolume` property indicates the object is a `Dog`, while the presence of the `MeowPitch` property indicates a `Cat`.
+This works because these respective properties are *required* on their respective types.
+Optional properties are *not* considered for duck typing at present.
+
+If two declared types are ambiguous (e.g. if both types have the same required properties), deserialization may fail.
+
+Duck typing is an experimental feature and may change in future releases.
+Your feedback is welcome.
+
 ### Removing a union at runtime
 
 When a base type has <xref:PolyType.DerivedTypeShapeAttribute> or equivalent attributes on it such that its type shape is recognized as being part of a union, but union behavior is not what you want, you can disable it at runtime by calling <xref:Nerdbank.MessagePack.DerivedTypeUnion.CreateDisabled(System.Type)> and adding it to the serializer configuration.

--- a/samples/cs/Unions.cs
+++ b/samples/cs/Unions.cs
@@ -191,3 +191,32 @@ namespace RuntimeSubTypes
         #endregion
     }
 }
+
+namespace DuckTyping
+{
+    #region DuckTyping
+#pragma warning disable DuckTyping // Experimental API
+
+    [GenerateShape]
+    public abstract partial record Animal(string Name);
+
+    [GenerateShape]
+    public partial record Dog(string Name, int BarkVolume) : Animal(Name);
+
+    [GenerateShape]
+    public partial record Cat(string Name, int MeowPitch) : Animal(Name);
+
+    public class AnimalShelter
+    {
+        public MessagePackSerializer Serializer { get; } = new()
+        {
+            DerivedTypeUnions = [
+                new DerivedTypeDuckTyping(
+                    TypeShapeResolver.ResolveDynamicOrThrow<Animal>(),
+                    TypeShapeResolver.ResolveDynamicOrThrow<Dog>(),
+                    TypeShapeResolver.ResolveDynamicOrThrow<Cat>()),
+            ],
+        };
+    }
+    #endregion
+}

--- a/src/Nerdbank.MessagePack/ConverterCache.cs
+++ b/src/Nerdbank.MessagePack/ConverterCache.cs
@@ -196,7 +196,7 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	}
 
 	/// <inheritdoc cref="DerivedTypeUnionCollection.TryGetDerivedTypeUnion(Type, out DerivedTypeUnion?)"/>
-	internal bool TryGetDynamicSubTypes(Type baseType, [NotNullWhen(true)] out DerivedTypeUnion? union) => configuration.DerivedTypeUnions.TryGetDerivedTypeUnion(baseType, out union);
+	internal bool TryGetDynamicUnion(Type baseType, [NotNullWhen(true)] out DerivedTypeUnion? union) => configuration.DerivedTypeUnions.TryGetDerivedTypeUnion(baseType, out union);
 
 	/// <summary>
 	/// Gets the property name that should be used when serializing a property.

--- a/src/Nerdbank.MessagePack/Converters/ShapeBasedUnionConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ShapeBasedUnionConverter`1.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable DuckTyping // Experimental API
+
+using System.Text.Json.Nodes;
+
+namespace Nerdbank.MessagePack.Converters;
+
+/// <summary>
+/// A converter for union types that distinguishes between member types based on their shape characteristics
+/// rather than explicit aliases.
+/// </summary>
+/// <typeparam name="TUnion">The union base type.</typeparam>
+internal class ShapeBasedUnionConverter<TUnion> : MessagePackConverter<TUnion>
+{
+	private readonly MessagePackConverter<TUnion> baseConverter;
+	private readonly DerivedTypeDuckTyping shapeMapping;
+	private readonly Dictionary<Type, MessagePackConverter> convertersByType;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ShapeBasedUnionConverter{TUnion}"/> class.
+	/// </summary>
+	/// <param name="baseConverter">The converter for the base type.</param>
+	/// <param name="shapeMapping">The shape-based mapping for distinguishing between types.</param>
+	/// <param name="convertersByType">Converters for each member type.</param>
+	public ShapeBasedUnionConverter(
+		MessagePackConverter<TUnion> baseConverter,
+		DerivedTypeDuckTyping shapeMapping,
+		Dictionary<Type, MessagePackConverter> convertersByType)
+	{
+		this.baseConverter = baseConverter;
+		this.shapeMapping = shapeMapping;
+		this.convertersByType = convertersByType;
+	}
+
+	/// <inheritdoc/>
+	public override TUnion? Read(ref MessagePackReader reader, SerializationContext context)
+	{
+		if (reader.TryReadNil())
+		{
+			return default;
+		}
+
+		// Try to identify the type based on shape analysis
+		if (this.shapeMapping.TryIdentifyType(reader, context, out ITypeShape? identifiedShape))
+		{
+			if (this.convertersByType.TryGetValue(identifiedShape.Type, out MessagePackConverter? converter))
+			{
+				return (TUnion?)converter.ReadObject(ref reader, context);
+			}
+		}
+
+		// Fall back to base converter if no specific type could be identified
+		return this.baseConverter.Read(ref reader, context);
+	}
+
+	/// <inheritdoc/>
+	public override void Write(ref MessagePackWriter writer, in TUnion? value, SerializationContext context)
+	{
+		if (value is null)
+		{
+			writer.WriteNil();
+			return;
+		}
+
+		Type actualType = value.GetType();
+
+		// Use specific converter if available, otherwise fallback to base converter.
+		if (this.convertersByType.TryGetValue(actualType, out MessagePackConverter? converter))
+		{
+			converter.WriteObject(ref writer, value, context);
+		}
+		else
+		{
+			this.baseConverter.Write(ref writer, value, context);
+		}
+	}
+
+	/// <inheritdoc/>
+	public override JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape)
+	{
+		// For shape-based unions, we create a oneOf schema without the array wrapper
+		JsonArray oneOfArray = [];
+
+		// Add base type schema
+		oneOfArray.Add((JsonNode?)this.baseConverter.GetJsonSchema(context, this.shapeMapping.BaseShape) ?? CreateUndocumentedSchema(this.baseConverter.GetType()));
+
+		// Add schemas for each derived type.
+		foreach (ITypeShape shape in this.shapeMapping.DerivedShapes.Span)
+		{
+			oneOfArray.Add((JsonNode)context.GetJsonSchema(shape));
+		}
+
+		return new JsonObject
+		{
+			["oneOf"] = oneOfArray,
+		};
+	}
+}

--- a/src/Nerdbank.MessagePack/DerivedTypeDuckTyping.cs
+++ b/src/Nerdbank.MessagePack/DerivedTypeDuckTyping.cs
@@ -1,0 +1,247 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// A shape-based union that can distinguish between union cases
+/// based on their structural characteristics rather than explicit aliases.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This union strategy analyzes the provided type shapes to identify distinguishing characteristics such as:
+/// </para>
+/// <list type="bullet">
+/// <item>Required properties that appear only in specific union cases</item>
+/// </list>
+/// <para>
+/// The resulting converter does not use explicit type aliases and instead inspects the MessagePack structure
+/// during deserialization to determine the appropriate union case to deserialize into.
+/// </para>
+/// <para>
+/// Note that this approach may be slower than alias-based unions
+/// as it may require buffering the entire value for analysis.
+/// </para>
+/// </remarks>
+[Experimental("DuckTyping")]
+public class DerivedTypeDuckTyping : DerivedTypeUnion
+{
+	private readonly ITypeShape baseShape;
+	private readonly ReadOnlyMemory<ITypeShape> derivedTypeShapes;
+	private readonly Dictionary<Type, ITypeShape> typeToShapeMap;
+	private readonly List<Filter> steps;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="DerivedTypeDuckTyping"/> class.
+	/// </summary>
+	/// <param name="baseShape">The shape of the base type.</param>
+	/// <param name="derivedTypeShapes">The shapes of the derived types.</param>
+	public DerivedTypeDuckTyping(ITypeShape baseShape, params ReadOnlySpan<ITypeShape> derivedTypeShapes)
+	{
+		Requires.NotNull(baseShape);
+
+		this.baseShape = baseShape;
+
+		// Make sure we have an immutable copy
+		this.derivedTypeShapes = derivedTypeShapes.ToArray();
+
+		this.typeToShapeMap = new(derivedTypeShapes.Length + 1);
+		if (baseShape.Type is { IsAbstract: false, IsInterface: false })
+		{
+			this.typeToShapeMap.Add(baseShape.Type, baseShape);
+		}
+
+		foreach (ITypeShape derivedTypeShape in derivedTypeShapes)
+		{
+			Requires.Argument(derivedTypeShape.Type is { IsAbstract: false, IsInterface: false }, nameof(derivedTypeShape), $"Derived types must be concrete, but {derivedTypeShape.Type.FullName} is not.");
+			this.typeToShapeMap.Add(derivedTypeShape.Type, derivedTypeShape);
+		}
+
+		Requires.Argument(this.typeToShapeMap.Count > 1, nameof(derivedTypeShapes), "At least two type shapes must be provided. The base shape only counts if it is a concrete type.");
+
+		this.steps = BuildMapping(derivedTypeShapes) ?? throw new ArgumentException("The type shapes given do not include (enough) unique characteristics.");
+	}
+
+	/// <inheritdoc/>
+	public override Type BaseType => this.baseShape.Type;
+
+	/// <summary>
+	/// Gets the shape of the base type.
+	/// </summary>
+	internal ITypeShape BaseShape => this.baseShape;
+
+	/// <summary>
+	/// Gets a list of the derived type shapes.
+	/// </summary>
+	internal ReadOnlyMemory<ITypeShape> DerivedShapes => this.derivedTypeShapes;
+
+	/// <summary>
+	/// Attempts to identify the runtime type based on MessagePack data.
+	/// </summary>
+	/// <param name="reader">A reader positioned at the start of the value to analyze.</param>
+	/// <param name="serializationContext">The serialization context.</param>
+	/// <param name="typeShape">The identified type shape, if successful.</param>
+	/// <returns>True if exactly one matching type was identified; false otherwise.</returns>
+#pragma warning disable NBMsgPack050 // Use ref parameters for ref structs -- acts as a peek reader
+	internal bool TryIdentifyType(in MessagePackReader reader, in SerializationContext serializationContext, [NotNullWhen(true)] out ITypeShape? typeShape)
+#pragma warning restore NBMsgPack050 // Use ref parameters for ref structs
+	{
+		DuckTypingContext context = new(reader, serializationContext, new HashSet<Type>(this.typeToShapeMap.Keys));
+
+		foreach (Filter step in this.steps)
+		{
+			step.Execute(ref context);
+
+			if (context.RemainingCandidateTypes.Count == 1)
+			{
+				typeShape = this.typeToShapeMap[context.RemainingCandidateTypes.First()];
+				return true;
+			}
+		}
+
+		typeShape = null;
+		return false;
+	}
+
+	/// <inheritdoc/>
+	internal override void InternalDerivationsOnly() => throw new NotImplementedException();
+
+	private static List<Filter> BuildMapping(ReadOnlySpan<ITypeShape> typeShapes)
+	{
+		List<Filter> steps = [];
+
+		AnalyzeRequiredProperties(typeShapes, steps);
+
+		return steps;
+	}
+
+	private static void AnalyzeRequiredProperties(ReadOnlySpan<ITypeShape> typeShapes, List<Filter> steps)
+	{
+		Dictionary<string, (HashSet<Type> WithProperty, HashSet<Type> WithoutProperty)> propertyAnalysis = new(StringComparer.Ordinal);
+
+		foreach (ITypeShape typeShape in typeShapes)
+		{
+			if (typeShape is not IObjectTypeShape { Constructor.Parameters: { Count: > 0 } parameters })
+			{
+				continue;
+			}
+
+			List<string> requiredProperties = [];
+			foreach (IParameterShape parameter in parameters)
+			{
+				if (parameter.IsRequired)
+				{
+					requiredProperties.Add(parameter.Name);
+				}
+			}
+
+			if (requiredProperties.Count > 0)
+			{
+				steps.Add(new RequiredPropertyStep(typeShape.Type, requiredProperties));
+			}
+		}
+	}
+
+	private ref struct DuckTypingContext
+	{
+		private readonly MessagePackReader reader;
+		private readonly SerializationContext context;
+		private Dictionary<string, MessagePackType>? propertyTypes;
+		private HashSet<Type> remainingCandidateTypes;
+
+		internal DuckTypingContext(in MessagePackReader reader, in SerializationContext context, HashSet<Type> remainingCandidateTypes)
+		{
+			this.reader = reader;
+			this.context = context;
+			this.remainingCandidateTypes = remainingCandidateTypes;
+		}
+
+		[UnscopedRef]
+		internal ref readonly MessagePackReader Reader => ref this.reader;
+
+		[UnscopedRef]
+		internal ref readonly SerializationContext Context => ref this.context;
+
+		internal IReadOnlyCollection<Type> RemainingCandidateTypes => this.remainingCandidateTypes;
+
+		internal bool HasProperty(string propertyName) => this.TryGetPropertyType(propertyName, out _);
+
+		internal bool TryGetPropertyType(string propertyName, out MessagePackType propertyType)
+		{
+			this.InitProperties();
+			return this.propertyTypes.TryGetValue(propertyName, out propertyType);
+		}
+
+		internal bool RemoveCandidateType(Type type) => this.remainingCandidateTypes.Remove(type);
+
+		[MemberNotNull(nameof(propertyTypes))]
+		private void InitProperties()
+		{
+			if (this.propertyTypes is null)
+			{
+				MessagePackReader peekReader = this.reader.CreatePeekReader();
+
+				this.propertyTypes = [];
+				if (peekReader.NextMessagePackType == MessagePackType.Map)
+				{
+					int count = peekReader.ReadMapHeader();
+					for (int i = 0; i < count; i++)
+					{
+						string? propertyName;
+						if (peekReader.NextMessagePackType == MessagePackType.String)
+						{
+							propertyName = peekReader.ReadString()!;
+
+							// Record the type of this property's value.
+							this.propertyTypes.Add(propertyName, peekReader.NextMessagePackType);
+						}
+						else
+						{
+							propertyName = null;
+
+							// Non-string key, skip it.
+							peekReader.Skip(this.context);
+						}
+
+						// Skip the value.
+						peekReader.Skip(this.context);
+					}
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// A filtering step that narrows down candidate types.
+	/// </summary>
+	private abstract class Filter
+	{
+		/// <summary>
+		/// Executes the filter to hopefully narrow down the candidate types to be deserialized.
+		/// </summary>
+		/// <param name="context">The duck typing context.</param>
+		internal abstract void Execute(ref DuckTypingContext context);
+	}
+
+	/// <summary>
+	/// A step that checks for the presence or absence of required properties.
+	/// </summary>
+	private class RequiredPropertyStep(Type type, IReadOnlyCollection<string> requiredPropertyNames) : Filter
+	{
+		/// <inheritdoc/>
+		internal override void Execute(ref DuckTypingContext context)
+		{
+			foreach (string propertyName in requiredPropertyNames)
+			{
+				if (!context.HasProperty(propertyName))
+				{
+					context.RemoveCandidateType(type);
+					break;
+				}
+			}
+		}
+	}
+}

--- a/src/Nerdbank.MessagePack/JsonSchemaContext.cs
+++ b/src/Nerdbank.MessagePack/JsonSchemaContext.cs
@@ -39,7 +39,7 @@ public class JsonSchemaContext
 	internal LibraryReservedMessagePackExtensionTypeCode ExtensionTypeCodes { get; }
 
 	/// <summary>
-	/// Obtains the JSON schema for a given type.
+	/// Obtains the JSON schema for a given type shape.
 	/// </summary>
 	/// <param name="typeShape">The shape for the type.</param>
 	/// <returns>The JSON schema.</returns>

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -720,10 +720,10 @@ public partial record MessagePackSerializer
 		{
 			builder.Write('\"');
 
-			var len = value.Length;
+			int len = value.Length;
 			for (int i = 0; i < len; i++)
 			{
-				var c = value[i];
+				char c = value[i];
 				switch (c)
 				{
 					case '"':

--- a/test/Nerdbank.MessagePack.Tests/DerivedTypeDuckTypingTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/DerivedTypeDuckTypingTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable DuckTyping // Experimental API
+
+public partial class DerivedTypeDuckTypingTests : MessagePackSerializerTestBase
+{
+	public DerivedTypeDuckTypingTests()
+	{
+		this.Serializer = this.Serializer with
+		{
+			DerivedTypeUnions = [
+				new DerivedTypeDuckTyping(
+					TypeShapeResolver.ResolveDynamicOrThrow<Animal>(),
+					TypeShapeResolver.ResolveDynamicOrThrow<Dog>(),
+					TypeShapeResolver.ResolveDynamicOrThrow<Cat>()),
+			],
+		};
+	}
+
+	[Fact]
+	public void RequiredPropertyDistinction_Roundtrip()
+	{
+		this.AssertRoundtrip<Animal>(new Dog("Buddy", 5));
+		this.AssertRoundtrip<Animal>(new Cat("Whiskers", 3));
+	}
+
+	[GenerateShape]
+	public abstract partial record Animal(string Name);
+
+	[GenerateShape]
+	public partial record Dog(string Name, int BarkVolume) : Animal(Name);
+
+	[GenerateShape]
+	public partial record Cat(string Name, int MeowPitch) : Animal(Name);
+
+	[GenerateShape]
+	public partial record IdenticalTypeBase;
+
+	[GenerateShape]
+	public partial record IdenticalType1 : IdenticalTypeBase
+	{
+		public string CommonProperty { get; init; } = string.Empty;
+	}
+
+	[GenerateShape]
+	public partial record IdenticalType2 : IdenticalTypeBase
+	{
+		public string CommonProperty { get; init; } = string.Empty;
+	}
+
+	[GenerateShapeFor<Animal>]
+	[GenerateShapeFor<Dog>]
+	[GenerateShapeFor<Cat>]
+	[GenerateShapeFor<IdenticalType1>]
+	[GenerateShapeFor<IdenticalType2>]
+	private partial class Witness;
+}


### PR DESCRIPTION
Duck typing allows for types like this:

```cs
[GenerateShape]
public abstract partial record Animal(string Name);

[GenerateShape]
public partial record Dog(string Name, int BarkVolume) : Animal(Name);

[GenerateShape]
public partial record Cat(string Name, int MeowPitch) : Animal(Name);
```

To be deserialized from msgpack data such as:

```json
{ "Name": "Rover", "BarkVolume": 10 }
{ "Name": "Whiskers", "MeowPitch": 13 }
```

Note the lack of type header information. Instead, the required properties that are present will disambiguate the type to be deserialized.