### PR TITLE
Remove unnecessary Commit() during async serialization

### DIFF
--- a/src/Nerdbank.MessagePack/MessagePackAsyncWriter.cs
+++ b/src/Nerdbank.MessagePack/MessagePackAsyncWriter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
 using Microsoft;
 
@@ -40,11 +39,6 @@ public class MessagePackAsyncWriter(PipeWriter pipeWriter)
 	/// </remarks>
 	public MessagePackWriter CreateWriter()
 	{
-#if !NET
-		// ref fields are not supported on .NET Framework, so we have to prepare to copy the struct.
-		this.bufferWriter.Commit();
-#endif
-
 		return new(new BufferWriter(ref this.bufferWriter));
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTestBase.cs
@@ -21,6 +21,9 @@ public abstract partial class MessagePackSerializerTestBase
 			// so disable the buffer that would lead it down the synchronous paths since we have
 			// small test data sizes.
 			MaxAsyncBuffer = 0,
+
+			// Also pause async Serialization to flush frequently to exercise those code paths.
+			StartingContext = new SerializationContext { UnflushedBytesThreshold = 50 },
 		};
 	}
 


### PR DESCRIPTION
The `MessagePackAsyncWriter.CreateWriter()` method was unnecessarily calling `IBufferWriter<byte>.Advance(int)` on .NET Framework. But beyond being overhead, this line is somehow responsible for the following exception which comes up randomly in yielding async serialization scenarios:

```
System.ArgumentOutOfRangeException : Specified argument was out of the range of valid values.
ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument)
Pipe.Advance(Int32 bytes)
BufferMemoryWriter.Commit() line 86
MessagePackAsyncWriter.CreateWriter() line 44
<WriteAsync>d__12.MoveNext() line 113
```

I don't know why the old code was defective. I only know it shouldn't be necessary, and that its removal makes the exception go away. I've adjusted the tests to cover yielding async serialization where we were missing that coverage before.