### PR TITLE
Primitive object serializer respects `WithAssumedDateTimeKind`

### DIFF
--- a/src/Nerdbank.MessagePack/Converters/PrimitivesAsObjectConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/PrimitivesAsObjectConverter.cs
@@ -84,13 +84,13 @@ internal class PrimitivesAsObjectConverter : MessagePackConverter<object?>
 			MessagePackReader peekReader = reader.CreatePeekReader();
 			ExtensionHeader header = peekReader.ReadExtensionHeader();
 
-			// For any of these extensions that relies on a converter, we ensure that it is our expected converter
-			// that supports the extension typde code found.
+			// For any of these *library-defined* extensions that relies on a converter, we ensure that
+			// it is our expected converter that supports the extension typde code found.
 			// A user-supplied converter or even an in-library alternate converter (e.g. GuidAsStringConverter)
 			// wouldn't be able to do the job of deserialization.
 			if (header.TypeCode == ReservedMessagePackExtensionTypeCode.DateTime)
 			{
-				value = reader.ReadDateTime();
+				value = context.GetConverter<DateTime>(null).Read(ref reader, context);
 			}
 			else if (header.TypeCode == context.ExtensionTypeCodes.Decimal && context.GetConverter<decimal>(null) is DecimalConverter decimalConverter)
 			{
@@ -176,7 +176,7 @@ internal class PrimitivesAsObjectConverter : MessagePackConverter<object?>
 				writer.Write(v);
 				break;
 			case DateTime v:
-				writer.Write(v);
+				context.GetConverter<DateTime>(null).Write(ref writer, v, context);
 				break;
 			case byte v:
 				writer.Write(v);

--- a/test/Nerdbank.MessagePack.Tests/PrimitivesDynamicDeserializationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/PrimitivesDynamicDeserializationTests.cs
@@ -11,11 +11,12 @@ public partial class PrimitivesDynamicDeserializationTests : PrimitivesDerializa
 	public void ReachIntoArray()
 	{
 		dynamic deserialized = this.DeserializePrimitives();
-		Assert.Equal(4, deserialized.nestedArray.Length);
+		Assert.Equal(5, deserialized.nestedArray.Length);
 		Assert.Equal(true, deserialized.nestedArray[0]);
 		Assert.Equal(3.5, deserialized.nestedArray[1]);
 		Assert.Equal(new Extension(15, new byte[] { 1, 2, 3 }), deserialized.nestedArray[2]);
 		Assert.Equal<DateTime>(ExpectedDateTime, deserialized.nestedArray[3]);
+		Assert.Equal<DateTime>(ExpectedDateTime, deserialized.nestedArray[4]);
 	}
 
 	[Fact]


### PR DESCRIPTION
This allows serializing a `DateTime` with `DateTimeKind.Unspecified` to be serialized while typed as `object` (when `WithObjectConverter()` is used), respecting whatever default Kind is set using `WithAssumedDateTimeKind`.