### PR TITLE
Give priority to custom converters over surrogates

### DIFF
--- a/samples/cs/CustomConverterFactory.cs
+++ b/samples/cs/CustomConverterFactory.cs
@@ -7,8 +7,8 @@ namespace CustomConverterFactory
     internal class NonGenericCustomConverterFactory : IMessagePackConverterFactory
     {
         // special purpose factory knows exactly what it supports. No generic type parameter needed.
-        public MessagePackConverter? CreateConverter(ITypeShape shape, in ConverterContext context)
-            => shape.Type == typeof(List<Guid>) ? new WrapInArrayConverter<List<Guid>>() : null;
+        public MessagePackConverter? CreateConverter(Type type, ITypeShape? shape, in ConverterContext context)
+            => type == typeof(List<Guid>) ? new WrapInArrayConverter<List<Guid>>() : null;
     }
     #endregion
 
@@ -16,8 +16,8 @@ namespace CustomConverterFactory
     internal class GenericCustomConverterFactory : IMessagePackConverterFactory, ITypeShapeFunc
     {
         // perform type check, then defer to generic method.
-        public MessagePackConverter? CreateConverter(ITypeShape shape, in ConverterContext context)
-            => shape.Type == typeof(int) ? this.Invoke(shape) : null;
+        public MessagePackConverter? CreateConverter(Type type, ITypeShape? shape, in ConverterContext context)
+            => shape?.Type == typeof(int) ? this.Invoke(shape) : null;
 
         // type check is already done, just create the converter.
         object? ITypeShapeFunc.Invoke<T>(ITypeShape<T> typeShape, object? state)
@@ -29,7 +29,7 @@ namespace CustomConverterFactory
     internal class VisitorCustomConverterFactory : IMessagePackConverterFactory
     {
         // perform type check, then defer to generic method.
-        public MessagePackConverter? CreateConverter(ITypeShape shape, in ConverterContext context)
+        public MessagePackConverter? CreateConverter(Type type, ITypeShape? shape, in ConverterContext context)
             => shape is IEnumerableTypeShape enumShape && enumShape.Type.GetGenericTypeDefinition() == typeof(List<>) ?
                 (MessagePackConverter?)shape.Accept(Visitor.Instance) : null;
 

--- a/samples/cs/CustomConverters.cs
+++ b/samples/cs/CustomConverters.cs
@@ -485,9 +485,9 @@ namespace CustomConverterFactory
 
     class MarshalingConverterFactory(object trackerKey) : IMessagePackConverterFactory, ITypeShapeFunc
     {
-        public MessagePackConverter? CreateConverter(ITypeShape shape, in ConverterContext context)
+        public MessagePackConverter? CreateConverter(Type type, ITypeShape? shape, in ConverterContext context)
         {
-            return shape.Type.GetCustomAttribute<MarshalByRefAttribute>() is not null ? this.Invoke(shape) : null;
+            return shape?.Type.GetCustomAttribute<MarshalByRefAttribute>() is not null ? this.Invoke(shape) : null;
         }
 
         object? ITypeShapeFunc.Invoke<T>(ITypeShape<T> typeShape, object? state) => new MarshalingConverter<T>(trackerKey);

--- a/src/Nerdbank.MessagePack/IMessagePackConverterFactory.cs
+++ b/src/Nerdbank.MessagePack/IMessagePackConverterFactory.cs
@@ -30,7 +30,13 @@ public interface IMessagePackConverterFactory
 	/// <summary>
 	/// Creates a converter for the given type if this factory is capable of it.
 	/// </summary>
-	/// <param name="shape">The shape of the type to be serialized.</param>
+	/// <param name="type">The type to be serialized.</param>
+	/// <param name="shape">
+	/// The shape of the type to be serialized, if available.
+	/// The shape will typically be available.
+	/// The only known exception is when the type has a
+	/// <see cref="TypeShapeAttribute.Marshaler">PolyType marshaler</see> defined.
+	/// </param>
 	/// <param name="context">The context in which this factory is being invoked. Provides access to other converters that may be required by the requested converter.</param>
 	/// <returns>The converter for the data type, or <see langword="null" />.</returns>
 	/// <remarks>
@@ -43,7 +49,7 @@ public interface IMessagePackConverterFactory
 	/// to forward the call to the generic <see cref="ITypeShapeFunc.Invoke{T}(ITypeShape{T}, object?)"/> method
 	/// defined on that same class.
 	/// </remarks>
-	MessagePackConverter? CreateConverter(ITypeShape shape, in ConverterContext context);
+	MessagePackConverter? CreateConverter(Type type, ITypeShape? shape, in ConverterContext context);
 }
 
 /// <summary>

--- a/test/Nerdbank.MessagePack.Tests/CustomConverterFactoryTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/CustomConverterFactoryTests.cs
@@ -97,7 +97,7 @@ public partial class CustomConverterFactoryTests : MessagePackSerializerTestBase
 
 	internal class DoubleArrayWrapperFactory : IMessagePackConverterFactory
 	{
-		public MessagePackConverter? CreateConverter(ITypeShape shape, in ConverterContext context)
+		public MessagePackConverter? CreateConverter(Type type, ITypeShape? shape, in ConverterContext context)
 		{
 			if (shape is IEnumerableTypeShape { Type.IsGenericType: true, ElementType: ITypeShape elementShape } enumShape && shape.Type.GetGenericTypeDefinition() == typeof(List<>))
 			{
@@ -162,9 +162,9 @@ public partial class CustomConverterFactoryTests : MessagePackSerializerTestBase
 
 	internal class MarshaledObjectConverterFactory : IMessagePackConverterFactory, ITypeShapeFunc
 	{
-		public MessagePackConverter? CreateConverter(ITypeShape shape, in ConverterContext context)
+		public MessagePackConverter? CreateConverter(Type type, ITypeShape? shape, in ConverterContext context)
 		{
-			return shape.Type.GetCustomAttribute<RpcMarshaledAttribute>() is null ? null : this.Invoke(shape);
+			return shape?.Type.GetCustomAttribute<RpcMarshaledAttribute>() is null ? null : this.Invoke(shape);
 		}
 
 		object? ITypeShapeFunc.Invoke<T>(ITypeShape<T> typeShape, object? state) => new MarshaledObjectConverter<T>();
@@ -200,9 +200,9 @@ public partial class CustomConverterFactoryTests : MessagePackSerializerTestBase
 
 	internal class CustomUnionConverterFactory : IMessagePackConverterFactory, ITypeShapeFunc
 	{
-		public MessagePackConverter? CreateConverter(ITypeShape shape, in ConverterContext context)
+		public MessagePackConverter? CreateConverter(Type type, ITypeShape? shape, in ConverterContext context)
 		{
-			return typeof(A).IsAssignableFrom(shape.Type) ? this.Invoke(shape) : null;
+			return typeof(A).IsAssignableFrom(type) && shape is not null ? this.Invoke(shape) : null;
 		}
 
 		object? ITypeShapeFunc.Invoke<T>(ITypeShape<T> typeShape, object? state) => new CustomUnionConverter<T>();


### PR DESCRIPTION
This involves a breaking change to the `IMessagePackConverterFactory` interface.

Closes #710