### PR TITLE
Add net472 target

### DIFF
--- a/src/Nerdbank.MessagePack/Nerdbank.MessagePack.csproj
+++ b/src/Nerdbank.MessagePack/Nerdbank.MessagePack.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net472;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)','net8.0'))">true</IsAotCompatible>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/src/Nerdbank.MessagePack/SecureHash/SurrogateEqualityComparer`2.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SurrogateEqualityComparer`2.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETSTANDARD
+#if !NET
 #pragma warning disable CS8604 // Possible null reference argument.
 #pragma warning disable CS8767 // Nullability of type of parameter doesn't match overridden member (possibly because of nullability attributes).
 #endif


### PR DESCRIPTION
An explicit .NET Framework target framework is critical to effective ngen. Otherwise a .NET Framework assembly that references this one and uses mscorlib types as type arguments will have no 'home' for native code to be written in by ngen. The Nerdbank.MessagePack.dll must have an mscorlib assembly reference or those methods will never be ngen'd.