### PR TITLE
Add `WithHiFiDateTime` optional converter

### DIFF
--- a/test/Nerdbank.MessagePack.Tests/OptionalConvertersTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/OptionalConvertersTests.cs
@@ -35,4 +35,14 @@ public class OptionalConvertersTests : MessagePackSerializerTestBase
 			   .WithAssumedDateTimeKind(DateTimeKind.Utc));
 		this.Logger.WriteLine(ex.Message);
 	}
+
+	[Fact]
+	public void WithHiFiDateTime_Twice()
+	{
+		ArgumentException ex = Assert.Throws<ArgumentException>(
+			   () => this.Serializer
+			   .WithHiFiDateTime()
+			   .WithHiFiDateTime());
+		this.Logger.WriteLine(ex.Message);
+	}
 }


### PR DESCRIPTION
Add `WithHiFiDateTime` optional converter

This converter will serialize a `DateTime` value and preserve its `Kind` property, no matter what it is.