### PR TITLE
Ignore non-serializable types (e.g. delegates) buried in properties that we won't serialize

### DIFF
--- a/src/Nerdbank.MessagePack/ConverterCache.cs
+++ b/src/Nerdbank.MessagePack/ConverterCache.cs
@@ -104,8 +104,8 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// <typeparam name="T">The data type to convert.</typeparam>
 	/// <param name="shape">The shape of the type to convert.</param>
 	/// <returns>A msgpack converter.</returns>
-	internal MessagePackConverter<T> GetOrAddConverter<T>(ITypeShape<T> shape)
-		=> (MessagePackConverter<T>)(this.lastConverter is MessagePackConverter<T> lastConverter ? lastConverter : (this.lastConverter = this.CachedConverters.GetOrAdd(shape)!));
+	internal ConverterResult<T> GetOrAddConverter<T>(ITypeShape<T> shape)
+		=> (ConverterResult<T>)(this.lastConverter is MessagePackConverter<T> lastConverter ? lastConverter : (this.lastConverter = this.CachedConverters.GetOrAdd(shape)!));
 
 	/// <summary>
 	/// Gets a converter for the given type shape.
@@ -114,8 +114,8 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// </summary>
 	/// <param name="shape">The shape of the type to convert.</param>
 	/// <returns>A msgpack converter.</returns>
-	internal MessagePackConverter GetOrAddConverter(ITypeShape shape)
-		=> (MessagePackConverter)this.CachedConverters.GetOrAdd(shape)!;
+	internal IConverterResult GetOrAddConverter(ITypeShape shape)
+		=> (IConverterResult)this.CachedConverters.GetOrAdd(shape)!;
 
 	/// <summary>
 	/// Gets a converter for the given type shape.
@@ -125,8 +125,8 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// <typeparam name="T">The type to convert.</typeparam>
 	/// <param name="provider">The type shape provider.</param>
 	/// <returns>A msgpack converter.</returns>
-	internal MessagePackConverter<T> GetOrAddConverter<T>(ITypeShapeProvider provider)
-		=> (MessagePackConverter<T>)this.CachedConverters.GetOrAddOrThrow(typeof(T), provider);
+	internal ConverterResult<T> GetOrAddConverter<T>(ITypeShapeProvider provider)
+		=> (ConverterResult<T>)this.CachedConverters.GetOrAddOrThrow(typeof(T), provider);
 
 	/// <summary>
 	/// Gets a converter for the given type shape.
@@ -136,8 +136,8 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// <param name="type">The type to convert.</param>
 	/// <param name="provider">The type shape provider.</param>
 	/// <returns>A msgpack converter.</returns>
-	internal IMessagePackConverterInternal GetOrAddConverter(Type type, ITypeShapeProvider provider)
-		=> (IMessagePackConverterInternal)this.CachedConverters.GetOrAddOrThrow(type, provider);
+	internal IConverterResult GetOrAddConverter(Type type, ITypeShapeProvider provider)
+		=> (IConverterResult)this.CachedConverters.GetOrAddOrThrow(type, provider);
 
 	/// <summary>
 	/// Gets a user-defined converter for the specified type if one is available from

--- a/src/Nerdbank.MessagePack/ConverterCache.cs
+++ b/src/Nerdbank.MessagePack/ConverterCache.cs
@@ -104,8 +104,8 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// <typeparam name="T">The data type to convert.</typeparam>
 	/// <param name="shape">The shape of the type to convert.</param>
 	/// <returns>A msgpack converter.</returns>
-	internal ConverterResult<T> GetOrAddConverter<T>(ITypeShape<T> shape)
-		=> (ConverterResult<T>)(this.lastConverter is MessagePackConverter<T> lastConverter ? lastConverter : (this.lastConverter = this.CachedConverters.GetOrAdd(shape)!));
+	internal ConverterResult GetOrAddConverter<T>(ITypeShape<T> shape)
+		=> (ConverterResult)(this.lastConverter is MessagePackConverter<T> lastConverter ? lastConverter : (this.lastConverter = this.CachedConverters.GetOrAdd(shape)!));
 
 	/// <summary>
 	/// Gets a converter for the given type shape.
@@ -114,8 +114,8 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// </summary>
 	/// <param name="shape">The shape of the type to convert.</param>
 	/// <returns>A msgpack converter.</returns>
-	internal IConverterResult GetOrAddConverter(ITypeShape shape)
-		=> (IConverterResult)this.CachedConverters.GetOrAdd(shape)!;
+	internal ConverterResult GetOrAddConverter(ITypeShape shape)
+		=> (ConverterResult)this.CachedConverters.GetOrAdd(shape)!;
 
 	/// <summary>
 	/// Gets a converter for the given type shape.
@@ -125,8 +125,8 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// <typeparam name="T">The type to convert.</typeparam>
 	/// <param name="provider">The type shape provider.</param>
 	/// <returns>A msgpack converter.</returns>
-	internal ConverterResult<T> GetOrAddConverter<T>(ITypeShapeProvider provider)
-		=> (ConverterResult<T>)this.CachedConverters.GetOrAddOrThrow(typeof(T), provider);
+	internal ConverterResult GetOrAddConverter<T>(ITypeShapeProvider provider)
+		=> (ConverterResult)this.CachedConverters.GetOrAddOrThrow(typeof(T), provider);
 
 	/// <summary>
 	/// Gets a converter for the given type shape.
@@ -136,8 +136,8 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// <param name="type">The type to convert.</param>
 	/// <param name="provider">The type shape provider.</param>
 	/// <returns>A msgpack converter.</returns>
-	internal IConverterResult GetOrAddConverter(Type type, ITypeShapeProvider provider)
-		=> (IConverterResult)this.CachedConverters.GetOrAddOrThrow(type, provider);
+	internal ConverterResult GetOrAddConverter(Type type, ITypeShapeProvider provider)
+		=> (ConverterResult)this.CachedConverters.GetOrAddOrThrow(type, provider);
 
 	/// <summary>
 	/// Gets a user-defined converter for the specified type if one is available from

--- a/src/Nerdbank.MessagePack/ConverterResult.cs
+++ b/src/Nerdbank.MessagePack/ConverterResult.cs
@@ -1,0 +1,328 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// The result of an operation that was to produce a <see cref="MessagePackConverter"/>.
+/// </summary>
+internal interface IConverterResult
+{
+	/// <summary>
+	/// Gets a value indicating whether the operation was successful.
+	/// </summary>
+	[MemberNotNullWhen(true, nameof(Value))]
+	[MemberNotNullWhen(false, nameof(Error))]
+	bool Success { get; }
+
+	/// <summary>
+	/// Gets the converter.
+	/// </summary>
+	/// <exception cref="MessagePackSerializationException">Thrown if <see cref="Success"/> is <see langword="false"/>.</exception>
+	MessagePackConverter? Value { get; }
+
+	/// <summary>
+	/// Gets the converter, or throws if the result is a failure.
+	/// </summary>
+	MessagePackConverter ValueOrThrow { get; }
+
+	/// <summary>
+	/// Gets the error that describes why the operation failed.
+	/// </summary>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="Success"/> is <see langword="true"/>.</exception>
+	VisitorError? Error { get; }
+
+	/// <summary>
+	/// Wraps the converter with one that provides reference preservation capabilities.
+	/// </summary>
+	/// <returns>A new result with the wrapped converter, or this same instance if it is already a failure.</returns>
+	IConverterResult WrapWithReferencePreservation();
+
+	/// <summary>
+	/// Prepares a more descriptive failure result, if this result is a failure.
+	/// </summary>
+	/// <typeparam name="T">The type argument for the returned <see cref="ConverterResult{T}"/>.</typeparam>
+	/// <param name="stepMessage">The message to prepend to the error path.</param>
+	/// <param name="failureResult">Receives the new failure result, if this one is a failure.</param>
+	/// <returns><see langword="true"/> if this is a failure and <paramref name="failureResult"/> is set; <see langword="false"/> otherwise.</returns>
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	bool TryPrepareFailPath<T>(string stepMessage, [NotNullWhen(true)] out ConverterResult<T>? failureResult);
+
+	/// <summary>
+	/// Prepares a more descriptive failure result, if this result is a failure.
+	/// </summary>
+	/// <typeparam name="T">The type argument for the returned <see cref="ConverterResult{T}"/>.</typeparam>
+	/// <param name="target">The shape that failed to produce a converter.</param>
+	/// <param name="failureResult">Receives the new failure result, if this one is a failure.</param>
+	/// <returns><see langword="true"/> if this is a failure and <paramref name="failureResult"/> is set; <see langword="false"/> otherwise.</returns>
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	bool TryPrepareFailPath<T>(ITypeShape target, [NotNullWhen(true)] out ConverterResult<T>? failureResult);
+
+	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	bool TryPrepareFailPath<T>(IPropertyShape target, [NotNullWhen(true)] out ConverterResult<T>? failureResult);
+
+	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	bool TryPrepareFailPath<T>(IParameterShape target, [NotNullWhen(true)] out ConverterResult<T>? failureResult);
+}
+
+/// <summary>
+/// A factory for <see cref="ConverterResult{T}"/> instances.
+/// </summary>
+internal static class ConverterResult
+{
+	/// <summary>
+	/// Creates a successful result.
+	/// </summary>
+	/// <typeparam name="T">The type of value the converter handles.</typeparam>
+	/// <param name="value">The converter.</param>
+	/// <returns>A successful result.</returns>
+	internal static ConverterResult<T> Ok<T>(MessagePackConverter<T> value) => new(value);
+
+	/// <summary>
+	/// Creates a failure result.
+	/// </summary>
+	/// <typeparam name="T">The type of value the converter would have handled.</typeparam>
+	/// <param name="error">The error describing the failure.</param>
+	/// <returns>A failure result.</returns>
+	internal static ConverterResult<T> Err<T>(VisitorError error) => new(error);
+
+	/// <summary>
+	/// Maps a <see cref="Result{TValue, TError}"/> to a <see cref="ConverterResult{T}"/> using the specified <paramref name="mapper"/>.
+	/// </summary>
+	/// <typeparam name="T1">The type of result of the original value.</typeparam>
+	/// <typeparam name="T2">The type of result coming from the <paramref name="mapper"/>.</typeparam>
+	/// <param name="result">The original result.</param>
+	/// <param name="mapper">The mapper.</param>
+	/// <returns>The final result.</returns>
+	internal static ConverterResult<T2> MapResult<T1, T2>(this Result<T1, VisitorError> result, Func<T1, MessagePackConverter<T2>> mapper)
+	{
+		return result.Success ? Ok(mapper(result.Value)) : Err<T2>(result.Error);
+	}
+}
+
+/// <summary>
+/// The result of an operation that was to produce a <see cref="MessagePackConverter{T}"/>.
+/// </summary>
+/// <typeparam name="T">The type of value the converter can serialize.</typeparam>
+[DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
+internal class ConverterResult<T> : IConverterResult
+{
+	private readonly MessagePackConverter<T>? value;
+	private readonly VisitorError? error;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ConverterResult{T}"/> class that represents success.
+	/// </summary>
+	/// <param name="value">The converter.</param>
+	internal ConverterResult(MessagePackConverter<T> value)
+	{
+		this.value = value;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ConverterResult{T}"/> class that represents failure.
+	/// </summary>
+	/// <param name="error">The error.</param>
+	internal ConverterResult(VisitorError error)
+	{
+		this.error = error;
+	}
+
+	/// <inheritdoc />
+	[MemberNotNullWhen(true, nameof(Value))]
+	[MemberNotNullWhen(false, nameof(Error))]
+	public bool Success => this.value is not null;
+
+	/// <summary>
+	/// Gets the converter.
+	/// </summary>
+	/// <exception cref="MessagePackSerializationException">Thrown if <see cref="Success"/> is <see langword="false"/>.</exception>
+	public MessagePackConverter<T>? Value => this.value;
+
+	/// <summary>
+	/// Gets the converter, or throws if the result is a failure.
+	/// </summary>
+	public MessagePackConverter<T> ValueOrThrow
+	{
+		get
+		{
+			this.error?.ThrowException();
+			return this.value!;
+		}
+	}
+
+	/// <inheritdoc/>
+	MessagePackConverter IConverterResult.ValueOrThrow => this.ValueOrThrow;
+
+	/// <inheritdoc />
+	public VisitorError? Error => this.error;
+
+	/// <inheritdoc />
+	MessagePackConverter? IConverterResult.Value => this.Value;
+
+	/// <summary>
+	/// Gets a  string used by the debugger to display the current result.
+	/// </summary>
+	private string DebuggerDisplay => this.Success ? $"Ok: {this.value}" : $"Err: {this.error}";
+
+	/// <summary>
+	/// Creates a successful result.
+	/// </summary>
+	/// <param name="value">The converter.</param>
+	/// <returns>A successful result.</returns>
+	public static ConverterResult<T> Ok(MessagePackConverter<T> value) => new(value);
+
+	/// <summary>
+	/// Creates a failure result.
+	/// </summary>
+	/// <param name="error">The error describing the failure.</param>
+	/// <returns>A failure result.</returns>
+	public static ConverterResult<T> Err(VisitorError error) => new(error);
+
+	/// <inheritdoc cref="IConverterResult.TryPrepareFailPath{T}(string, out ConverterResult{T}?)"/>
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	public bool TryPrepareFailPath(string stepMessage, [NotNullWhen(true)] out ConverterResult<T>? failureResult)
+		=> this.TryPrepareFailPath<T>(stepMessage, out failureResult);
+
+	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	public bool TryPrepareFailPath(IPropertyShape property, [NotNullWhen(true)] out ConverterResult<T>? failureResult)
+		=> this.TryPrepareFailPath<T>(property, out failureResult);
+
+	/// <inheritdoc cref="IConverterResult.TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)"/>
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	public bool TryPrepareFailPath(ITypeShape typeShape, [NotNullWhen(true)] out ConverterResult<T>? failureResult)
+		=> this.TryPrepareFailPath<T>(typeShape, out failureResult);
+
+	/// <inheritdoc />
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	public bool TryPrepareFailPath<T1>(string stepMessage, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	{
+		if (this.Success)
+		{
+			failureResult = null;
+			return false;
+		}
+
+		failureResult = new ConverterResult<T1>(new VisitorError(stepMessage, this.Error));
+		return true;
+	}
+
+	/// <inheritdoc />
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	public bool TryPrepareFailPath<T1>(IPropertyShape shape, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	{
+		if (this.Success)
+		{
+			failureResult = null;
+			return false;
+		}
+
+		failureResult = ConverterResult.Err<T1>(new VisitorError($"{shape.DeclaringType.Type.FullName}.{shape.Name}", this.Error));
+		return true;
+	}
+
+	/// <inheritdoc />
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	public bool TryPrepareFailPath<T1>(IParameterShape shape, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	{
+		if (this.Success)
+		{
+			failureResult = null;
+			return false;
+		}
+
+		failureResult = ConverterResult.Err<T1>(new VisitorError($"{shape.Name}", this.Error));
+		return true;
+	}
+
+	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	public bool TryPrepareFailPath<T1>(IUnionCaseShape target, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	{
+		if (this.Success)
+		{
+			failureResult = null;
+			return false;
+		}
+
+		failureResult = ConverterResult.Err<T1>(new VisitorError($"Union case: {target.UnionCaseType.Type.FullName ?? target.UnionCaseType.Type.Name}", this.Error));
+		return true;
+	}
+
+	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	public bool TryPrepareFailPath<T1>(IOptionalTypeShape shape, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	{
+		if (this.Success)
+		{
+			failureResult = null;
+			return false;
+		}
+
+		failureResult = ConverterResult.Err<T1>(new VisitorError($"Optional: {shape.Type.FullName ?? shape.Type.Name}", this.Error));
+		return true;
+	}
+
+	/// <inheritdoc/>
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	public bool TryPrepareFailPath<T1>(ITypeShape shape, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	{
+		if (this.Success)
+		{
+			failureResult = null;
+			return false;
+		}
+
+		failureResult = ConverterResult.Err<T1>(new VisitorError(shape.Type.FullName ?? shape.Type.Name, this.Error));
+		return true;
+	}
+
+	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
+	[MemberNotNullWhen(false, nameof(Value))]
+	[MemberNotNullWhen(true, nameof(Error))]
+	public bool TryPrepareFailPath<T1>(ISurrogateTypeShape shape, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	{
+		if (this.Success)
+		{
+			failureResult = null;
+			return false;
+		}
+
+		failureResult = ConverterResult.Err<T1>(new VisitorError($"surrogate {shape.SurrogateType.Type.FullName ?? shape.SurrogateType.Type.Name}", this.Error));
+		return true;
+	}
+
+	/// <summary>
+	/// Wraps the converter with one that provides reference preservation capabilities.
+	/// </summary>
+	/// <returns>A new result with the wrapped converter, or this same instance if it is already a failure.</returns>
+	public ConverterResult<T> WrapWithReferencePreservation()
+	{
+		return this.Success ? Ok(this.value is ReferencePreservingConverter<T> already ? already : new ReferencePreservingConverter<T>(this.Value)) : this;
+	}
+
+	/// <inheritdoc />
+	IConverterResult IConverterResult.WrapWithReferencePreservation() => this.WrapWithReferencePreservation();
+}

--- a/src/Nerdbank.MessagePack/ConverterResult.cs
+++ b/src/Nerdbank.MessagePack/ConverterResult.cs
@@ -10,129 +10,25 @@ using System.Diagnostics.CodeAnalysis;
 namespace Nerdbank.MessagePack;
 
 /// <summary>
-/// The result of an operation that was to produce a <see cref="MessagePackConverter"/>.
-/// </summary>
-internal interface IConverterResult
-{
-	/// <summary>
-	/// Gets a value indicating whether the operation was successful.
-	/// </summary>
-	[MemberNotNullWhen(true, nameof(Value))]
-	[MemberNotNullWhen(false, nameof(Error))]
-	bool Success { get; }
-
-	/// <summary>
-	/// Gets the converter.
-	/// </summary>
-	/// <exception cref="MessagePackSerializationException">Thrown if <see cref="Success"/> is <see langword="false"/>.</exception>
-	MessagePackConverter? Value { get; }
-
-	/// <summary>
-	/// Gets the converter, or throws if the result is a failure.
-	/// </summary>
-	MessagePackConverter ValueOrThrow { get; }
-
-	/// <summary>
-	/// Gets the error that describes why the operation failed.
-	/// </summary>
-	/// <exception cref="InvalidOperationException">Thrown if <see cref="Success"/> is <see langword="true"/>.</exception>
-	VisitorError? Error { get; }
-
-	/// <summary>
-	/// Wraps the converter with one that provides reference preservation capabilities.
-	/// </summary>
-	/// <returns>A new result with the wrapped converter, or this same instance if it is already a failure.</returns>
-	IConverterResult WrapWithReferencePreservation();
-
-	/// <summary>
-	/// Prepares a more descriptive failure result, if this result is a failure.
-	/// </summary>
-	/// <typeparam name="T">The type argument for the returned <see cref="ConverterResult{T}"/>.</typeparam>
-	/// <param name="stepMessage">The message to prepend to the error path.</param>
-	/// <param name="failureResult">Receives the new failure result, if this one is a failure.</param>
-	/// <returns><see langword="true"/> if this is a failure and <paramref name="failureResult"/> is set; <see langword="false"/> otherwise.</returns>
-	[MemberNotNullWhen(false, nameof(Value))]
-	[MemberNotNullWhen(true, nameof(Error))]
-	bool TryPrepareFailPath<T>(string stepMessage, [NotNullWhen(true)] out ConverterResult<T>? failureResult);
-
-	/// <summary>
-	/// Prepares a more descriptive failure result, if this result is a failure.
-	/// </summary>
-	/// <typeparam name="T">The type argument for the returned <see cref="ConverterResult{T}"/>.</typeparam>
-	/// <param name="target">The shape that failed to produce a converter.</param>
-	/// <param name="failureResult">Receives the new failure result, if this one is a failure.</param>
-	/// <returns><see langword="true"/> if this is a failure and <paramref name="failureResult"/> is set; <see langword="false"/> otherwise.</returns>
-	[MemberNotNullWhen(false, nameof(Value))]
-	[MemberNotNullWhen(true, nameof(Error))]
-	bool TryPrepareFailPath<T>(ITypeShape target, [NotNullWhen(true)] out ConverterResult<T>? failureResult);
-
-	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
-	[MemberNotNullWhen(false, nameof(Value))]
-	[MemberNotNullWhen(true, nameof(Error))]
-	bool TryPrepareFailPath<T>(IPropertyShape target, [NotNullWhen(true)] out ConverterResult<T>? failureResult);
-
-	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
-	[MemberNotNullWhen(false, nameof(Value))]
-	[MemberNotNullWhen(true, nameof(Error))]
-	bool TryPrepareFailPath<T>(IParameterShape target, [NotNullWhen(true)] out ConverterResult<T>? failureResult);
-}
-
-/// <summary>
-/// A factory for <see cref="ConverterResult{T}"/> instances.
-/// </summary>
-internal static class ConverterResult
-{
-	/// <summary>
-	/// Creates a successful result.
-	/// </summary>
-	/// <typeparam name="T">The type of value the converter handles.</typeparam>
-	/// <param name="value">The converter.</param>
-	/// <returns>A successful result.</returns>
-	internal static ConverterResult<T> Ok<T>(MessagePackConverter<T> value) => new(value);
-
-	/// <summary>
-	/// Creates a failure result.
-	/// </summary>
-	/// <typeparam name="T">The type of value the converter would have handled.</typeparam>
-	/// <param name="error">The error describing the failure.</param>
-	/// <returns>A failure result.</returns>
-	internal static ConverterResult<T> Err<T>(VisitorError error) => new(error);
-
-	/// <summary>
-	/// Maps a <see cref="Result{TValue, TError}"/> to a <see cref="ConverterResult{T}"/> using the specified <paramref name="mapper"/>.
-	/// </summary>
-	/// <typeparam name="T1">The type of result of the original value.</typeparam>
-	/// <typeparam name="T2">The type of result coming from the <paramref name="mapper"/>.</typeparam>
-	/// <param name="result">The original result.</param>
-	/// <param name="mapper">The mapper.</param>
-	/// <returns>The final result.</returns>
-	internal static ConverterResult<T2> MapResult<T1, T2>(this Result<T1, VisitorError> result, Func<T1, MessagePackConverter<T2>> mapper)
-	{
-		return result.Success ? Ok(mapper(result.Value)) : Err<T2>(result.Error);
-	}
-}
-
-/// <summary>
 /// The result of an operation that was to produce a <see cref="MessagePackConverter{T}"/>.
 /// </summary>
-/// <typeparam name="T">The type of value the converter can serialize.</typeparam>
 [DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
-internal class ConverterResult<T> : IConverterResult
+internal class ConverterResult
 {
-	private readonly MessagePackConverter<T>? value;
+	private readonly MessagePackConverter? value;
 	private readonly VisitorError? error;
 
 	/// <summary>
-	/// Initializes a new instance of the <see cref="ConverterResult{T}"/> class that represents success.
+	/// Initializes a new instance of the <see cref="ConverterResult"/> class with a converter.
 	/// </summary>
 	/// <param name="value">The converter.</param>
-	internal ConverterResult(MessagePackConverter<T> value)
+	internal ConverterResult(MessagePackConverter value)
 	{
 		this.value = value;
 	}
 
 	/// <summary>
-	/// Initializes a new instance of the <see cref="ConverterResult{T}"/> class that represents failure.
+	/// Initializes a new instance of the <see cref="ConverterResult"/> class that represents failure.
 	/// </summary>
 	/// <param name="error">The error.</param>
 	internal ConverterResult(VisitorError error)
@@ -140,21 +36,23 @@ internal class ConverterResult<T> : IConverterResult
 		this.error = error;
 	}
 
-	/// <inheritdoc />
+	/// <summary>
+	/// Gets a value indicating whether the converter was created.
+	/// </summary>
 	[MemberNotNullWhen(true, nameof(Value))]
 	[MemberNotNullWhen(false, nameof(Error))]
-	public bool Success => this.value is not null;
+	internal bool Success => this.value is not null;
+
+	/// <summary>
+	/// Gets the converter, if successfully created.
+	/// </summary>
+	internal MessagePackConverter? Value => this.value;
 
 	/// <summary>
 	/// Gets the converter.
 	/// </summary>
-	/// <exception cref="MessagePackSerializationException">Thrown if <see cref="Success"/> is <see langword="false"/>.</exception>
-	public MessagePackConverter<T>? Value => this.value;
-
-	/// <summary>
-	/// Gets the converter, or throws if the result is a failure.
-	/// </summary>
-	public MessagePackConverter<T> ValueOrThrow
+	/// <exception cref="Exception">Thrown when the converter could not be created.</exception>
+	internal MessagePackConverter ValueOrThrow
 	{
 		get
 		{
@@ -163,14 +61,10 @@ internal class ConverterResult<T> : IConverterResult
 		}
 	}
 
-	/// <inheritdoc/>
-	MessagePackConverter IConverterResult.ValueOrThrow => this.ValueOrThrow;
-
-	/// <inheritdoc />
-	public VisitorError? Error => this.error;
-
-	/// <inheritdoc />
-	MessagePackConverter? IConverterResult.Value => this.Value;
+	/// <summary>
+	/// Gets the error encountered when trying to create the converter, if any.
+	/// </summary>
+	internal VisitorError? Error => this.error;
 
 	/// <summary>
 	/// Gets a  string used by the debugger to display the current result.
@@ -178,41 +72,28 @@ internal class ConverterResult<T> : IConverterResult
 	private string DebuggerDisplay => this.Success ? $"Ok: {this.value}" : $"Err: {this.error}";
 
 	/// <summary>
-	/// Creates a successful result.
+	/// Wraps a converter as a successful result.
 	/// </summary>
 	/// <param name="value">The converter.</param>
 	/// <returns>A successful result.</returns>
-	public static ConverterResult<T> Ok(MessagePackConverter<T> value) => new(value);
+	internal static ConverterResult Ok(MessagePackConverter value) => new(value);
 
 	/// <summary>
-	/// Creates a failure result.
+	/// Wraps a visitor failure as a failed result.
 	/// </summary>
 	/// <param name="error">The error describing the failure.</param>
 	/// <returns>A failure result.</returns>
-	public static ConverterResult<T> Err(VisitorError error) => new(error);
+	internal static ConverterResult Err(VisitorError error) => new(error);
 
-	/// <inheritdoc cref="IConverterResult.TryPrepareFailPath{T}(string, out ConverterResult{T}?)"/>
+	/// <summary>
+	/// Wraps a failure result with additional context about the step that failed, if this result represents a failure.
+	/// </summary>
+	/// <param name="stepMessage">Additional context about the failure.</param>
+	/// <param name="failureResult">Receives a new failure result that contains the original and additional context, if this result represents a failure.</param>
+	/// <returns><see langword="true" /> if this result represents a failure; <see langword="false" /> otherwise.</returns>
 	[MemberNotNullWhen(false, nameof(Value))]
 	[MemberNotNullWhen(true, nameof(Error))]
-	public bool TryPrepareFailPath(string stepMessage, [NotNullWhen(true)] out ConverterResult<T>? failureResult)
-		=> this.TryPrepareFailPath<T>(stepMessage, out failureResult);
-
-	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
-	[MemberNotNullWhen(false, nameof(Value))]
-	[MemberNotNullWhen(true, nameof(Error))]
-	public bool TryPrepareFailPath(IPropertyShape property, [NotNullWhen(true)] out ConverterResult<T>? failureResult)
-		=> this.TryPrepareFailPath<T>(property, out failureResult);
-
-	/// <inheritdoc cref="IConverterResult.TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)"/>
-	[MemberNotNullWhen(false, nameof(Value))]
-	[MemberNotNullWhen(true, nameof(Error))]
-	public bool TryPrepareFailPath(ITypeShape typeShape, [NotNullWhen(true)] out ConverterResult<T>? failureResult)
-		=> this.TryPrepareFailPath<T>(typeShape, out failureResult);
-
-	/// <inheritdoc />
-	[MemberNotNullWhen(false, nameof(Value))]
-	[MemberNotNullWhen(true, nameof(Error))]
-	public bool TryPrepareFailPath<T1>(string stepMessage, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	internal bool TryPrepareFailPath(string stepMessage, [NotNullWhen(true)] out ConverterResult? failureResult)
 	{
 		if (this.Success)
 		{
@@ -220,14 +101,16 @@ internal class ConverterResult<T> : IConverterResult
 			return false;
 		}
 
-		failureResult = new ConverterResult<T1>(new VisitorError(stepMessage, this.Error));
+		failureResult = new ConverterResult(new VisitorError(stepMessage, this.Error));
 		return true;
 	}
 
-	/// <inheritdoc />
+	/// <inheritdoc cref="TryPrepareFailPath(string, out ConverterResult?)" />
+	/// <param name="shape">The shape that was being processed when the failure occurred.</param>
+	/// <param name="failureResult"><inheritdoc cref="TryPrepareFailPath(string, out ConverterResult?)" path="/param[@name='failureResult']" /></param>
 	[MemberNotNullWhen(false, nameof(Value))]
 	[MemberNotNullWhen(true, nameof(Error))]
-	public bool TryPrepareFailPath<T1>(IPropertyShape shape, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	internal bool TryPrepareFailPath(ITypeShape shape, [NotNullWhen(true)] out ConverterResult? failureResult)
 	{
 		if (this.Success)
 		{
@@ -235,14 +118,16 @@ internal class ConverterResult<T> : IConverterResult
 			return false;
 		}
 
-		failureResult = ConverterResult.Err<T1>(new VisitorError($"{shape.DeclaringType.Type.FullName}.{shape.Name}", this.Error));
+		failureResult = Err(new VisitorError(shape.Type.FullName ?? shape.Type.Name, this.Error));
 		return true;
 	}
 
-	/// <inheritdoc />
+	/// <inheritdoc cref="TryPrepareFailPath(ITypeShape, out ConverterResult?)" />
+	/// <param name="shape">The shape that was being processed when the failure occurred.</param>
+	/// <param name="failureResult"><inheritdoc cref="TryPrepareFailPath(string, out ConverterResult?)" path="/param[@name='failureResult']" /></param>
 	[MemberNotNullWhen(false, nameof(Value))]
 	[MemberNotNullWhen(true, nameof(Error))]
-	public bool TryPrepareFailPath<T1>(IParameterShape shape, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	internal bool TryPrepareFailPath(IPropertyShape shape, [NotNullWhen(true)] out ConverterResult? failureResult)
 	{
 		if (this.Success)
 		{
@@ -250,14 +135,14 @@ internal class ConverterResult<T> : IConverterResult
 			return false;
 		}
 
-		failureResult = ConverterResult.Err<T1>(new VisitorError($"{shape.Name}", this.Error));
+		failureResult = Err(new VisitorError($"{shape.DeclaringType.Type.FullName}.{shape.Name}", this.Error));
 		return true;
 	}
 
-	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
+	/// <inheritdoc cref="TryPrepareFailPath(ITypeShape, out ConverterResult?)" />
 	[MemberNotNullWhen(false, nameof(Value))]
 	[MemberNotNullWhen(true, nameof(Error))]
-	public bool TryPrepareFailPath<T1>(IUnionCaseShape target, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	internal bool TryPrepareFailPath(IParameterShape shape, [NotNullWhen(true)] out ConverterResult? failureResult)
 	{
 		if (this.Success)
 		{
@@ -265,14 +150,14 @@ internal class ConverterResult<T> : IConverterResult
 			return false;
 		}
 
-		failureResult = ConverterResult.Err<T1>(new VisitorError($"Union case: {target.UnionCaseType.Type.FullName ?? target.UnionCaseType.Type.Name}", this.Error));
+		failureResult = Err(new VisitorError($"{shape.Name}", this.Error));
 		return true;
 	}
 
-	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
+	/// <inheritdoc cref="TryPrepareFailPath(ITypeShape, out ConverterResult?)" />
 	[MemberNotNullWhen(false, nameof(Value))]
 	[MemberNotNullWhen(true, nameof(Error))]
-	public bool TryPrepareFailPath<T1>(IOptionalTypeShape shape, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	internal bool TryPrepareFailPath(IUnionCaseShape target, [NotNullWhen(true)] out ConverterResult? failureResult)
 	{
 		if (this.Success)
 		{
@@ -280,14 +165,14 @@ internal class ConverterResult<T> : IConverterResult
 			return false;
 		}
 
-		failureResult = ConverterResult.Err<T1>(new VisitorError($"Optional: {shape.Type.FullName ?? shape.Type.Name}", this.Error));
+		failureResult = Err(new VisitorError($"Union case: {target.UnionCaseType.Type.FullName ?? target.UnionCaseType.Type.Name}", this.Error));
 		return true;
 	}
 
-	/// <inheritdoc/>
+	/// <inheritdoc cref="TryPrepareFailPath(ITypeShape, out ConverterResult?)" />
 	[MemberNotNullWhen(false, nameof(Value))]
 	[MemberNotNullWhen(true, nameof(Error))]
-	public bool TryPrepareFailPath<T1>(ITypeShape shape, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	internal bool TryPrepareFailPath(IOptionalTypeShape shape, [NotNullWhen(true)] out ConverterResult? failureResult)
 	{
 		if (this.Success)
 		{
@@ -295,14 +180,14 @@ internal class ConverterResult<T> : IConverterResult
 			return false;
 		}
 
-		failureResult = ConverterResult.Err<T1>(new VisitorError(shape.Type.FullName ?? shape.Type.Name, this.Error));
+		failureResult = Err(new VisitorError($"Optional: {shape.Type.FullName ?? shape.Type.Name}", this.Error));
 		return true;
 	}
 
-	/// <inheritdoc cref="TryPrepareFailPath{T}(ITypeShape, out ConverterResult{T}?)" />
+	/// <inheritdoc cref="TryPrepareFailPath(ITypeShape, out ConverterResult?)" />
 	[MemberNotNullWhen(false, nameof(Value))]
 	[MemberNotNullWhen(true, nameof(Error))]
-	public bool TryPrepareFailPath<T1>(ISurrogateTypeShape shape, [NotNullWhen(true)] out ConverterResult<T1>? failureResult)
+	internal bool TryPrepareFailPath(ISurrogateTypeShape shape, [NotNullWhen(true)] out ConverterResult? failureResult)
 	{
 		if (this.Success)
 		{
@@ -310,7 +195,7 @@ internal class ConverterResult<T> : IConverterResult
 			return false;
 		}
 
-		failureResult = ConverterResult.Err<T1>(new VisitorError($"surrogate {shape.SurrogateType.Type.FullName ?? shape.SurrogateType.Type.Name}", this.Error));
+		failureResult = Err(new VisitorError($"surrogate {shape.SurrogateType.Type.FullName ?? shape.SurrogateType.Type.Name}", this.Error));
 		return true;
 	}
 
@@ -318,11 +203,8 @@ internal class ConverterResult<T> : IConverterResult
 	/// Wraps the converter with one that provides reference preservation capabilities.
 	/// </summary>
 	/// <returns>A new result with the wrapped converter, or this same instance if it is already a failure.</returns>
-	public ConverterResult<T> WrapWithReferencePreservation()
+	internal ConverterResult WrapWithReferencePreservation()
 	{
-		return this.Success ? Ok(this.value is ReferencePreservingConverter<T> already ? already : new ReferencePreservingConverter<T>(this.Value)) : this;
+		return this.Success ? Ok(((IMessagePackConverterInternal)this.Value).WrapWithReferencePreservation()) : this;
 	}
-
-	/// <inheritdoc />
-	IConverterResult IConverterResult.WrapWithReferencePreservation() => this.WrapWithReferencePreservation();
 }

--- a/src/Nerdbank.MessagePack/Converters/DelayedConverterFactory.cs
+++ b/src/Nerdbank.MessagePack/Converters/DelayedConverterFactory.cs
@@ -13,14 +13,14 @@ internal sealed class DelayedConverterFactory : IDelayedValueFactory
 {
 	/// <inheritdoc/>
 	public DelayedValue Create<T>(ITypeShape<T> typeShape)
-		=> new DelayedValue<ConverterResult<T>>(self => ConverterResult.Ok(new DelayedConverter<T>(self)));
+		=> new DelayedValue<ConverterResult>(self => ConverterResult.Ok(new DelayedConverter<T>(self)));
 
 	/// <summary>
 	/// A converter that defers to another converter that is not yet available.
 	/// </summary>
 	/// <typeparam name="T">The convertible data type.</typeparam>
 	/// <param name="self">A box containing the not-yet-done converter.</param>
-	internal class DelayedConverter<T>(DelayedValue<ConverterResult<T>> self) : MessagePackConverter<T>
+	internal class DelayedConverter<T>(DelayedValue<ConverterResult> self) : MessagePackConverter<T>
 	{
 		/// <inheritdoc/>
 		public override bool PreferAsyncSerialization => self.Result.ValueOrThrow.PreferAsyncSerialization;
@@ -31,19 +31,19 @@ internal sealed class DelayedConverterFactory : IDelayedValueFactory
 
 		/// <inheritdoc/>
 		public override T? Read(ref MessagePackReader reader, SerializationContext context)
-			=> self.Result.ValueOrThrow.Read(ref reader, context);
+			=> ((MessagePackConverter<T>)self.Result.ValueOrThrow).Read(ref reader, context);
 
 		/// <inheritdoc/>
 		public override ValueTask<T?> ReadAsync(MessagePackAsyncReader reader, SerializationContext context)
-			=> self.Result.ValueOrThrow.ReadAsync(reader, context);
+			=> ((MessagePackConverter<T>)self.Result.ValueOrThrow).ReadAsync(reader, context);
 
 		/// <inheritdoc/>
 		public override void Write(ref MessagePackWriter writer, in T? value, SerializationContext context)
-			=> self.Result.ValueOrThrow.Write(ref writer, value, context);
+			=> ((MessagePackConverter<T>)self.Result.ValueOrThrow).Write(ref writer, value, context);
 
 		/// <inheritdoc/>
 		public override ValueTask WriteAsync(MessagePackAsyncWriter writer, T? value, SerializationContext context)
-			=> self.Result.ValueOrThrow.WriteAsync(writer, value, context);
+			=> ((MessagePackConverter<T>)self.Result.ValueOrThrow).WriteAsync(writer, value, context);
 
 		/// <inheritdoc/>
 		public override ValueTask<bool> SkipToIndexValueAsync(MessagePackAsyncReader reader, object? index, SerializationContext context)

--- a/src/Nerdbank.MessagePack/Converters/DelayedConverterFactory.cs
+++ b/src/Nerdbank.MessagePack/Converters/DelayedConverterFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 using PolyType.Utilities;
 
@@ -14,36 +13,44 @@ internal sealed class DelayedConverterFactory : IDelayedValueFactory
 {
 	/// <inheritdoc/>
 	public DelayedValue Create<T>(ITypeShape<T> typeShape)
-		=> new DelayedValue<MessagePackConverter<T>>(self => new DelayedConverter<T>(self));
+		=> new DelayedValue<ConverterResult<T>>(self => ConverterResult.Ok(new DelayedConverter<T>(self)));
 
 	/// <summary>
 	/// A converter that defers to another converter that is not yet available.
 	/// </summary>
 	/// <typeparam name="T">The convertible data type.</typeparam>
 	/// <param name="self">A box containing the not-yet-done converter.</param>
-	internal class DelayedConverter<T>(DelayedValue<MessagePackConverter<T>> self) : MessagePackConverter<T>
+	internal class DelayedConverter<T>(DelayedValue<ConverterResult<T>> self) : MessagePackConverter<T>
 	{
 		/// <inheritdoc/>
-		public override bool PreferAsyncSerialization => self.Result.PreferAsyncSerialization;
+		public override bool PreferAsyncSerialization => self.Result.ValueOrThrow.PreferAsyncSerialization;
 
 		/// <inheritdoc/>
 		public override JsonObject? GetJsonSchema(JsonSchemaContext context, ITypeShape typeShape)
-			=> self.Result.GetJsonSchema(context, typeShape);
+			=> self.Result.ValueOrThrow.GetJsonSchema(context, typeShape);
 
 		/// <inheritdoc/>
 		public override T? Read(ref MessagePackReader reader, SerializationContext context)
-			=> self.Result.Read(ref reader, context);
+			=> self.Result.ValueOrThrow.Read(ref reader, context);
 
 		/// <inheritdoc/>
 		public override ValueTask<T?> ReadAsync(MessagePackAsyncReader reader, SerializationContext context)
-			=> self.Result.ReadAsync(reader, context);
+			=> self.Result.ValueOrThrow.ReadAsync(reader, context);
 
 		/// <inheritdoc/>
 		public override void Write(ref MessagePackWriter writer, in T? value, SerializationContext context)
-			=> self.Result.Write(ref writer, value, context);
+			=> self.Result.ValueOrThrow.Write(ref writer, value, context);
 
 		/// <inheritdoc/>
 		public override ValueTask WriteAsync(MessagePackAsyncWriter writer, T? value, SerializationContext context)
-			=> self.Result.WriteAsync(writer, value, context);
+			=> self.Result.ValueOrThrow.WriteAsync(writer, value, context);
+
+		/// <inheritdoc/>
+		public override ValueTask<bool> SkipToIndexValueAsync(MessagePackAsyncReader reader, object? index, SerializationContext context)
+			=> self.Result.ValueOrThrow.SkipToIndexValueAsync(reader, index, context);
+
+		/// <inheritdoc/>
+		public override ValueTask<bool> SkipToPropertyValueAsync(MessagePackAsyncReader reader, IPropertyShape propertyShape, SerializationContext context)
+			=> self.Result.ValueOrThrow.SkipToPropertyValueAsync(reader, propertyShape, context);
 	}
 }

--- a/src/Nerdbank.MessagePack/JsonSchemaContext.cs
+++ b/src/Nerdbank.MessagePack/JsonSchemaContext.cs
@@ -61,7 +61,7 @@ public class JsonSchemaContext
 			return CreateReference(qualifiedReference);
 		}
 
-		MessagePackConverter converter = this.cache.GetOrAddConverter(typeShape);
+		MessagePackConverter converter = this.cache.GetOrAddConverter(typeShape).ValueOrThrow;
 		if (converter.GetJsonSchema(this, typeShape) is not JsonObject schema)
 		{
 			schema = MessagePackConverter<int>.CreateUndocumentedSchema(converter.GetType());

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -212,7 +212,7 @@ public partial record MessagePackSerializer
 		try
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
-			this.ConverterCache.GetOrAddConverter(shape).WriteObject(ref writer, value, context.Value);
+			this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.WriteObject(ref writer, value, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -235,7 +235,7 @@ public partial record MessagePackSerializer
 		try
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
-			this.ConverterCache.GetOrAddConverter(shape).Write(ref writer, value, context.Value);
+			this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.Write(ref writer, value, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -256,7 +256,7 @@ public partial record MessagePackSerializer
 		try
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(provider, cancellationToken);
-			this.ConverterCache.GetOrAddConverter<T>(provider).Write(ref writer, value, context.Value);
+			this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow.Write(ref writer, value, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -281,7 +281,7 @@ public partial record MessagePackSerializer
 		try
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
-			return this.ConverterCache.GetOrAddConverter(shape).ReadObject(ref reader, context.Value);
+			return this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.ReadObject(ref reader, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -365,7 +365,7 @@ public partial record MessagePackSerializer
 		using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
 		try
 		{
-			return this.ConverterCache.GetOrAddConverter(shape).Read(ref reader, context.Value);
+			return this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.Read(ref reader, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -392,7 +392,7 @@ public partial record MessagePackSerializer
 		try
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(provider, cancellationToken);
-			return this.ConverterCache.GetOrAddConverter<T>(provider).Read(ref reader, context.Value);
+			return this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow.Read(ref reader, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -418,7 +418,7 @@ public partial record MessagePackSerializer
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
 			MessagePackAsyncWriter asyncWriter = new(writer);
-			await this.ConverterCache.GetOrAddConverter(shape).WriteAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
+			await this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.WriteAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
 			asyncWriter.Flush();
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
@@ -437,7 +437,7 @@ public partial record MessagePackSerializer
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
 			MessagePackAsyncWriter asyncWriter = new(writer);
-			await this.ConverterCache.GetOrAddConverter(shape).WriteObjectAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
+			await this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.WriteObjectAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
 			asyncWriter.Flush();
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
@@ -463,7 +463,7 @@ public partial record MessagePackSerializer
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(provider, cancellationToken);
 			MessagePackAsyncWriter asyncWriter = new(writer);
-			await this.ConverterCache.GetOrAddConverter<T>(provider).WriteAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
+			await this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow.WriteAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
 			asyncWriter.Flush();
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
@@ -481,11 +481,11 @@ public partial record MessagePackSerializer
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>The deserialized value.</returns>
 	public ValueTask<T?> DeserializeAsync<T>(PipeReader reader, ITypeShape<T> shape, CancellationToken cancellationToken = default)
-		=> this.DeserializeAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, this.ConverterCache.GetOrAddConverter(shape), cancellationToken);
+		=> this.DeserializeAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow, cancellationToken);
 
 	/// <inheritdoc cref="DeserializeAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)"/>
 	public ValueTask<object?> DeserializeObjectAsync(PipeReader reader, ITypeShape shape, CancellationToken cancellationToken = default)
-		=> this.DeserializeObjectAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, this.ConverterCache.GetOrAddConverter(shape), cancellationToken);
+		=> this.DeserializeObjectAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow, cancellationToken);
 
 	/// <summary>
 	/// Deserializes a value from a <see cref="PipeReader"/>.
@@ -496,7 +496,7 @@ public partial record MessagePackSerializer
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>The deserialized value.</returns>
 	public ValueTask<T?> DeserializeAsync<T>(PipeReader reader, ITypeShapeProvider provider, CancellationToken cancellationToken = default)
-		=> this.DeserializeAsync(Requires.NotNull(reader), Requires.NotNull(provider), this.ConverterCache.GetOrAddConverter<T>(provider), cancellationToken);
+		=> this.DeserializeAsync(Requires.NotNull(reader), Requires.NotNull(provider), this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow, cancellationToken);
 
 	/// <inheritdoc cref="ConvertToJson(in ReadOnlySequence{byte}, JsonOptions?)"/>
 	public string ConvertToJson(ReadOnlyMemory<byte> msgpack, JsonOptions? options = null) => this.ConvertToJson(new ReadOnlySequence<byte>(msgpack), options);
@@ -756,29 +756,29 @@ public partial record MessagePackSerializer
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 	public IAsyncEnumerable<T?> DeserializeEnumerableAsync<T>(PipeReader reader, ITypeShape<T> shape, CancellationToken cancellationToken = default)
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, this.ConverterCache.GetOrAddConverter(shape), cancellationToken);
+		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow, cancellationToken);
 
 	/// <inheritdoc cref="DeserializeEnumerableAsync{T}(PipeReader, ITypeShapeProvider, MessagePackConverter{T}, CancellationToken)"/>
 	public IAsyncEnumerable<T?> DeserializeEnumerableAsync<T>(PipeReader reader, ITypeShapeProvider provider, CancellationToken cancellationToken = default)
-		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), provider, this.ConverterCache.GetOrAddConverter<T>(provider), cancellationToken);
+		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), provider, this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow, cancellationToken);
 
 	/// <inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShapeProvider, StreamingEnumerationOptions{T, TElement}, MessagePackConverter{TElement}, CancellationToken)"/>
 	/// <param name="shape"><inheritdoc cref="DeserializeAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" path="/param[@name='shape']"/></param>
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 	public IAsyncEnumerable<TElement?> DeserializeEnumerableAsync<T, TElement>(PipeReader reader, ITypeShape<T> shape, StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, Requires.NotNull(options), this.ConverterCache.GetOrAddConverter(shape.Provider.GetTypeShapeOrThrow<TElement>()), cancellationToken);
+		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, Requires.NotNull(options), this.ConverterCache.GetOrAddConverter(shape.Provider.GetTypeShapeOrThrow<TElement>()).ValueOrThrow, cancellationToken);
 
 	/// <inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShapeProvider, StreamingEnumerationOptions{T, TElement}, MessagePackConverter{TElement}, CancellationToken)"/>
 	public IAsyncEnumerable<TElement?> DeserializeEnumerableAsync<T, TElement>(PipeReader reader, ITypeShapeProvider provider, StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
-		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), provider, Requires.NotNull(options), this.ConverterCache.GetOrAddConverter<TElement>(provider), cancellationToken);
+		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), provider, Requires.NotNull(options), this.ConverterCache.GetOrAddConverter<TElement>(provider).ValueOrThrow, cancellationToken);
 
 	/// <summary>
 	/// Gets a converter for a given type shape.
 	/// </summary>
 	/// <param name="typeShape">The type shape.</param>
 	/// <returns>A converter.</returns>
-	internal MessagePackConverter GetConverter(ITypeShape typeShape) => this.ConverterCache.GetOrAddConverter(typeShape);
+	internal IConverterResult GetConverter(ITypeShape typeShape) => this.ConverterCache.GetOrAddConverter(typeShape);
 
 	/// <summary>
 	/// Creates a new serialization context that is ready to process a serialization job.

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -235,7 +235,7 @@ public partial record MessagePackSerializer
 		try
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
-			this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.Write(ref writer, value, context.Value);
+			((MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow).Write(ref writer, value, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -256,7 +256,7 @@ public partial record MessagePackSerializer
 		try
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(provider, cancellationToken);
-			this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow.Write(ref writer, value, context.Value);
+			((MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow).Write(ref writer, value, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -365,7 +365,7 @@ public partial record MessagePackSerializer
 		using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
 		try
 		{
-			return this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.Read(ref reader, context.Value);
+			return ((MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow).Read(ref reader, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -392,7 +392,7 @@ public partial record MessagePackSerializer
 		try
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(provider, cancellationToken);
-			return this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow.Read(ref reader, context.Value);
+			return ((MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow).Read(ref reader, context.Value);
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -418,7 +418,7 @@ public partial record MessagePackSerializer
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
 			MessagePackAsyncWriter asyncWriter = new(writer);
-			await this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.WriteAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
+			await ((MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow).WriteAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
 			asyncWriter.Flush();
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
@@ -463,7 +463,7 @@ public partial record MessagePackSerializer
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(provider, cancellationToken);
 			MessagePackAsyncWriter asyncWriter = new(writer);
-			await this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow.WriteAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
+			await ((MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow).WriteAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
 			asyncWriter.Flush();
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
@@ -481,7 +481,7 @@ public partial record MessagePackSerializer
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>The deserialized value.</returns>
 	public ValueTask<T?> DeserializeAsync<T>(PipeReader reader, ITypeShape<T> shape, CancellationToken cancellationToken = default)
-		=> this.DeserializeAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow, cancellationToken);
+		=> this.DeserializeAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, (MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow, cancellationToken);
 
 	/// <inheritdoc cref="DeserializeAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)"/>
 	public ValueTask<object?> DeserializeObjectAsync(PipeReader reader, ITypeShape shape, CancellationToken cancellationToken = default)
@@ -496,7 +496,7 @@ public partial record MessagePackSerializer
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>The deserialized value.</returns>
 	public ValueTask<T?> DeserializeAsync<T>(PipeReader reader, ITypeShapeProvider provider, CancellationToken cancellationToken = default)
-		=> this.DeserializeAsync(Requires.NotNull(reader), Requires.NotNull(provider), this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow, cancellationToken);
+		=> this.DeserializeAsync(Requires.NotNull(reader), Requires.NotNull(provider), (MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow, cancellationToken);
 
 	/// <inheritdoc cref="ConvertToJson(in ReadOnlySequence{byte}, JsonOptions?)"/>
 	public string ConvertToJson(ReadOnlyMemory<byte> msgpack, JsonOptions? options = null) => this.ConvertToJson(new ReadOnlySequence<byte>(msgpack), options);
@@ -756,29 +756,29 @@ public partial record MessagePackSerializer
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 	public IAsyncEnumerable<T?> DeserializeEnumerableAsync<T>(PipeReader reader, ITypeShape<T> shape, CancellationToken cancellationToken = default)
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow, cancellationToken);
+		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, (MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow, cancellationToken);
 
 	/// <inheritdoc cref="DeserializeEnumerableAsync{T}(PipeReader, ITypeShapeProvider, MessagePackConverter{T}, CancellationToken)"/>
 	public IAsyncEnumerable<T?> DeserializeEnumerableAsync<T>(PipeReader reader, ITypeShapeProvider provider, CancellationToken cancellationToken = default)
-		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), provider, this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow, cancellationToken);
+		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), provider, (MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter<T>(provider).ValueOrThrow, cancellationToken);
 
 	/// <inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShapeProvider, StreamingEnumerationOptions{T, TElement}, MessagePackConverter{TElement}, CancellationToken)"/>
 	/// <param name="shape"><inheritdoc cref="DeserializeAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" path="/param[@name='shape']"/></param>
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
 	public IAsyncEnumerable<TElement?> DeserializeEnumerableAsync<T, TElement>(PipeReader reader, ITypeShape<T> shape, StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
 #pragma warning restore CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
-		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, Requires.NotNull(options), this.ConverterCache.GetOrAddConverter(shape.Provider.GetTypeShapeOrThrow<TElement>()).ValueOrThrow, cancellationToken);
+		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), Requires.NotNull(shape).Provider, Requires.NotNull(options), (MessagePackConverter<TElement>)this.ConverterCache.GetOrAddConverter(shape.Provider.GetTypeShapeOrThrow<TElement>()).ValueOrThrow, cancellationToken);
 
 	/// <inheritdoc cref="DeserializeEnumerableAsync{T, TElement}(PipeReader, ITypeShapeProvider, StreamingEnumerationOptions{T, TElement}, MessagePackConverter{TElement}, CancellationToken)"/>
 	public IAsyncEnumerable<TElement?> DeserializeEnumerableAsync<T, TElement>(PipeReader reader, ITypeShapeProvider provider, StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
-		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), provider, Requires.NotNull(options), this.ConverterCache.GetOrAddConverter<TElement>(provider).ValueOrThrow, cancellationToken);
+		=> this.DeserializeEnumerableAsync(Requires.NotNull(reader), provider, Requires.NotNull(options), (MessagePackConverter<TElement>)this.ConverterCache.GetOrAddConverter<TElement>(provider).ValueOrThrow, cancellationToken);
 
 	/// <summary>
 	/// Gets a converter for a given type shape.
 	/// </summary>
 	/// <param name="typeShape">The type shape.</param>
 	/// <returns>A converter.</returns>
-	internal IConverterResult GetConverter(ITypeShape typeShape) => this.ConverterCache.GetOrAddConverter(typeShape);
+	internal ConverterResult GetConverter(ITypeShape typeShape) => this.ConverterCache.GetOrAddConverter(typeShape);
 
 	/// <summary>
 	/// Creates a new serialization context that is ready to process a serialization job.

--- a/src/Nerdbank.MessagePack/PolyfillExtensions.cs
+++ b/src/Nerdbank.MessagePack/PolyfillExtensions.cs
@@ -437,8 +437,6 @@ namespace Nerdbank.MessagePack
 			value = default;
 			return false;
 		}
-
-		internal static Exception ThrowNotSupportedOnNETFramework() => throw new PlatformNotSupportedException("This functionality is only supported on .NET.");
 	}
 #endif
 }

--- a/src/Nerdbank.MessagePack/ReferencePreservingVisitor.cs
+++ b/src/Nerdbank.MessagePack/ReferencePreservingVisitor.cs
@@ -19,19 +19,19 @@ internal class ReferencePreservingVisitor(TypeShapeVisitor inner) : TypeShapeVis
 
 	/// <inheritdoc/>
 	public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
-		=> ((IMessagePackConverterInternal)inner.VisitDictionary(dictionaryShape, state)!).WrapWithReferencePreservation();
+		=> ((IConverterResult)inner.VisitDictionary(dictionaryShape, state)!).WrapWithReferencePreservation();
 
 	/// <inheritdoc/>
 	public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state = null)
-		=> ((IMessagePackConverterInternal)inner.VisitEnumerable(enumerableShape, state)!).WrapWithReferencePreservation();
+		=> ((IConverterResult)inner.VisitEnumerable(enumerableShape, state)!).WrapWithReferencePreservation();
 
 	/// <inheritdoc/>
 	public override object? VisitObject<T>(IObjectTypeShape<T> objectShape, object? state = null)
-		=> ((IMessagePackConverterInternal)inner.VisitObject(objectShape, state)!).WrapWithReferencePreservation();
+		=> ((IConverterResult)inner.VisitObject(objectShape, state)!).WrapWithReferencePreservation();
 
 	/// <inheritdoc/>
 	public override object? VisitUnion<TUnion>(IUnionTypeShape<TUnion> unionShape, object? state = null)
-		=> ((IMessagePackConverterInternal)inner.VisitUnion(unionShape, state)!).WrapWithReferencePreservation();
+		=> ((IConverterResult)inner.VisitUnion(unionShape, state)!).WrapWithReferencePreservation();
 
 	/// <inheritdoc/>
 	public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state = null)
@@ -39,5 +39,5 @@ internal class ReferencePreservingVisitor(TypeShapeVisitor inner) : TypeShapeVis
 
 	/// <inheritdoc/>
 	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
-		=> ((IMessagePackConverterInternal)inner.VisitSurrogate(surrogateShape, state)!).WrapWithReferencePreservation();
+		=> ((IConverterResult)inner.VisitSurrogate(surrogateShape, state)!).WrapWithReferencePreservation();
 }

--- a/src/Nerdbank.MessagePack/ReferencePreservingVisitor.cs
+++ b/src/Nerdbank.MessagePack/ReferencePreservingVisitor.cs
@@ -19,19 +19,19 @@ internal class ReferencePreservingVisitor(TypeShapeVisitor inner) : TypeShapeVis
 
 	/// <inheritdoc/>
 	public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
-		=> ((IConverterResult)inner.VisitDictionary(dictionaryShape, state)!).WrapWithReferencePreservation();
+		=> ((ConverterResult)inner.VisitDictionary(dictionaryShape, state)!).WrapWithReferencePreservation();
 
 	/// <inheritdoc/>
 	public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state = null)
-		=> ((IConverterResult)inner.VisitEnumerable(enumerableShape, state)!).WrapWithReferencePreservation();
+		=> ((ConverterResult)inner.VisitEnumerable(enumerableShape, state)!).WrapWithReferencePreservation();
 
 	/// <inheritdoc/>
 	public override object? VisitObject<T>(IObjectTypeShape<T> objectShape, object? state = null)
-		=> ((IConverterResult)inner.VisitObject(objectShape, state)!).WrapWithReferencePreservation();
+		=> ((ConverterResult)inner.VisitObject(objectShape, state)!).WrapWithReferencePreservation();
 
 	/// <inheritdoc/>
 	public override object? VisitUnion<TUnion>(IUnionTypeShape<TUnion> unionShape, object? state = null)
-		=> ((IConverterResult)inner.VisitUnion(unionShape, state)!).WrapWithReferencePreservation();
+		=> ((ConverterResult)inner.VisitUnion(unionShape, state)!).WrapWithReferencePreservation();
 
 	/// <inheritdoc/>
 	public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state = null)
@@ -39,5 +39,5 @@ internal class ReferencePreservingVisitor(TypeShapeVisitor inner) : TypeShapeVis
 
 	/// <inheritdoc/>
 	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
-		=> ((IConverterResult)inner.VisitSurrogate(surrogateShape, state)!).WrapWithReferencePreservation();
+		=> ((ConverterResult)inner.VisitSurrogate(surrogateShape, state)!).WrapWithReferencePreservation();
 }

--- a/src/Nerdbank.MessagePack/ResultExtensions.cs
+++ b/src/Nerdbank.MessagePack/ResultExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// Extension methods for the <see cref="Result{TValue, TError}"/> type.
+/// </summary>
+internal static class ResultExtensions
+{
+	/// <summary>
+	/// Maps a <see cref="Result{TValue, TError}"/> to a <see cref="ConverterResult"/> using the specified <paramref name="mapper"/>.
+	/// </summary>
+	/// <typeparam name="T1">The type of result of the original value.</typeparam>
+	/// <typeparam name="T2">The type of result coming from the <paramref name="mapper"/>.</typeparam>
+	/// <param name="result">The original result.</param>
+	/// <param name="mapper">The mapper.</param>
+	/// <returns>The final result.</returns>
+	internal static ConverterResult MapResult<T1, T2>(this Result<T1, VisitorError> result, Func<T1, MessagePackConverter<T2>> mapper)
+		=> result.Success ? ConverterResult.Ok(mapper(result.Value)) : ConverterResult.Err(result.Error);
+}

--- a/src/Nerdbank.MessagePack/Result`2.cs
+++ b/src/Nerdbank.MessagePack/Result`2.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// Represents the outcome of an operation that may have produced either a value of type <typeparamref name="TValue"/>
+/// or an exception describing a failure.
+/// </summary>
+/// <typeparam name="TValue">The type of the successful result value.</typeparam>
+/// <typeparam name="TError">The type of the error value.</typeparam>
+[DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
+internal struct Result<TValue, TError> : IEquatable<Result<TValue, TError>>
+{
+	private bool? success;
+	private TValue? value;
+	private TError? error;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Result{TValue, TError}"/> struct representing a successful value.
+	/// </summary>
+	/// <param name="value">The successful result value.</param>
+	private Result(TValue value)
+	{
+		this.value = value;
+		this.success = true;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Result{TValue, TError}"/> struct representing a failure.
+	/// </summary>
+	/// <param name="error">The exception that represents the failure.</param>
+	private Result(TError error)
+	{
+		this.error = error;
+		this.success = false;
+	}
+
+	/// <summary>
+	/// Gets a value indicating whether this instance is the default, i.e. no result (neither success nor failure) was recorded.
+	/// </summary>
+	public bool IsDefault => this.success is null;
+
+	/// <summary>
+	/// Gets a value indicating whether the recorded result represents a success.
+	/// </summary>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="IsDefault"/> is <see langword="true" />.</exception>
+	public bool Success => this.success ?? throw new InvalidOperationException("No result was recorded.");
+
+	/// <summary>
+	/// Gets the successful value when <see cref="Success"/> is true.
+	/// If the result represents a failure, the recorded exception is thrown.
+	/// </summary>
+	/// <exception cref="Exception">The recorded exception is rethrown if the result represents a failure.</exception>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="IsDefault"/> is <see langword="true" />.</exception>
+	public TValue Value => this.Success ? this.value! : throw new InvalidOperationException("No value was recorded.");
+
+	/// <summary>
+	/// Gets the recorded exception when <see cref="Success"/> is false.
+	/// </summary>
+	/// <exception cref="InvalidOperationException">Thrown when no error was recorded (when <see cref="Success"/> is true).</exception>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="IsDefault"/> is <see langword="true" />.</exception>
+	public TError Error => !this.Success ? this.error! : throw new InvalidOperationException("No error was recorded.");
+
+	/// <summary>
+	/// Gets a  string used by the debugger to display the current result.
+	/// </summary>
+	private string DebuggerDisplay => this.IsDefault ? "(default)" : (this.Success ? $"Ok: {this.value}" : $"Err: {this.error}");
+
+	/// <summary>
+	/// Implicitly converts a value of <typeparamref name="TValue"/> into a successful <see cref="Result{TValue, TError}"/>.
+	/// </summary>
+	/// <param name="value">The value to wrap as a successful result.</param>
+	public static implicit operator Result<TValue, TError>(TValue value) => Ok(value);
+
+	/// <summary>
+	/// Implicitly converts an <see cref="Exception"/> into a failed <see cref="Result{TValue, TError}"/>.
+	/// </summary>
+	/// <param name="error">The error to wrap as a failed result.</param>
+	public static implicit operator Result<TValue, TError>(TError error) => Err(error);
+
+	/// <summary>
+	/// Creates a <see cref="Result{TValue, TError}"/> that represents a successful operation with the provided value.
+	/// </summary>
+	/// <param name="value">The successful result value.</param>
+	/// <returns>A <see cref="Result{TValue, TError}"/> representing success.</returns>
+	public static Result<TValue, TError> Ok(TValue value) => new(value);
+
+	/// <summary>
+	/// Creates a <see cref="Result{TValue, TError}"/> that represents a failed operation with the provided exception.
+	/// </summary>
+	/// <param name="error">The error that represents the failure.</param>
+	/// <returns>A <see cref="Result{TValue, TError}"/> representing failure.</returns>
+	public static Result<TValue, TError> Err(TError error) => new(error);
+
+	/// <summary>
+	/// Returns the successful value when this result represents success; otherwise returns the provided default value.
+	/// </summary>
+	/// <param name="defaultValue">The value to return if this result represents an error.</param>
+	/// <returns>The successful value when <see cref="Success"/> is <see langword="true"/>, otherwise <paramref name="defaultValue"/>.</returns>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="IsDefault"/> is <see langword="true"/>.</exception>
+	public TValue GetValueOrDefault(TValue defaultValue) => this.Success ? this.Value : defaultValue;
+
+	/// <inheritdoc/>
+	public bool Equals(Result<TValue, TError> other)
+	{
+		if (this.success != other.success)
+		{
+			return false;
+		}
+
+		if (!this.success.HasValue)
+		{
+			return true;
+		}
+
+		return this.success.Value
+			? EqualityComparer<TValue?>.Default.Equals(this.value, other.value)
+			: EqualityComparer<TError?>.Default.Equals(this.error, other.error);
+	}
+
+	/// <summary>
+	/// Transforms the successful value of this result using the specified <paramref name="mapper"/>.
+	/// </summary>
+	/// <typeparam name="TResult">The type of the value produced by the <paramref name="mapper"/>.</typeparam>
+	/// <param name="mapper">A function that maps the successful value to a new value.</param>
+	/// <returns>
+	/// A <see cref="Result{TResult, TError}"/> containing the mapped value when this result is successful,
+	/// otherwise a failed <see cref="Result{TResult, TError}"/> containing the original error.
+	/// </returns>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="IsDefault"/> is <see langword="true"/>.</exception>
+	public Result<TResult, TError> Map<TResult>(Func<TValue, TResult> mapper) => this.Success ? mapper(this.Value) : this.Error;
+
+	/// <summary>
+	/// Binds the successful value of this result to another operation that itself returns a <see cref="Result{TResult, TError}"/>.
+	/// </summary>
+	/// <typeparam name="TResult">The result type of the bound operation.</typeparam>
+	/// <param name="binder">A function that, given the successful value, returns a new <see cref="Result{TResult, TError}"/>.</param>
+	/// <returns>
+	/// The <see cref="Result{TResult, TError}"/> returned by <paramref name="binder"/> when this result is successful,
+	/// otherwise a failed <see cref="Result{TResult, TError}"/> containing the original error.
+	/// </returns>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="IsDefault"/> is <see langword="true"/>.</exception>
+	public Result<TResult, TError> Binder<TResult>(Func<TValue, Result<TResult, TError>> binder) => this.Success ? binder(this.Value) : this.Error;
+
+	/// <summary>
+	/// Matches on the result, invoking <paramref name="onSuccess"/> when successful or <paramref name="onError"/> when failed.
+	/// </summary>
+	/// <typeparam name="T">The return type of the match handlers.</typeparam>
+	/// <param name="onSuccess">Function to run when the result represents success. Receives the successful value.</param>
+	/// <param name="onError">Function to run when the result represents failure. Receives the recorded error.</param>
+	/// <returns>The value returned by the invoked handler.</returns>
+	/// <exception cref="InvalidOperationException">Thrown if <see cref="IsDefault"/> is <see langword="true"/>.</exception>
+	public T Match<T>(Func<TValue, T> onSuccess, Func<TError, T> onError) => this.Success ? onSuccess(this.Value) : onError(this.Error);
+}

--- a/src/Nerdbank.MessagePack/SerializationContext.cs
+++ b/src/Nerdbank.MessagePack/SerializationContext.cs
@@ -168,8 +168,8 @@ public record struct SerializationContext
 		where T : IShapeable<T>
 	{
 		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter<T> result = this.Cache.GetOrAddConverter(T.GetTypeShape()).ValueOrThrow;
-		return this.ReferenceEqualityTracker is null ? result : result.WrapWithReferencePreservation();
+		MessagePackConverter result = this.Cache.GetOrAddConverter(T.GetTypeShape()).ValueOrThrow;
+		return (MessagePackConverter<T>)(this.ReferenceEqualityTracker is null ? result : ((IMessagePackConverterInternal)result).WrapWithReferencePreservation());
 	}
 
 	/// <summary>
@@ -186,8 +186,8 @@ public record struct SerializationContext
 		where TProvider : IShapeable<T>
 	{
 		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter<T> result = this.Cache.GetOrAddConverter(TProvider.GetTypeShape()).ValueOrThrow;
-		return this.ReferenceEqualityTracker is null ? result : result.WrapWithReferencePreservation();
+		MessagePackConverter result = this.Cache.GetOrAddConverter(TProvider.GetTypeShape()).ValueOrThrow;
+		return (MessagePackConverter<T>)(this.ReferenceEqualityTracker is null ? result : ((IMessagePackConverterInternal)result).WrapWithReferencePreservation());
 	}
 #endif
 
@@ -209,8 +209,8 @@ public record struct SerializationContext
 	public MessagePackConverter<T> GetConverter<T>(ITypeShapeProvider? provider)
 	{
 		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter<T> result = this.Cache.GetOrAddConverter<T>(provider ?? this.TypeShapeProvider ?? throw new UnreachableException()).ValueOrThrow;
-		return this.ReferenceEqualityTracker is null ? result : result.WrapWithReferencePreservation();
+		MessagePackConverter result = this.Cache.GetOrAddConverter<T>(provider ?? this.TypeShapeProvider ?? throw new UnreachableException()).ValueOrThrow;
+		return (MessagePackConverter<T>)(this.ReferenceEqualityTracker is null ? result : ((IMessagePackConverterInternal)result).WrapWithReferencePreservation());
 	}
 
 	/// <summary>
@@ -244,8 +244,8 @@ public record struct SerializationContext
 	{
 		Requires.NotNull(shape);
 		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter<T> result = this.Cache.GetOrAddConverter(shape).ValueOrThrow;
-		return this.ReferenceEqualityTracker is null ? result : (MessagePackConverter<T>)((IMessagePackConverterInternal)result).WrapWithReferencePreservation();
+		MessagePackConverter result = this.Cache.GetOrAddConverter(shape).ValueOrThrow;
+		return (MessagePackConverter<T>)(this.ReferenceEqualityTracker is null ? result : ((IMessagePackConverterInternal)result).WrapWithReferencePreservation());
 	}
 
 	/// <summary>

--- a/src/Nerdbank.MessagePack/SerializationContext.cs
+++ b/src/Nerdbank.MessagePack/SerializationContext.cs
@@ -168,7 +168,7 @@ public record struct SerializationContext
 		where T : IShapeable<T>
 	{
 		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter<T> result = this.Cache.GetOrAddConverter(T.GetTypeShape());
+		MessagePackConverter<T> result = this.Cache.GetOrAddConverter(T.GetTypeShape()).ValueOrThrow;
 		return this.ReferenceEqualityTracker is null ? result : result.WrapWithReferencePreservation();
 	}
 
@@ -186,7 +186,7 @@ public record struct SerializationContext
 		where TProvider : IShapeable<T>
 	{
 		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter<T> result = this.Cache.GetOrAddConverter(TProvider.GetTypeShape());
+		MessagePackConverter<T> result = this.Cache.GetOrAddConverter(TProvider.GetTypeShape()).ValueOrThrow;
 		return this.ReferenceEqualityTracker is null ? result : result.WrapWithReferencePreservation();
 	}
 #endif
@@ -209,7 +209,7 @@ public record struct SerializationContext
 	public MessagePackConverter<T> GetConverter<T>(ITypeShapeProvider? provider)
 	{
 		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter<T> result = this.Cache.GetOrAddConverter<T>(provider ?? this.TypeShapeProvider ?? throw new UnreachableException());
+		MessagePackConverter<T> result = this.Cache.GetOrAddConverter<T>(provider ?? this.TypeShapeProvider ?? throw new UnreachableException()).ValueOrThrow;
 		return this.ReferenceEqualityTracker is null ? result : result.WrapWithReferencePreservation();
 	}
 
@@ -226,7 +226,7 @@ public record struct SerializationContext
 	{
 		Requires.NotNull(shape);
 		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter result = this.Cache.GetOrAddConverter(shape);
+		MessagePackConverter result = this.Cache.GetOrAddConverter(shape).ValueOrThrow;
 		return this.ReferenceEqualityTracker is null ? result : ((IMessagePackConverterInternal)result).WrapWithReferencePreservation();
 	}
 
@@ -244,7 +244,7 @@ public record struct SerializationContext
 	{
 		Requires.NotNull(shape);
 		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter<T> result = this.Cache.GetOrAddConverter(shape);
+		MessagePackConverter<T> result = this.Cache.GetOrAddConverter(shape).ValueOrThrow;
 		return this.ReferenceEqualityTracker is null ? result : (MessagePackConverter<T>)((IMessagePackConverterInternal)result).WrapWithReferencePreservation();
 	}
 
@@ -261,7 +261,7 @@ public record struct SerializationContext
 	public MessagePackConverter GetConverter(Type type, ITypeShapeProvider? provider)
 	{
 		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
-		IMessagePackConverterInternal result = this.Cache.GetOrAddConverter(type, provider ?? this.TypeShapeProvider ?? throw new UnreachableException());
+		IMessagePackConverterInternal result = (IMessagePackConverterInternal)this.Cache.GetOrAddConverter(type, provider ?? this.TypeShapeProvider ?? throw new UnreachableException()).ValueOrThrow;
 		return this.ReferenceEqualityTracker is null ? (MessagePackConverter)result : result.WrapWithReferencePreservation();
 	}
 

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -4,6 +4,7 @@
 #pragma warning disable DuckTyping // Experimental API
 
 using System.Collections.Frozen;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -46,12 +47,17 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	internal TypeShapeVisitor OutwardVisitor { get; set; }
 
 	/// <inheritdoc/>
-	object? ITypeShapeFunc.Invoke<T>(ITypeShape<T> typeShape, object? state) => typeShape.Accept(this.OutwardVisitor, state);
+	object? ITypeShapeFunc.Invoke<T>(ITypeShape<T> typeShape, object? state)
+	{
+		object? result = typeShape.Accept(this.OutwardVisitor, state);
+		Debug.Assert(result is null or IConverterResult, $"We should not be returning raw converters, but we got one from {typeShape}.");
+		return result;
+	}
 
 	/// <inheritdoc/>
 	public override object? VisitObject<T>(IObjectTypeShape<T> objectShape, object? state = null)
 	{
-		if (this.TryGetCustomOrPrimitiveConverter(objectShape, objectShape.AttributeProvider, out MessagePackConverter<T>? customConverter))
+		if (this.TryGetCustomOrPrimitiveConverter(objectShape, objectShape.AttributeProvider, out ConverterResult<T>? customConverter))
 		{
 			return customConverter;
 		}
@@ -103,40 +109,50 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			IParameterShape? matchingConstructorParameter = null;
 			ctorParametersByName?.TryGetValue(property.Name, out matchingConstructorParameter);
 
-			if (property.Accept(this, matchingConstructorParameter) is PropertyAccessors<T> accessors)
+			switch (property.Accept(this, matchingConstructorParameter))
 			{
-				KeyAttribute? keyAttribute = (KeyAttribute?)property.AttributeProvider?.GetCustomAttributes(typeof(KeyAttribute), false).FirstOrDefault();
-				if (keyAttribute is not null || this.owner.PerfOverSchemaStability || objectShape.IsTupleType)
-				{
-					propertyAccessors ??= new();
-					int index = keyAttribute?.Index ?? propertyIndex;
-					while (propertyAccessors.Count <= index)
+				case PropertyAccessors<T> accessors:
+					KeyAttribute? keyAttribute = (KeyAttribute?)property.AttributeProvider?.GetCustomAttributes(typeof(KeyAttribute), false).FirstOrDefault();
+					if (keyAttribute is not null || this.owner.PerfOverSchemaStability || objectShape.IsTupleType)
 					{
-						propertyAccessors.Add(null);
+						propertyAccessors ??= new();
+						int index = keyAttribute?.Index ?? propertyIndex;
+						while (propertyAccessors.Count <= index)
+						{
+							propertyAccessors.Add(null);
+						}
+
+						propertyAccessors[index] = (propertyName, accessors);
+					}
+					else
+					{
+						serializable ??= new();
+						deserializable ??= new();
+
+						StringEncoding.GetEncodedStringBytes(propertyName, out ReadOnlyMemory<byte> utf8Bytes, out ReadOnlyMemory<byte> msgpackEncoded);
+						if (accessors.MsgPackWriters is var (serialize, serializeAsync))
+						{
+							serializable.Add(new(propertyName, msgpackEncoded, serialize, serializeAsync, accessors.Converter, accessors.ShouldSerialize, property));
+						}
+
+						if (accessors.MsgPackReaders is var (deserialize, deserializeAsync))
+						{
+							deserializable.Add(new(property.Name, utf8Bytes, deserialize, deserializeAsync, accessors.Converter, property.Position));
+						}
 					}
 
-					propertyAccessors[index] = (propertyName, accessors);
-				}
-				else
-				{
-					serializable ??= new();
-					deserializable ??= new();
-
-					StringEncoding.GetEncodedStringBytes(propertyName, out ReadOnlyMemory<byte> utf8Bytes, out ReadOnlyMemory<byte> msgpackEncoded);
-					if (accessors.MsgPackWriters is var (serialize, serializeAsync))
+					break;
+				case IConverterResult failure:
+					if (failure.TryPrepareFailPath<T>(property, out ConverterResult<T>? failureResult))
 					{
-						serializable.Add(new(propertyName, msgpackEncoded, serialize, serializeAsync, accessors.Converter, accessors.ShouldSerialize, property));
+						return failureResult;
 					}
 
-					if (accessors.MsgPackReaders is var (deserialize, deserializeAsync))
-					{
-						deserializable.Add(new(property.Name, utf8Bytes, deserialize, deserializeAsync, accessors.Converter, property.Position));
-					}
-				}
+					break;
 			}
 		}
 
-		MessagePackConverter<T> converter;
+		ConverterResult<T> converter;
 		if (propertyAccessors is not null)
 		{
 			if (serializable is { Count: > 0 })
@@ -183,8 +199,8 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 
 			ArrayConstructorVisitorInputs<T> inputs = new(propertyAccessors, unusedDataPropertyAccess);
 			converter = ctorShape is not null
-				? (MessagePackConverter<T>)ctorShape.Accept(this, inputs)!
-				: new ObjectArrayConverter<T>(inputs.GetJustAccessors(), unusedDataPropertyAccess, null, objectShape.Properties, this.owner.SerializeDefaultValues);
+				? (ConverterResult<T>)ctorShape.Accept(this, inputs)!
+				: ConverterResult.Ok(new ObjectArrayConverter<T>(inputs.GetJustAccessors(), unusedDataPropertyAccess, null, objectShape.Properties, this.owner.SerializeDefaultValues));
 		}
 		else
 		{
@@ -198,32 +214,32 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			if (ctorShape is not null)
 			{
 				MapConstructorVisitorInputs<T> inputs = new(serializableMap, deserializableMap, ctorParametersByName!, unusedDataPropertyAccess);
-				converter = (MessagePackConverter<T>)ctorShape.Accept(this, inputs)!;
+				converter = (ConverterResult<T>)ctorShape.Accept(this, inputs)!;
 			}
 			else
 			{
 				Func<T>? ctor = typeof(T) == typeof(object) ? (Func<T>)(object)new Func<object>(() => new object()) : null;
-				converter = new ObjectMapConverter<T>(
+				converter = ConverterResult.Ok(new ObjectMapConverter<T>(
 					serializableMap,
 					deserializableMap,
 					unusedDataPropertyAccess,
 					ctor,
 					objectShape.Properties,
-					this.owner.SerializeDefaultValues);
+					this.owner.SerializeDefaultValues));
 			}
 		}
 
 		// Test IsValueType before considering unions so that the native compiler
 		// does not have to generate a SubTypes<T> for value types which will never be used.
-		if (!typeof(T).IsValueType)
+		if (converter.Success && !typeof(T).IsValueType)
 		{
 			if (this.owner.TryGetDynamicUnion(objectShape.Type, out DerivedTypeUnion? union) && !union.Disabled)
 			{
-				return union switch
+				converter = union switch
 				{
-					IDerivedTypeMapping mapping => new UnionConverter<T>(converter, this.CreateSubTypes(objectShape.Type, converter, mapping)),
-					DerivedTypeDuckTyping duckTyping => this.CreateDuckTypingUnionConverter<T>(duckTyping, converter),
-					_ => throw new NotSupportedException($"Unrecognized union type: {union.GetType().Name}"),
+					IDerivedTypeMapping mapping => this.CreateSubTypes(objectShape.Type, converter.Value, mapping).MapResult(st => new UnionConverter<T>(converter.Value, st)),
+					DerivedTypeDuckTyping duckTyping => this.CreateDuckTypingUnionConverter<T>(duckTyping, converter.Value),
+					_ => ConverterResult.Err<T>(new NotSupportedException($"Unrecognized union type: {union.GetType().Name}")),
 				};
 			}
 		}
@@ -234,9 +250,13 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	/// <inheritdoc/>
 	public override object? VisitUnion<TUnion>(IUnionTypeShape<TUnion> unionShape, object? state = null)
 	{
-		MessagePackConverter<TUnion> baseTypeConverter = (MessagePackConverter<TUnion>)unionShape.BaseType.Accept(this)!;
+		ConverterResult<TUnion> baseTypeConverter = (ConverterResult<TUnion>)unionShape.BaseType.Accept(this)!;
+		if (baseTypeConverter.TryPrepareFailPath("union base type", out ConverterResult<TUnion>? failureResult))
+		{
+			return failureResult;
+		}
 
-		if (baseTypeConverter is UnionConverter<TUnion>)
+		if (baseTypeConverter.Value is UnionConverter<TUnion>)
 		{
 			// A runtime mapping *and* attributes are defined for the same base type.
 			// The runtime mapping has already been applied and that trumps attributes.
@@ -251,27 +271,29 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			return union switch
 			{
 				{ Disabled: true } => baseTypeConverter,
-				IDerivedTypeMapping mapping => new UnionConverter<TUnion>(baseTypeConverter, this.CreateSubTypes(baseType, baseTypeConverter, mapping)),
-				DerivedTypeDuckTyping duckTyping => this.CreateDuckTypingUnionConverter<TUnion>(duckTyping, baseTypeConverter),
-				_ => throw new NotSupportedException($"Unrecognized union type: {union.GetType().Name}"),
+				IDerivedTypeMapping mapping => this.CreateSubTypes(baseType, baseTypeConverter.Value, mapping).Map(st => new UnionConverter<TUnion>(baseTypeConverter.Value, st)),
+				DerivedTypeDuckTyping duckTyping => this.CreateDuckTypingUnionConverter(duckTyping, baseTypeConverter.Value),
+				_ => ConverterResult.Err<TUnion>(new NotSupportedException($"Unrecognized union type: {union.GetType().Name}")),
 			};
 		}
 
 		Getter<TUnion, int> getUnionCaseIndex = unionShape.GetGetUnionCaseIndex();
 		Dictionary<int, MessagePackConverter> deserializerByIntAlias = new(unionShape.UnionCases.Count);
 		List<(DerivedTypeIdentifier Alias, MessagePackConverter Converter, ITypeShape Shape)> serializers = new(unionShape.UnionCases.Count);
-		KeyValuePair<int, MessagePackConverter<TUnion>>[] unionCases = unionShape.UnionCases
-			.Select(unionCase =>
+		foreach (IUnionCaseShape unionCase in unionShape.UnionCases)
+		{
+			bool useTag = unionCase.IsTagSpecified || this.owner.PerfOverSchemaStability;
+			DerivedTypeIdentifier alias = useTag ? new(unionCase.Tag) : new(unionCase.Name);
+			ConverterResult<TUnion> caseConverter = (ConverterResult<TUnion>)unionCase.Accept(this, null)!;
+			if (caseConverter.TryPrepareFailPath(unionCase, out failureResult))
 			{
-				bool useTag = unionCase.IsTagSpecified || this.owner.PerfOverSchemaStability;
-				DerivedTypeIdentifier alias = useTag ? new(unionCase.Tag) : new(unionCase.Name);
-				var caseConverter = (MessagePackConverter<TUnion>)unionCase.Accept(this, null)!;
-				deserializerByIntAlias.Add(unionCase.Tag, caseConverter);
-				serializers.Add((alias, caseConverter, unionCase.UnionCaseType));
+				return failureResult;
+			}
 
-				return new KeyValuePair<int, MessagePackConverter<TUnion>>(unionCase.Tag, caseConverter);
-			})
-			.ToArray();
+			deserializerByIntAlias.Add(unionCase.Tag, caseConverter.Value);
+			serializers.Add((alias, caseConverter.Value, unionCase.UnionCaseType));
+		}
+
 		SubTypes<TUnion> subTypes = new()
 		{
 			DeserializersByIntAlias = deserializerByIntAlias.ToFrozenDictionary(),
@@ -283,15 +305,20 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			TryGetSerializer = (ref TUnion value) => getUnionCaseIndex(ref value) is int idx && idx >= 0 ? (serializers[idx].Alias, serializers[idx].Converter) : null,
 		};
 
-		return new UnionConverter<TUnion>(baseTypeConverter, subTypes);
+		return ConverterResult.Ok(new UnionConverter<TUnion>(baseTypeConverter.Value, subTypes));
 	}
 
 	/// <inheritdoc/>
 	public override object? VisitUnionCase<TUnionCase, TUnion>(IUnionCaseShape<TUnionCase, TUnion> unionCaseShape, object? state = null)
 	{
 		// NB: don't use the cached converter for TUnionCase, as it might equal TUnion.
-		var caseConverter = (MessagePackConverter<TUnionCase>)unionCaseShape.UnionCaseType.Accept(this)!;
-		return new UnionCaseConverter<TUnionCase, TUnion>(caseConverter, unionCaseShape.Marshaler);
+		var caseConverter = (ConverterResult<TUnionCase>)unionCaseShape.UnionCaseType.Accept(this)!;
+		if (caseConverter.TryPrepareFailPath(unionCaseShape, out ConverterResult<TUnionCase>? failureResult))
+		{
+			return failureResult;
+		}
+
+		return ConverterResult.Ok(new UnionCaseConverter<TUnionCase, TUnion>(caseConverter.Value, unionCaseShape.Marshaler));
 	}
 
 	/// <inheritdoc/>
@@ -299,7 +326,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	{
 		IParameterShape? constructorParameterShape = (IParameterShape?)state;
 
-		MessagePackConverter<TPropertyType> converter = this.GetConverterForMemberOrParameter(propertyShape.PropertyType, propertyShape.AttributeProvider);
+		ConverterResult<TPropertyType> converter = this.GetConverterForMemberOrParameter(propertyShape.PropertyType, propertyShape.AttributeProvider);
 
 		static string CreateReadFailMessage(IPropertyShape<TDeclaringType, TPropertyType> propertyShape) => $"Failed to deserialize '{propertyShape.Name}' property on {typeof(TDeclaringType).FullName}.";
 		static string CreateWriteFailMessage(IPropertyShape<TDeclaringType, TPropertyType> propertyShape) => $"Failed to serialize '{propertyShape.Name}' property on {typeof(TDeclaringType).FullName}.";
@@ -348,7 +375,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				TPropertyType? value = getter(ref Unsafe.AsRef(in container));
 				try
 				{
-					converter.Write(ref writer, value, context);
+					converter.ValueOrThrow.Write(ref writer, value, context);
 				}
 				catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
 				{
@@ -359,7 +386,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			{
 				try
 				{
-					await converter.WriteAsync(writer, getter(ref container), context).ConfigureAwait(false);
+					await converter.ValueOrThrow.WriteAsync(writer, getter(ref container), context).ConfigureAwait(false);
 				}
 				catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
 				{
@@ -378,7 +405,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			{
 				try
 				{
-					setter(ref container, converter.Read(ref reader, context)!);
+					setter(ref container, converter.ValueOrThrow.Read(ref reader, context)!);
 				}
 				catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
 				{
@@ -389,7 +416,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			{
 				try
 				{
-					setter(ref container, (await converter.ReadAsync(reader, context).ConfigureAwait(false))!);
+					setter(ref container, (await converter.ValueOrThrow.ReadAsync(reader, context).ConfigureAwait(false))!);
 					return container;
 				}
 				catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
@@ -400,7 +427,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			msgpackReaders = (deserialize, deserializeAsync);
 			suppressIfNoConstructorParameter = false;
 		}
-		else if (propertyShape.HasGetter && converter is IDeserializeInto<TPropertyType> inflater)
+		else if (propertyShape.HasGetter && converter.Value is IDeserializeInto<TPropertyType> inflater)
 		{
 			// The property has no setter, but it has a getter and the property type is a collection.
 			// So we'll assume the declaring type initializes the collection in its constructor,
@@ -452,9 +479,17 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			msgpackReaders = (deserialize, deserializeAsync);
 		}
 
-		return suppressIfNoConstructorParameter && constructorParameterShape is null
-			? null
-			: new PropertyAccessors<TDeclaringType>(msgpackWriters, msgpackReaders, converter, shouldSerialize, propertyShape);
+		if (suppressIfNoConstructorParameter && constructorParameterShape is null)
+		{
+			return null;
+		}
+
+		if (!converter.Success)
+		{
+			return converter;
+		}
+
+		return new PropertyAccessors<TDeclaringType>(msgpackWriters, msgpackReaders, converter.Value, shouldSerialize, propertyShape);
 	}
 
 	/// <inheritdoc/>
@@ -466,13 +501,13 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				{
 					if (constructorShape.Parameters.Count == 0)
 					{
-						return new ObjectMapConverter<TDeclaringType>(
+						return ConverterResult<TDeclaringType>.Ok(new ObjectMapConverter<TDeclaringType>(
 							inputs.Serializers,
 							inputs.Deserializers,
 							inputs.UnusedDataProperty,
 							constructorShape.GetDefaultConstructor(),
 							constructorShape.DeclaringType.Properties,
-							this.owner.SerializeDefaultValues);
+							this.owner.SerializeDefaultValues));
 					}
 
 					List<SerializableProperty<TDeclaringType>> propertySerializers = inputs.Serializers.Properties.Span.ToList();
@@ -482,7 +517,13 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 					foreach (KeyValuePair<string, IParameterShape> p in inputs.ParametersByName)
 					{
 						ICustomAttributeProvider? propertyAttributeProvider = constructorShape.DeclaringType.Properties.FirstOrDefault(prop => prop.Name == p.Value.Name)?.AttributeProvider;
-						var prop = (DeserializableProperty<TArgumentState>)p.Value.Accept(this, constructorShape)!;
+						object parameterResult = p.Value.Accept(this, constructorShape)!;
+						if (parameterResult is IConverterResult converterResult && converterResult.TryPrepareFailPath(p.Value, out ConverterResult<TDeclaringType>? failureResult))
+						{
+							return failureResult;
+						}
+
+						var prop = (DeserializableProperty<TArgumentState>)parameterResult;
 						string name = this.owner.GetSerializedPropertyName(p.Value.Name, propertyAttributeProvider);
 						spanDictContent[i++] = new(Encoding.UTF8.GetBytes(name), prop);
 					}
@@ -491,7 +532,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 
 					MapSerializableProperties<TDeclaringType> serializeable = inputs.Serializers;
 					serializeable.Properties = propertySerializers.ToArray();
-					return new ObjectMapWithNonDefaultCtorConverter<TDeclaringType, TArgumentState>(
+					return ConverterResult.Ok(new ObjectMapWithNonDefaultCtorConverter<TDeclaringType, TArgumentState>(
 						serializeable,
 						constructorShape.GetArgumentStateConstructor(),
 						inputs.UnusedDataProperty,
@@ -499,14 +540,14 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 						new MapDeserializableProperties<TArgumentState>(parameters),
 						constructorShape.Parameters,
 						this.owner.SerializeDefaultValues,
-						this.owner.DeserializeDefaultValues);
+						this.owner.DeserializeDefaultValues));
 				}
 
 			case ArrayConstructorVisitorInputs<TDeclaringType> inputs:
 				{
 					if (constructorShape.Parameters.Count == 0)
 					{
-						return new ObjectArrayConverter<TDeclaringType>(inputs.GetJustAccessors(), inputs.UnusedDataProperty, constructorShape.GetDefaultConstructor(), constructorShape.DeclaringType.Properties, this.owner.SerializeDefaultValues);
+						return ConverterResult.Ok(new ObjectArrayConverter<TDeclaringType>(inputs.GetJustAccessors(), inputs.UnusedDataProperty, constructorShape.GetDefaultConstructor(), constructorShape.DeclaringType.Properties, this.owner.SerializeDefaultValues));
 					}
 
 					Dictionary<string, int> propertyIndexesByName = new(StringComparer.Ordinal);
@@ -531,10 +572,16 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 							throw new NotSupportedException($"{constructorShape.DeclaringType.Type.FullName} has a constructor parameter named '{parameter.Name}' that does not match any property on the type, even allowing for camelCase to PascalCase conversion. This is not supported. Adjust the parameters and/or properties or write a custom converter for this type.");
 						}
 
-						parameters[index] = (DeserializableProperty<TArgumentState>)parameter.Accept(this, constructorShape)!;
+						object parameterResult = parameter.Accept(this, constructorShape)!;
+						if (parameterResult is IConverterResult converterResult && converterResult.TryPrepareFailPath(parameter, out ConverterResult<TDeclaringType>? failureResult))
+						{
+							return failureResult;
+						}
+
+						parameters[index] = (DeserializableProperty<TArgumentState>)parameterResult;
 					}
 
-					return new ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentState>(
+					return ConverterResult.Ok(new ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentState>(
 						inputs.GetJustAccessors(),
 						inputs.UnusedDataProperty,
 						constructorShape.GetArgumentStateConstructor(),
@@ -542,7 +589,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 						parameters,
 						constructorShape.Parameters,
 						this.owner.SerializeDefaultValues,
-						this.owner.DeserializeDefaultValues);
+						this.owner.DeserializeDefaultValues));
 				}
 
 			default:
@@ -555,7 +602,11 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	{
 		IConstructorShape constructorShape = (IConstructorShape)(state ?? throw new ArgumentNullException(nameof(state)));
 
-		MessagePackConverter<TParameterType> converter = this.GetConverterForMemberOrParameter(parameterShape.ParameterType, parameterShape.AttributeProvider);
+		ConverterResult<TParameterType> converter = this.GetConverterForMemberOrParameter(parameterShape.ParameterType, parameterShape.AttributeProvider);
+		if (!converter.Success)
+		{
+			return converter;
+		}
 
 		Setter<TArgumentState, TParameterType> setter = parameterShape.GetSetter();
 
@@ -575,7 +626,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				try
 				{
 					ThrowIfAlreadyAssigned(state, parameterShape.Position, parameterShape.Name);
-					setter(ref state, converter.Read(ref reader, context) ?? throw NewDisallowedDeserializedNullValueException(parameterShape));
+					setter(ref state, converter.Value.Read(ref reader, context) ?? throw NewDisallowedDeserializedNullValueException(parameterShape));
 				}
 				catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
 				{
@@ -587,7 +638,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				try
 				{
 					ThrowIfAlreadyAssigned(state, parameterShape.Position, parameterShape.Name);
-					setter(ref state, (await converter.ReadAsync(reader, context).ConfigureAwait(false)) ?? throw NewDisallowedDeserializedNullValueException(parameterShape));
+					setter(ref state, (await converter.Value.ReadAsync(reader, context).ConfigureAwait(false)) ?? throw NewDisallowedDeserializedNullValueException(parameterShape));
 					return state;
 				}
 				catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
@@ -603,7 +654,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				try
 				{
 					ThrowIfAlreadyAssigned(state, parameterShape.Position, parameterShape.Name);
-					setter(ref state, converter.Read(ref reader, context)!);
+					setter(ref state, converter.Value.Read(ref reader, context)!);
 				}
 				catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
 				{
@@ -615,7 +666,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				try
 				{
 					ThrowIfAlreadyAssigned(state, parameterShape.Position, parameterShape.Name);
-					setter(ref state, (await converter.ReadAsync(reader, context).ConfigureAwait(false))!);
+					setter(ref state, (await converter.Value.ReadAsync(reader, context).ConfigureAwait(false))!);
 					return state;
 				}
 				catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
@@ -630,18 +681,26 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			StringEncoding.UTF8.GetBytes(parameterShape.Name),
 			read,
 			readAsync,
-			converter,
+			converter.Value,
 			parameterShape.Position);
 	}
 
 	/// <inheritdoc/>
 	public override object? VisitOptional<TOptional, TElement>(IOptionalTypeShape<TOptional, TElement> optionalShape, object? state = null)
-		=> new OptionalConverter<TOptional, TElement>(this.GetConverter(optionalShape.ElementType), optionalShape.GetDeconstructor(), optionalShape.GetNoneConstructor(), optionalShape.GetSomeConstructor());
+	{
+		ConverterResult<TElement> converter = this.GetConverter(optionalShape.ElementType);
+		if (converter.TryPrepareFailPath(optionalShape, out ConverterResult<TElement>? failure))
+		{
+			return failure;
+		}
+
+		return ConverterResult.Ok(new OptionalConverter<TOptional, TElement>(converter.Value, optionalShape.GetDeconstructor(), optionalShape.GetNoneConstructor(), optionalShape.GetSomeConstructor()));
+	}
 
 	/// <inheritdoc/>
 	public override object? VisitDictionary<TDictionary, TKey, TValue>(IDictionaryTypeShape<TDictionary, TKey, TValue> dictionaryShape, object? state = null)
 	{
-		if (this.TryGetCustomOrPrimitiveConverter(dictionaryShape, dictionaryShape.AttributeProvider, out MessagePackConverter<TDictionary>? customConverter))
+		if (this.TryGetCustomOrPrimitiveConverter(dictionaryShape, dictionaryShape.AttributeProvider, out ConverterResult<TDictionary>? customConverter))
 		{
 			return customConverter;
 		}
@@ -649,24 +708,34 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 		MemberConverterInfluence? memberInfluence = state as MemberConverterInfluence;
 
 		// Serialization functions.
-		MessagePackConverter<TKey> keyConverter = this.GetConverter(dictionaryShape.KeyType);
-		MessagePackConverter<TValue> valueConverter = this.GetConverter(dictionaryShape.ValueType);
+		ConverterResult<TKey> keyConverter = this.GetConverter(dictionaryShape.KeyType);
+		ConverterResult<TValue> valueConverter = this.GetConverter(dictionaryShape.ValueType);
 		Func<TDictionary, IReadOnlyDictionary<TKey, TValue>> getReadable = dictionaryShape.GetGetDictionary();
 
-		// Deserialization functions.
-		return dictionaryShape.ConstructionStrategy switch
+		if (keyConverter.TryPrepareFailPath("key", out ConverterResult<TDictionary>? keyFailure))
 		{
-			CollectionConstructionStrategy.None => new DictionaryConverter<TDictionary, TKey, TValue>(getReadable, keyConverter, valueConverter),
-			CollectionConstructionStrategy.Mutable => new MutableDictionaryConverter<TDictionary, TKey, TValue>(getReadable, keyConverter, valueConverter, dictionaryShape.GetInserter(DictionaryInsertionMode.Throw), dictionaryShape.GetDefaultConstructor(), this.GetCollectionOptions(dictionaryShape, memberInfluence)),
-			CollectionConstructionStrategy.Parameterized => new ImmutableDictionaryConverter<TDictionary, TKey, TValue>(getReadable, keyConverter, valueConverter, dictionaryShape.GetParameterizedConstructor(), this.GetCollectionOptions(dictionaryShape, memberInfluence)),
+			return keyFailure;
+		}
+
+		if (valueConverter.TryPrepareFailPath("value", out ConverterResult<TDictionary>? valueFailure))
+		{
+			return valueFailure;
+		}
+
+		// Deserialization functions.
+		return ConverterResult.Ok(dictionaryShape.ConstructionStrategy switch
+		{
+			CollectionConstructionStrategy.None => new DictionaryConverter<TDictionary, TKey, TValue>(getReadable, keyConverter.Value, valueConverter.Value),
+			CollectionConstructionStrategy.Mutable => new MutableDictionaryConverter<TDictionary, TKey, TValue>(getReadable, keyConverter.Value, valueConverter.Value, dictionaryShape.GetInserter(DictionaryInsertionMode.Throw), dictionaryShape.GetDefaultConstructor(), this.GetCollectionOptions(dictionaryShape, memberInfluence)),
+			CollectionConstructionStrategy.Parameterized => new ImmutableDictionaryConverter<TDictionary, TKey, TValue>(getReadable, keyConverter.Value, valueConverter.Value, dictionaryShape.GetParameterizedConstructor(), this.GetCollectionOptions(dictionaryShape, memberInfluence)),
 			_ => throw new NotSupportedException($"Unrecognized dictionary pattern: {typeof(TDictionary).Name}"),
-		};
+		});
 	}
 
 	/// <inheritdoc/>
 	public override object? VisitEnumerable<TEnumerable, TElement>(IEnumerableTypeShape<TEnumerable, TElement> enumerableShape, object? state = null)
 	{
-		if (this.TryGetCustomOrPrimitiveConverter(enumerableShape, enumerableShape.AttributeProvider, out MessagePackConverter<TEnumerable>? customConverter))
+		if (this.TryGetCustomOrPrimitiveConverter(enumerableShape, enumerableShape.AttributeProvider, out ConverterResult<TEnumerable>? customConverter))
 		{
 			return customConverter;
 		}
@@ -674,7 +743,11 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 		MemberConverterInfluence? memberInfluence = state as MemberConverterInfluence;
 
 		// Serialization functions.
-		MessagePackConverter<TElement> elementConverter = this.GetConverter(enumerableShape.ElementType);
+		ConverterResult<TElement> elementConverter = this.GetConverter(enumerableShape.ElementType);
+		if (elementConverter.TryPrepareFailPath("element", out ConverterResult<TEnumerable>? elementFailure))
+		{
+			return elementFailure;
+		}
 
 		if (enumerableShape.Type.IsArray)
 		{
@@ -682,14 +755,14 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			if (enumerableShape.Rank > 1)
 			{
 #if NET
-				return this.owner.MultiDimensionalArrayFormat switch
+				return ConverterResult.Ok<TEnumerable>(this.owner.MultiDimensionalArrayFormat switch
 				{
-					MultiDimensionalArrayFormat.Nested => new ArrayWithNestedDimensionsConverter<TEnumerable, TElement>(elementConverter, enumerableShape.Rank),
-					MultiDimensionalArrayFormat.Flat => new ArrayWithFlattenedDimensionsConverter<TEnumerable, TElement>(elementConverter),
+					MultiDimensionalArrayFormat.Nested => new ArrayWithNestedDimensionsConverter<TEnumerable, TElement>(elementConverter.Value, enumerableShape.Rank),
+					MultiDimensionalArrayFormat.Flat => new ArrayWithFlattenedDimensionsConverter<TEnumerable, TElement>(elementConverter.Value),
 					_ => throw new NotSupportedException(),
-				};
+				});
 #else
-				throw PolyfillExtensions.ThrowNotSupportedOnNETFramework();
+				return ConverterResult.Err<TEnumerable>(new PlatformNotSupportedException("This functionality is only supported on .NET."));
 #endif
 			}
 #if NET
@@ -697,54 +770,68 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				enumerableShape.ConstructionStrategy == CollectionConstructionStrategy.Parameterized &&
 				HardwareAccelerated.TryGetConverter<TEnumerable, TElement>(out converter))
 			{
-				return converter;
+				return ConverterResult.Ok(converter);
 			}
 #endif
 			else if (enumerableShape.ConstructionStrategy == CollectionConstructionStrategy.Parameterized &&
 				ArraysOfPrimitivesConverters.TryGetConverter(enumerableShape.GetGetEnumerable(), enumerableShape.GetParameterizedConstructor(), out converter))
 			{
-				return converter;
+				return ConverterResult.Ok(converter);
 			}
 			else
 			{
-				return new ArrayConverter<TElement>(elementConverter);
+				return ConverterResult.Ok(new ArrayConverter<TElement>(elementConverter.Value));
 			}
 		}
 
 		Func<TEnumerable, IEnumerable<TElement>>? getEnumerable = enumerableShape.IsAsyncEnumerable ? null : enumerableShape.GetGetEnumerable();
-		return enumerableShape.ConstructionStrategy switch
+		return ConverterResult.Ok(enumerableShape.ConstructionStrategy switch
 		{
-			CollectionConstructionStrategy.None => new EnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter),
-			CollectionConstructionStrategy.Mutable => new MutableEnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter, enumerableShape.GetAppender(), enumerableShape.GetDefaultConstructor(), this.GetCollectionOptions(enumerableShape, memberInfluence)),
+			CollectionConstructionStrategy.None => new EnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter.Value),
+			CollectionConstructionStrategy.Mutable => new MutableEnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter.Value, enumerableShape.GetAppender(), enumerableShape.GetDefaultConstructor(), this.GetCollectionOptions(enumerableShape, memberInfluence)),
 #if NET
 			CollectionConstructionStrategy.Parameterized when !this.owner.DisableHardwareAcceleration && HardwareAccelerated.TryGetConverter<TEnumerable, TElement>(out MessagePackConverter<TEnumerable>? converter) => converter,
 #endif
 			CollectionConstructionStrategy.Parameterized when getEnumerable is not null && ArraysOfPrimitivesConverters.TryGetConverter(getEnumerable, enumerableShape.GetParameterizedConstructor(), out MessagePackConverter<TEnumerable>? converter) => converter,
-			CollectionConstructionStrategy.Parameterized => new SpanEnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter, enumerableShape.GetParameterizedConstructor(), this.GetCollectionOptions(enumerableShape, memberInfluence)),
+			CollectionConstructionStrategy.Parameterized => new SpanEnumerableConverter<TEnumerable, TElement>(getEnumerable, elementConverter.Value, enumerableShape.GetParameterizedConstructor(), this.GetCollectionOptions(enumerableShape, memberInfluence)),
 			_ => throw new NotSupportedException($"Unrecognized enumerable pattern: {typeof(TEnumerable).Name}"),
-		};
+		});
 	}
 
 	/// <inheritdoc/>
 	public override object? VisitEnum<TEnum, TUnderlying>(IEnumTypeShape<TEnum, TUnderlying> enumShape, object? state = null)
 	{
-		if (this.TryGetCustomOrPrimitiveConverter(enumShape, enumShape.AttributeProvider, out MessagePackConverter<TEnum>? customConverter))
+		if (this.TryGetCustomOrPrimitiveConverter(enumShape, enumShape.AttributeProvider, out ConverterResult<TEnum>? customConverter))
 		{
 			return customConverter;
 		}
 
-		return this.owner.SerializeEnumValuesByName
-			? new EnumAsStringConverter<TEnum, TUnderlying>(this.GetConverter(enumShape.UnderlyingType), enumShape.Members)
-			: new EnumAsOrdinalConverter<TEnum, TUnderlying>(this.GetConverter(enumShape.UnderlyingType));
+		ConverterResult<TUnderlying> underlyingConverter = this.GetConverter(enumShape.UnderlyingType);
+		if (underlyingConverter.TryPrepareFailPath(enumShape, out ConverterResult<TEnum>? failure))
+		{
+			return failure;
+		}
+
+		return ConverterResult.Ok<TEnum>(this.owner.SerializeEnumValuesByName
+			? new EnumAsStringConverter<TEnum, TUnderlying>(underlyingConverter.Value, enumShape.Members)
+			: new EnumAsOrdinalConverter<TEnum, TUnderlying>(underlyingConverter.Value));
 	}
 
 	/// <inheritdoc/>
 	public override object? VisitSurrogate<T, TSurrogate>(ISurrogateTypeShape<T, TSurrogate> surrogateShape, object? state = null)
-		=> new SurrogateConverter<T, TSurrogate>(surrogateShape, this.GetConverter(surrogateShape.SurrogateType, state: state));
+	{
+		ConverterResult<TSurrogate> surrogateConverter = this.GetConverter(surrogateShape.SurrogateType, state: state);
+		if (surrogateConverter.TryPrepareFailPath(surrogateShape, out ConverterResult<T>? failure))
+		{
+			return failure;
+		}
+
+		return ConverterResult.Ok(new SurrogateConverter<T, TSurrogate>(surrogateShape, surrogateConverter.Value));
+	}
 
 	/// <inheritdoc/>
 	public override object? VisitFunction<TFunction, TArgumentState, TResult>(IFunctionTypeShape<TFunction, TArgumentState, TResult> functionShape, object? state = null)
-		=> throw new NotSupportedException("Delegate types cannot be serialized.");
+		=> ConverterResult.Err<TFunction>("Delegate types cannot be serialized.");
 
 	/// <summary>
 	/// Gets or creates a converter for the given type shape.
@@ -764,7 +851,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	/// if it were to appear in <paramref name="memberAttributes"/>.
 	/// Callers that want to respect that attribute must call <see cref="TryGetConverterFromAttribute"/> first.
 	/// </remarks>
-	protected MessagePackConverter<T> GetConverter<T>(ITypeShape<T> shape, ICustomAttributeProvider? memberAttributes = null, object? state = null)
+	protected ConverterResult<T> GetConverter<T>(ITypeShape<T> shape, ICustomAttributeProvider? memberAttributes = null, object? state = null)
 	{
 		if (memberAttributes is not null)
 		{
@@ -784,11 +871,11 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				// PERF: Ideally, we can store and retrieve member influenced converters
 				// just like we do for non-member influenced ones.
 				// We'd probably use a separate dictionary dedicated to member-influenced converters.
-				return (MessagePackConverter<T>)shape.Invoke(this, memberInfluence)!;
+				return (ConverterResult<T>)shape.Invoke(this, memberInfluence)!;
 			}
 		}
 
-		return (MessagePackConverter<T>)this.context.GetOrAdd(shape, state)!;
+		return (ConverterResult<T>)this.context.GetOrAdd(shape, state)!;
 	}
 
 	/// <summary>
@@ -797,10 +884,10 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	/// <param name="shape">The type shape.</param>
 	/// <param name="state">An optional state object to pass to the converter.</param>
 	/// <returns>The converter.</returns>
-	protected IMessagePackConverterInternal GetConverter(ITypeShape shape, object? state = null)
+	protected IConverterResult GetConverter(ITypeShape shape, object? state = null)
 	{
 		ITypeShapeFunc self = this;
-		return (IMessagePackConverterInternal)shape.Invoke(this, state)!;
+		return (IConverterResult)shape.Invoke(this, state)!;
 	}
 
 	private static void ThrowIfAlreadyAssigned<TArgumentState>(in TArgumentState argumentState, int position, string name)
@@ -819,7 +906,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 		}
 	}
 
-	private SubTypes<TBaseType> CreateSubTypes<TBaseType>(Type baseType, MessagePackConverter<TBaseType> baseTypeConverter, IDerivedTypeMapping mapping)
+	private Result<SubTypes<TBaseType>, VisitorError> CreateSubTypes<TBaseType>(Type baseType, MessagePackConverter<TBaseType> baseTypeConverter, IDerivedTypeMapping mapping)
 	{
 		if (mapping is DerivedTypeUnion { Disabled: true })
 		{
@@ -837,7 +924,22 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			// We don't want a reference-preserving converter here because that layer has already run
 			// by the time our subtype converter is invoked.
 			// And doubling up on it means values get serialized incorrectly.
-			MessagePackConverter converter = shape.Type == baseType ? baseTypeConverter : this.GetConverter(shape).UnwrapReferencePreservation();
+			MessagePackConverter converter;
+			if (shape.Type == baseType)
+			{
+				converter = baseTypeConverter;
+			}
+			else
+			{
+				IConverterResult subtypeConverter = this.GetConverter(shape);
+				if (subtypeConverter.TryPrepareFailPath(pair.Value, out ConverterResult<TBaseType>? failureResult))
+				{
+					return failureResult.Error!;
+				}
+
+				converter = ((IMessagePackConverterInternal)subtypeConverter.Value).UnwrapReferencePreservation();
+			}
+
 			switch (alias.Type)
 			{
 				case DerivedTypeIdentifier.AliasType.Integer:
@@ -888,7 +990,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	/// <param name="duckTyping">Information about the base type and derived types that distinguish objects between each type.</param>
 	/// <param name="baseTypeConverter">The converter to use when serializing the base type itself.</param>
 	/// <returns>A dictionary of <see cref="MessagePackConverter{T}"/> objects, keyed by the alias by which they will be identified in the data stream.</returns>
-	private ShapeBasedUnionConverter<TBase>? CreateDuckTypingUnionConverter<TBase>(DerivedTypeDuckTyping duckTyping, MessagePackConverter<TBase> baseTypeConverter)
+	private ConverterResult<TBase> CreateDuckTypingUnionConverter<TBase>(DerivedTypeDuckTyping duckTyping, MessagePackConverter<TBase> baseTypeConverter)
 	{
 		// Create converters for each member type
 		Dictionary<Type, MessagePackConverter> convertersByType = new(duckTyping.DerivedShapes.Length);
@@ -899,11 +1001,16 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				throw new ArgumentException($"Type '{shape.Type}' is not assignable to base type '{typeof(TBase)}'.", nameof(duckTyping));
 			}
 
-			MessagePackConverter converter = (MessagePackConverter)this.GetConverter(shape);
-			convertersByType[shape.Type] = converter;
+			IConverterResult converter = this.GetConverter(shape);
+			if (converter.TryPrepareFailPath(shape, out ConverterResult<TBase>? failureResult))
+			{
+				return failureResult;
+			}
+
+			convertersByType[shape.Type] = converter.Value;
 		}
 
-		return new ShapeBasedUnionConverter<TBase>(baseTypeConverter, duckTyping, convertersByType);
+		return ConverterResult.Ok(new ShapeBasedUnionConverter<TBase>(baseTypeConverter, duckTyping, convertersByType));
 	}
 
 	/// <summary>
@@ -914,34 +1021,43 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	/// <param name="attributeProvider"><inheritdoc cref="TryGetConverterFromAttribute{T}" path="/param[@name='attributeProvider']"/></param>
 	/// <param name="converter">Receives the converter if one is found.</param>
 	/// <returns>A value indicating whether a match was found.</returns>
-	private bool TryGetCustomOrPrimitiveConverter<T>(ITypeShape<T> typeShape, ICustomAttributeProvider? attributeProvider, [NotNullWhen(true)] out MessagePackConverter<T>? converter)
+	private bool TryGetCustomOrPrimitiveConverter<T>(ITypeShape<T> typeShape, ICustomAttributeProvider? attributeProvider, [NotNullWhen(true)] out ConverterResult<T>? converter)
 	{
 		// Check if the type has a custom converter.
-		if (this.owner.TryGetRuntimeProfferedConverter(typeShape, out converter))
+		if (this.owner.TryGetRuntimeProfferedConverter(typeShape, out MessagePackConverter<T>? proferredConverter))
 		{
+			converter = ConverterResult.Ok(proferredConverter);
 			return true;
 		}
 
 		if (this.owner.InternStrings && typeof(T) == typeof(string))
 		{
-			converter = (MessagePackConverter<T>)(object)(this.owner.PreserveReferences != ReferencePreservationMode.Off ? ReferencePreservingInterningStringConverter : InterningStringConverter);
+			converter = ConverterResult.Ok((MessagePackConverter<T>)(object)(this.owner.PreserveReferences != ReferencePreservationMode.Off ? ReferencePreservingInterningStringConverter : InterningStringConverter));
 			return true;
 		}
 
 		// Check if the type has a built-in converter.
-		if (PrimitiveConverterLookup.TryGetPrimitiveConverter(this.owner.PreserveReferences, out converter))
+		if (PrimitiveConverterLookup.TryGetPrimitiveConverter(this.owner.PreserveReferences, out MessagePackConverter<T>? primitiveConverter))
 		{
+			converter = ConverterResult.Ok(primitiveConverter);
 			return true;
 		}
 
 		return this.TryGetConverterFromAttribute(typeShape, attributeProvider, out converter);
 	}
 
-	private MessagePackConverter<T> GetConverterForMemberOrParameter<T>(ITypeShape<T> typeShape, ICustomAttributeProvider? attributeProvider)
+	private ConverterResult<T> GetConverterForMemberOrParameter<T>(ITypeShape<T> typeShape, ICustomAttributeProvider? attributeProvider)
 	{
-		return this.TryGetConverterFromAttribute(typeShape, attributeProvider, out MessagePackConverter<T>? converter)
-			? converter
-			: this.GetConverter(typeShape, attributeProvider);
+		try
+		{
+			return this.TryGetConverterFromAttribute(typeShape, attributeProvider, out ConverterResult<T>? converter)
+				? converter
+				: this.GetConverter(typeShape, attributeProvider);
+		}
+		catch (Exception ex)
+		{
+			return ConverterResult<T>.Err(ex);
+		}
 	}
 
 	/// <summary>
@@ -956,7 +1072,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 	/// <param name="converter">Receives the converter, if applicable.</param>
 	/// <returns>A value indicating whether a converter was found.</returns>
 	/// <exception cref="MessagePackSerializationException">Thrown if the prescribed converter has no default constructor.</exception>
-	private bool TryGetConverterFromAttribute<T>(ITypeShape<T> typeShape, ICustomAttributeProvider? attributeProvider, [NotNullWhen(true)] out MessagePackConverter<T>? converter)
+	private bool TryGetConverterFromAttribute<T>(ITypeShape<T> typeShape, ICustomAttributeProvider? attributeProvider, [NotNullWhen(true)] out ConverterResult<T>? converter)
 	{
 		if (attributeProvider?.GetCustomAttribute<MessagePackConverterAttribute>() is not { } customConverterAttribute)
 		{
@@ -967,12 +1083,13 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 		Type converterType = customConverterAttribute.ConverterType;
 		if ((typeShape.GetAssociatedTypeShape(converterType) as IObjectTypeShape)?.GetDefaultConstructor() is Func<object> converterFactory)
 		{
-			converter = (MessagePackConverter<T>)converterFactory();
+			MessagePackConverter<T> intermediateConverter = (MessagePackConverter<T>)converterFactory();
 			if (this.owner.PreserveReferences != ReferencePreservationMode.Off)
 			{
-				converter = converter.WrapWithReferencePreservation();
+				intermediateConverter = intermediateConverter.WrapWithReferencePreservation();
 			}
 
+			converter = ConverterResult.Ok(intermediateConverter);
 			return true;
 		}
 
@@ -981,7 +1098,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			throw new MessagePackSerializationException($"{typeof(T).FullName} has {typeof(MessagePackConverterAttribute)} that refers to {customConverterAttribute.ConverterType.FullName} but that converter has no default constructor.");
 		}
 
-		converter = (MessagePackConverter<T>)ctor.Invoke(Array.Empty<object?>());
+		converter = ConverterResult.Ok((MessagePackConverter<T>)ctor.Invoke(Array.Empty<object?>()));
 		return true;
 	}
 

--- a/src/Nerdbank.MessagePack/StreamingDeserializer`1.cs
+++ b/src/Nerdbank.MessagePack/StreamingDeserializer`1.cs
@@ -197,7 +197,7 @@ internal readonly struct StreamingDeserializer<TElement>(MessagePackSerializer s
 			// We use a converter to do the actual skipping.
 			ITypeShape? typeShape = provider.GetTypeShape(expression.Object.Type);
 			Requires.Argument(typeShape is not null, nameof(expression), "The expression does not have a known type shape.");
-			MessagePackConverter converter = serializer.GetConverter(typeShape);
+			MessagePackConverter converter = serializer.GetConverter(typeShape).ValueOrThrow;
 
 			return await converter.SkipToIndexValueAsync(reader, indexArg, context).ConfigureAwait(false) ? null : expression;
 		}
@@ -277,7 +277,7 @@ internal readonly struct StreamingDeserializer<TElement>(MessagePackSerializer s
 			Requires.Argument(propertyShape is not null, nameof(expression), "The expression does not refer to a serialized property.");
 
 			// We use a converter to do the actual skipping.
-			MessagePackConverter converter = serializer.GetConverter(typeShape);
+			MessagePackConverter converter = serializer.GetConverter(typeShape).ValueOrThrow;
 
 			return await converter.SkipToPropertyValueAsync(reader, propertyShape, context).ConfigureAwait(false) ? null : expression;
 

--- a/src/Nerdbank.MessagePack/VisitorError.cs
+++ b/src/Nerdbank.MessagePack/VisitorError.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace Nerdbank.MessagePack;
+
+/// <summary>
+/// Represents an error encountered while constructing or traversing a converter graph.
+/// This type forms a linked list of contextual messages and/or an original exception
+/// that caused the failure. It can produce a combined textual path description or
+/// throw a <see cref="MessagePackSerializationException"/> that wraps the original exception.
+/// </summary>
+internal class VisitorError
+{
+	/// <summary>
+	/// The inner (previous) error in the chain, if any.
+	/// </summary>
+	private VisitorError? inner;
+
+	/// <summary>
+	/// The original exception associated with this error node, if any.
+	/// </summary>
+	private Exception? exception;
+
+	/// <summary>
+	/// A contextual message describing this error node, if any.
+	/// </summary>
+	private string? message;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="VisitorError"/> class from an exception.
+	/// </summary>
+	/// <param name="exception">The exception that caused the error.</param>
+	/// <param name="inner">An optional inner <see cref="VisitorError"/> representing additional context.</param>
+	internal VisitorError(Exception exception, VisitorError? inner = null) => (this.exception, this.inner) = (exception, inner);
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="VisitorError"/> class from a message.
+	/// </summary>
+	/// <param name="message">A contextual message describing the error.</param>
+	/// <param name="inner">An optional inner <see cref="VisitorError"/> representing additional context.</param>
+	internal VisitorError(string message, VisitorError? inner = null) => (this.message, this.inner) = (message, inner);
+
+	/// <summary>
+	/// Implicitly converts an <see cref="Exception"/> to a <see cref="VisitorError"/>.
+	/// </summary>
+	/// <param name="exception">The exception to wrap.</param>
+	/// <returns>A new <see cref="VisitorError"/> instance containing the provided exception.</returns>
+	public static implicit operator VisitorError(Exception exception) => new(exception);
+
+	/// <summary>
+	/// Implicitly converts a textual message to a <see cref="VisitorError"/>.
+	/// </summary>
+	/// <param name="message">The message to wrap.</param>
+	/// <returns>A new <see cref="VisitorError"/> instance containing the provided message.</returns>
+	public static implicit operator VisitorError(string message) => new(message);
+
+	/// <inheritdoc/>
+	public override string ToString()
+	{
+		this.Prepare(out StringBuilder builder, out Exception? originalException);
+		return builder.ToString();
+	}
+
+	/// <summary>
+	/// Throws a <see cref="MessagePackSerializationException"/> describing the error chain.
+	/// This method never returns.
+	/// </summary>
+	/// <exception cref="MessagePackSerializationException">
+	/// Always thrown to report the prepared error message and, if available, the original exception.
+	/// </exception>
+	[DoesNotReturn]
+	internal void ThrowException()
+	{
+		this.Prepare(out StringBuilder builder, out Exception? originalException);
+		builder.Insert(0, "An error occurred while preparing the converter graph. ");
+		throw new MessagePackSerializationException(builder.ToString(), originalException);
+	}
+
+	/// <summary>
+	/// Prepares a textual description of the error path and extracts the original exception, if any.
+	/// </summary>
+	/// <param name="pathBuilder">
+	/// When this method returns, contains a <see cref="StringBuilder"/> whose content is a human-readable
+	/// description of the error path (prefixed with "Path: " if any path information exists).
+	/// </param>
+	/// <param name="originalException">
+	/// When this method returns, contains the first non-null <see cref="Exception"/> found in the error chain,
+	/// or <see langword="null"/> if none was present.
+	/// </param>
+	private void Prepare(out StringBuilder pathBuilder, out Exception? originalException)
+	{
+		pathBuilder = new();
+		VisitorError? current = this;
+		originalException = null;
+		while (current is not null)
+		{
+			if (current.message is not null)
+			{
+				if (pathBuilder.Length > 0)
+				{
+					pathBuilder.Append(" -> ");
+				}
+
+				pathBuilder.Append(current.message);
+			}
+
+			originalException ??= current.exception;
+			current = current.inner;
+		}
+
+		if (pathBuilder.Length > 0)
+		{
+			pathBuilder.Insert(0, "Path: ");
+			pathBuilder.Append('.');
+		}
+	}
+}

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -31,6 +32,24 @@ public abstract partial class MessagePackSerializerTestBase
 	protected MessagePackSerializer Serializer { get; set; }
 
 	protected ITestOutputHelper Logger => TestContext.Current.TestOutputHelper ?? throw new InvalidOperationException("No logger available.");
+
+	public static string GetFullMessage(Exception ex)
+	{
+		StringBuilder builder = new();
+		Exception? current = ex;
+		while (current is not null)
+		{
+			if (builder.Length > 0)
+			{
+				builder.Append(' ');
+			}
+
+			builder.Append(current.Message);
+			current = current.InnerException;
+		}
+
+		return builder.ToString();
+	}
 
 #if !NET
 	internal static ITypeShapeProvider GetShapeProvider<TProvider>()

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
@@ -100,9 +100,9 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 		{
 			this.AssertRoundtrip(new HasMultiDimensionalArray());
 		}
-		catch (MessagePackSerializationException ex) when (ex.InnerException is PlatformNotSupportedException)
+		catch (MessagePackSerializationException ex) when (ex.GetBaseException() is PlatformNotSupportedException)
 		{
-			throw SkipException.ForSkip($"Skipped: {ex.Message}");
+			throw SkipException.ForSkip($"Skipped: {GetFullMessage(ex)}");
 		}
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/SerializationRejectsFunctionsTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/SerializationRejectsFunctionsTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+public partial class SerializationRejectsFunctionsTests : MessagePackSerializerTestBase
+{
+	[Fact]
+	public void UnserializedDelegateTypesDoNotBreakSerialization()
+	{
+		this.AssertRoundtrip(new TypeWithUnserializedPropertyWithFunctionProperty { SimpleProperty = 42 });
+	}
+
+	[GenerateShape]
+	public partial record TypeWithUnserializedPropertyWithFunctionProperty
+	{
+		public int SimpleProperty { get; set; }
+
+		public TypeWithFunctionProperty Unserialized => throw new NotImplementedException();
+	}
+
+	public class TypeWithFunctionProperty
+	{
+		public Func<int>? FunctionProperty { get; set; }
+	}
+}


### PR DESCRIPTION
We use new converter monads to allow representing success and failure cases, so that failure cases can be tracked and thrown or ignored by the visitor callers as appropriate. This allows us to completely avoid throwing exceptions until we know that we want to throw an observed one.