### PR TITLE
Update tests to use the same patterns we espouse to users

### DIFF
--- a/src/Nerdbank.MessagePack.Analyzers/Strings.resx
+++ b/src/Nerdbank.MessagePack.Analyzers/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -232,7 +232,7 @@
     <value>Use ref parameters for ref structs</value>
   </data>
   <data name="NBMsgPack051_MessageFormat" xml:space="preserve">
-    <value>{0} Consider suppressing this warning for multi-targeting projects.</value>
+    <value>{0} If using a witness type, you may want to check that it has an explicit GenerateShapeFor&lt;T&gt; attribute for the shape being serialized.</value>
   </data>
   <data name="NBMsgPack051_Title" xml:space="preserve">
     <value>Prefer modern .NET APIs</value>

--- a/src/Nerdbank.MessagePack.SignalR/MessagePackHubProtocol.Reader.cs
+++ b/src/Nerdbank.MessagePack.SignalR/MessagePackHubProtocol.Reader.cs
@@ -219,7 +219,7 @@ internal partial class MessagePackHubProtocol
 			return null;
 		}
 
-		return EnvelopeSerializer.Deserialize(ref reader, PolyType.SourceGenerator.TypeShapeProvider_Nerdbank_MessagePack_SignalR.Default.String_Array);
+		return EnvelopeSerializer.Deserialize<string[], Witness>(ref reader);
 	}
 
 	private static Type? TryGetReturnType(IInvocationBinder binder, string invocationId)

--- a/src/Nerdbank.MessagePack.SignalR/MessagePackHubProtocol.Writer.cs
+++ b/src/Nerdbank.MessagePack.SignalR/MessagePackHubProtocol.Writer.cs
@@ -48,7 +48,7 @@ internal partial class MessagePackHubProtocol
 	   => EnvelopeSerializer.Serialize(ref writer, headers ?? ImmutableDictionary<string, string>.Empty, PolyType.SourceGenerator.TypeShapeProvider_Nerdbank_MessagePack_SignalR.Default.IDictionary_String_String);
 
 	private static void WriteStreamIds(ref MessagePackWriter writer, string[]? streamIds)
-		=> EnvelopeSerializer.Serialize(ref writer, streamIds ?? [], PolyType.SourceGenerator.TypeShapeProvider_Nerdbank_MessagePack_SignalR.Default.String_Array);
+		=> EnvelopeSerializer.Serialize<string[], Witness>(ref writer, streamIds ?? []);
 
 	private void WriteMessageCore(IBufferWriter<byte> output, HubMessage message)
 	{

--- a/test/Nerdbank.MessagePack.Tests/MessagePackConverterAttributeTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackConverterAttributeTests.cs
@@ -48,8 +48,8 @@ public partial class MessagePackConverterAttributeTests : MessagePackSerializerT
 	public void EnumWithCustomConverter()
 	{
 		MyEnum value = MyEnum.Value2;
-		byte[] msgpack = this.Serializer.Serialize(value, SourceGenProvider.MyEnum, TestContext.Current.CancellationToken);
-		MyEnum deserializedValue = this.Serializer.Deserialize(msgpack, SourceGenProvider.MyEnum, TestContext.Current.CancellationToken);
+		byte[] msgpack = this.Serializer.Serialize<MyEnum, Witness>(value, TestContext.Current.CancellationToken);
+		MyEnum deserializedValue = this.Serializer.Deserialize<MyEnum, Witness>(msgpack, TestContext.Current.CancellationToken);
 		Assert.Equal(value, deserializedValue);
 
 		MessagePackReader reader = new(msgpack);

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
@@ -413,7 +413,7 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 	public void WriteLargeStringToStream()
 	{
 		string value = new string('x', 100 * 1024);
-		this.Serializer.Serialize(Stream.Null, value, SourceGenProvider.String, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<string, Witness>(Stream.Null, value, TestContext.Current.CancellationToken);
 	}
 
 	/// <summary>
@@ -426,18 +426,18 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 	[Fact]
 	public void ObjectKeyedCollections()
 	{
-		byte[] msgpack = this.Serializer.Serialize(new Dictionary<string, object>(), SourceGenProvider.IDictionary, TestContext.Current.CancellationToken);
-		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Deserialize(msgpack, SourceGenProvider.IDictionary, TestContext.Current.CancellationToken));
+		byte[] msgpack = this.Serializer.Serialize<IDictionary, Witness>(new Dictionary<string, object>(), TestContext.Current.CancellationToken);
+		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Deserialize<IDictionary, Witness>(msgpack, TestContext.Current.CancellationToken));
 		NotSupportedException innerException = Assert.IsType<NotSupportedException>(ex.GetBaseException());
 		this.Logger.WriteLine(innerException.Message);
 
-		msgpack = this.Serializer.Serialize(new Dictionary<object, string>(), SourceGenProvider.IDictionary_Object_String, TestContext.Current.CancellationToken);
-		ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Deserialize(msgpack, SourceGenProvider.IDictionary_Object_String, TestContext.Current.CancellationToken));
+		msgpack = this.Serializer.Serialize<IDictionary<object, string>, Witness>(new Dictionary<object, string>(), TestContext.Current.CancellationToken);
+		ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Deserialize<IDictionary<object, string>, Witness>(msgpack, TestContext.Current.CancellationToken));
 		innerException = Assert.IsType<NotSupportedException>(ex.GetBaseException());
 		this.Logger.WriteLine(innerException.Message);
 
-		msgpack = this.Serializer.Serialize(new HashSet<object>(), SourceGenProvider.HashSet_Object, TestContext.Current.CancellationToken);
-		ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Deserialize(msgpack, SourceGenProvider.HashSet_Object, TestContext.Current.CancellationToken));
+		msgpack = this.Serializer.Serialize<HashSet<object>, Witness>(new HashSet<object>(), TestContext.Current.CancellationToken);
+		ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.Deserialize<HashSet<object>, Witness>(msgpack, TestContext.Current.CancellationToken));
 		innerException = Assert.IsType<NotSupportedException>(ex.GetBaseException());
 		this.Logger.WriteLine(innerException.Message);
 

--- a/test/Nerdbank.MessagePack.Tests/MultipleTypeShapeProvidersTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MultipleTypeShapeProvidersTests.cs
@@ -37,7 +37,7 @@ public partial class MultipleTypeShapeProvidersTests : MessagePackSerializerTest
 	public void ShapesFromTwoAssemblies_BothDirect()
 	{
 		this.Serializer.Serialize(SomeExtension, TestContext.Current.CancellationToken);
-		this.Serializer.Serialize(SomeExtension, SourceGenProvider.Extension, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize(SomeExtension, TestContext.Current.CancellationToken);
 	}
 
 	[Fact]

--- a/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
@@ -288,7 +288,7 @@ public partial class ObjectsAsArraysTests : MessagePackSerializerTestBase
 		writer.Flush();
 		long positionAfterIndex = sequence.Length;
 
-		this.Serializer.Serialize(ref writer, expectedFamily.FirstChild, GetShape<Person>(), TestContext.Current.CancellationToken);
+		this.Serializer.Serialize(ref writer, expectedFamily.FirstChild, TestContext.Current.CancellationToken);
 		writer.Flush();
 		this.LogMsgPack(sequence);
 
@@ -334,7 +334,7 @@ public partial class ObjectsAsArraysTests : MessagePackSerializerTestBase
 		writer.Flush();
 		long positionAfterIndex = sequence.Length;
 
-		this.Serializer.Serialize(ref writer, expectedFamily.FirstChild, GetShape<Person>(), TestContext.Current.CancellationToken);
+		this.Serializer.Serialize(ref writer, expectedFamily.FirstChild, TestContext.Current.CancellationToken);
 		writer.Flush();
 		this.LogMsgPack(sequence);
 
@@ -381,13 +381,6 @@ public partial class ObjectsAsArraysTests : MessagePackSerializerTestBase
 		ClassWithPropertyGettersWithCtorParam obj = new(true);
 		this.AssertRoundtrip(obj);
 	}
-
-	private static ITypeShape<T> GetShape<T>()
-#if NET
-		where T : IShapeable<T> => T.GetTypeShape();
-#else
-		=> GetTypeShape<T, Witness>();
-#endif
 
 	[GenerateShapeFor<int>]
 	private partial class Witness;

--- a/test/Nerdbank.MessagePack.Tests/PrimitivesDerializationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/PrimitivesDerializationTests.cs
@@ -216,41 +216,41 @@ public partial class PrimitivesDerializationTests : MessagePackSerializerTestBas
 		MessagePackWriter writer = new(seq);
 		writer.WriteMapHeader(ExpectedKeys.Length);
 		writer.Write("Prop1");
-		this.Serializer.Serialize<object>(ref writer, "Value1", SourceGenProvider.Object, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<object, Witness>(ref writer, "Value1", TestContext.Current.CancellationToken);
 		writer.Write("Prop2");
-		this.Serializer.Serialize<object>(ref writer, 42, SourceGenProvider.Object, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<object, Witness>(ref writer, 42, TestContext.Current.CancellationToken);
 		writer.Write("nestedArray");
 		writer.WriteArrayHeader(5);
-		this.Serializer.Serialize<object>(ref writer, true, SourceGenProvider.Object, TestContext.Current.CancellationToken);
-		this.Serializer.Serialize<object>(ref writer, 3.5, SourceGenProvider.Object, TestContext.Current.CancellationToken);
-		this.Serializer.Serialize<object>(ref writer, new Extension(15, new byte[] { 1, 2, 3 }), SourceGenProvider.Object, TestContext.Current.CancellationToken);
-		this.Serializer.Serialize<object>(ref writer, ExpectedDateTime, SourceGenProvider.Object, TestContext.Current.CancellationToken);
-		this.Serializer.Serialize<object>(ref writer, ExpectedDateTimeUnspecifiedKind, SourceGenProvider.Object, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<object, Witness>(ref writer, true, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<object, Witness>(ref writer, 3.5, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<object, Witness>(ref writer, new Extension(15, new byte[] { 1, 2, 3 }), TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<object, Witness>(ref writer, ExpectedDateTime, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<object, Witness>(ref writer, ExpectedDateTimeUnspecifiedKind, TestContext.Current.CancellationToken);
 		writer.Write(45); // int key for stretching tests
-		this.Serializer.Serialize<object>(ref writer, (byte[])[1, 2, 3], SourceGenProvider.Object, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<object, Witness>(ref writer, (byte[])[1, 2, 3], TestContext.Current.CancellationToken);
 		writer.Write(-45); // negative int key for stretching tests
-		this.Serializer.Serialize<object>(ref writer, false, SourceGenProvider.Object, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<object, Witness>(ref writer, false, TestContext.Current.CancellationToken);
 
 		writer.Write("nestedObject");
 		writer.WriteMapHeader(1);
 		writer.Write("nestedProp");
-		this.Serializer.Serialize<object>(ref writer, "nestedValue", SourceGenProvider.Object, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<object, Witness>(ref writer, "nestedValue", TestContext.Current.CancellationToken);
 
 		writer.Write("decimal");
-		this.Serializer.Serialize(ref writer, ExpectedDecimal, SourceGenProvider.Decimal, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<decimal, Witness>(ref writer, ExpectedDecimal, TestContext.Current.CancellationToken);
 
 		writer.Write("bigint");
-		this.Serializer.Serialize(ref writer, ExpectedBigInteger, SourceGenProvider.BigInteger, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<BigInteger, Witness>(ref writer, ExpectedBigInteger, TestContext.Current.CancellationToken);
 
 		writer.Write("guid");
-		this.Serializer.Serialize(ref writer, ExpectedGuid, SourceGenProvider.Guid, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<Guid, Witness>(ref writer, ExpectedGuid, TestContext.Current.CancellationToken);
 
 #if NET
 		writer.Write("i128");
-		this.Serializer.Serialize(ref writer, ExpectedInt128, SourceGenProvider.Int128, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<Int128, Witness>(ref writer, ExpectedInt128, TestContext.Current.CancellationToken);
 
 		writer.Write("u128");
-		this.Serializer.Serialize(ref writer, ExpectedUInt128, SourceGenProvider.UInt128, TestContext.Current.CancellationToken);
+		this.Serializer.Serialize<UInt128, Witness>(ref writer, ExpectedUInt128, TestContext.Current.CancellationToken);
 #endif
 
 		writer.Flush();
@@ -259,6 +259,14 @@ public partial class PrimitivesDerializationTests : MessagePackSerializerTestBas
 		return new MessagePackReader(seq);
 	}
 
+#if NET
+	[GenerateShapeFor<Int128>]
+	[GenerateShapeFor<UInt128>]
+#endif
+	[GenerateShapeFor<decimal>]
+	[GenerateShapeFor<BigInteger>]
+	[GenerateShapeFor<Guid>]
+	[GenerateShapeFor<object>]
 	[GenerateShapeFor<IReadOnlyDictionary<MessagePackValue, object>>]
 	private partial class Witness;
 }

--- a/test/Nerdbank.MessagePack.Tests/SecurityTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/SecurityTests.cs
@@ -139,7 +139,7 @@ public partial class SecurityTests : MessagePackSerializerTestBase
 		writer.Write("value2");
 		writer.Flush();
 		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(
-			() => this.Serializer.Deserialize(seq, SourceGenProvider.Dictionary_String_String, TestContext.Current.CancellationToken));
+			() => this.Serializer.Deserialize<Dictionary<string, string>, Witness>(seq, TestContext.Current.CancellationToken));
 		this.Logger.WriteLine(ex.GetBaseException().Message);
 	}
 

--- a/test/Nerdbank.MessagePack.Tests/StreamingEnumerableTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StreamingEnumerableTests.cs
@@ -21,7 +21,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 
 		int readCount = 0;
 		PipeReader reader = PipeReader.Create(sequence);
-		await foreach (int current in this.Serializer.DeserializeEnumerableAsync(reader, SourceGenProvider.Int32, TestContext.Current.CancellationToken))
+		await foreach (int current in this.Serializer.DeserializeEnumerableAsync<int, Witness>(reader, TestContext.Current.CancellationToken))
 		{
 			readCount++;
 			this.Logger.WriteLine(current.ToString());
@@ -37,7 +37,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 	public async Task DeserializeEnumerableAsync_TopLevel_Empty()
 	{
 		PipeReader reader = PipeReader.Create(new([]));
-		await foreach (int current in this.Serializer.DeserializeEnumerableAsync(reader, SourceGenProvider.Int32, TestContext.Current.CancellationToken))
+		await foreach (int current in this.Serializer.DeserializeEnumerableAsync<int, Witness>(reader, TestContext.Current.CancellationToken))
 		{
 			Assert.Fail("No items should have been read.");
 		}
@@ -161,7 +161,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		int readCount = 0;
 		PipeReader reader = PipeReader.Create(sequence);
 		MessagePackSerializer.StreamingEnumerationOptions<int[], int> options = new(a => a);
-		await foreach (int current in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.Int32_Array, options, TestContext.Current.CancellationToken))
+		await foreach (int current in this.Serializer.DeserializePathEnumerableAsync<int[], int, Witness>(reader, options, TestContext.Current.CancellationToken))
 		{
 			readCount++;
 			this.Logger.WriteLine(current.ToString());
@@ -180,7 +180,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		PipeReader reader = PipeReader.Create(new(msgpack));
 		MessagePackSerializer.StreamingEnumerationOptions<SimpleStreamingContainerKeyed[], SimpleStreamingContainerKeyed> options = new(a => a);
 		List<SimpleStreamingContainerKeyed?> actual = new();
-		await foreach (SimpleStreamingContainerKeyed? item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.SimpleStreamingContainerKeyed_Array, options, TestContext.Current.CancellationToken))
+		await foreach (SimpleStreamingContainerKeyed? item in this.Serializer.DeserializePathEnumerableAsync<SimpleStreamingContainerKeyed[], SimpleStreamingContainerKeyed, Witness>(reader, options, TestContext.Current.CancellationToken))
 		{
 			actual.Add(item);
 		}
@@ -202,7 +202,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		List<SimpleStreamingContainerKeyed?> actual = new();
 		NotSupportedException ex = await Assert.ThrowsAsync<NotSupportedException>(async delegate
 		{
-			await foreach (SimpleStreamingContainerKeyed? item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.SimpleStreamingContainerKeyed_Array, options, TestContext.Current.CancellationToken))
+			await foreach (SimpleStreamingContainerKeyed? item in this.Serializer.DeserializePathEnumerableAsync<SimpleStreamingContainerKeyed[], SimpleStreamingContainerKeyed, Witness>(reader, options, TestContext.Current.CancellationToken))
 			{
 				actual.Add(item);
 			}
@@ -228,7 +228,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		{
 			LeaveOpen = leaveOpen,
 		};
-		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.OuterStreamingContainer, options, TestContext.Current.CancellationToken))
+		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, options, TestContext.Current.CancellationToken))
 		{
 			Assert.Equal(count++ + 1, item);
 		}
@@ -238,7 +238,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		if (leaveOpen)
 		{
 			// Verify correct positioning by deserializing the next top-level structure in the pipe.
-			string? actual = await this.Serializer.DeserializeAsync(reader, SourceGenProvider.String, TestContext.Current.CancellationToken);
+			string? actual = await this.Serializer.DeserializeAsync<string, Witness>(reader, TestContext.Current.CancellationToken);
 			Assert.Equal("hi", actual);
 		}
 	}
@@ -258,7 +258,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		{
 			LeaveOpen = leaveOpen,
 		};
-		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.SimpleStreamingContainerKeyed, options, TestContext.Current.CancellationToken))
+		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, options, TestContext.Current.CancellationToken))
 		{
 			Assert.Equal(count++ + 1, item);
 		}
@@ -268,7 +268,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		if (leaveOpen)
 		{
 			// Verify correct positioning by deserializing the next top-level structure in the pipe.
-			string? actual = await this.Serializer.DeserializeAsync(reader, SourceGenProvider.String, TestContext.Current.CancellationToken);
+			string? actual = await this.Serializer.DeserializeAsync<string, Witness>(reader, TestContext.Current.CancellationToken);
 			Assert.Equal("hi", actual);
 		}
 	}
@@ -292,7 +292,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		{
 			LeaveOpen = leaveOpen,
 		};
-		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.OuterStreamingContainerByArray, options, TestContext.Current.CancellationToken))
+		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, options, TestContext.Current.CancellationToken))
 		{
 			Assert.Equal(count++ + 1, item);
 		}
@@ -302,7 +302,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		if (leaveOpen)
 		{
 			// Verify correct positioning by deserializing the next top-level structure in the pipe.
-			string? actual = await this.Serializer.DeserializeAsync(reader, SourceGenProvider.String, TestContext.Current.CancellationToken);
+			string? actual = await this.Serializer.DeserializeAsync<string, Witness>(reader, TestContext.Current.CancellationToken);
 			Assert.Equal("hi", actual);
 		}
 	}
@@ -326,7 +326,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		{
 			LeaveOpen = leaveOpen,
 		};
-		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.OuterStreamingContainerByImmutableArray, options, TestContext.Current.CancellationToken))
+		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, options, TestContext.Current.CancellationToken))
 		{
 			Assert.Equal(count++ + 1, item);
 		}
@@ -336,7 +336,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		if (leaveOpen)
 		{
 			// Verify correct positioning by deserializing the next top-level structure in the pipe.
-			string? actual = await this.Serializer.DeserializeAsync(reader, SourceGenProvider.String, TestContext.Current.CancellationToken);
+			string? actual = await this.Serializer.DeserializeAsync<string, Witness>(reader, TestContext.Current.CancellationToken);
 			Assert.Equal("hi", actual);
 		}
 	}
@@ -360,7 +360,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		{
 			LeaveOpen = leaveOpen,
 		};
-		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.OuterStreamingContainerByDictionary, options, TestContext.Current.CancellationToken))
+		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, options, TestContext.Current.CancellationToken))
 		{
 			Assert.Equal(count++ + 1, item);
 		}
@@ -370,7 +370,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		if (leaveOpen)
 		{
 			// Verify correct positioning by deserializing the next top-level structure in the pipe.
-			string? actual = await this.Serializer.DeserializeAsync(reader, SourceGenProvider.String, TestContext.Current.CancellationToken);
+			string? actual = await this.Serializer.DeserializeAsync<string, Witness>(reader, TestContext.Current.CancellationToken);
 			Assert.Equal("hi", actual);
 		}
 	}
@@ -395,7 +395,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		{
 			LeaveOpen = leaveOpen,
 		};
-		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.OuterStreamingContainerByDictionaryCustomKey, options, TestContext.Current.CancellationToken))
+		await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, options, TestContext.Current.CancellationToken))
 		{
 			Assert.Equal(count++ + 1, item);
 		}
@@ -405,7 +405,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		if (leaveOpen)
 		{
 			// Verify correct positioning by deserializing the next top-level structure in the pipe.
-			string? actual = await this.Serializer.DeserializeAsync(reader, SourceGenProvider.String, TestContext.Current.CancellationToken);
+			string? actual = await this.Serializer.DeserializeAsync<string, Witness>(reader, TestContext.Current.CancellationToken);
 			Assert.Equal("hi", actual);
 		}
 	}
@@ -425,7 +425,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		PipeReader reader = PipeReader.Create(new(msgpack));
 		try
 		{
-			await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.OuterStreamingContainer, options, TestContext.Current.CancellationToken))
+			await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, options, TestContext.Current.CancellationToken))
 			{
 				Assert.Fail("Should not have received any items.");
 			}
@@ -455,7 +455,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		PipeReader reader = PipeReader.Create(new(msgpack));
 		try
 		{
-			await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.OuterStreamingContainer, options, TestContext.Current.CancellationToken))
+			await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, options, TestContext.Current.CancellationToken))
 			{
 				Assert.Fail("Should not have received any items.");
 			}
@@ -485,7 +485,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 		PipeReader reader = PipeReader.Create(new(msgpack));
 		try
 		{
-			await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, SourceGenProvider.OuterStreamingContainer, options, TestContext.Current.CancellationToken))
+			await foreach (int item in this.Serializer.DeserializePathEnumerableAsync(reader, options, TestContext.Current.CancellationToken))
 			{
 				Assert.Fail("Should not have received any items.");
 			}
@@ -504,6 +504,7 @@ public partial class StreamingEnumerableTests : MessagePackSerializerTestBase
 
 	[GenerateShapeFor<string>]
 	[GenerateShapeFor<int>]
+	[GenerateShapeFor<int[]>]
 	[GenerateShapeFor<SimpleStreamingContainerKeyed[]>]
 	private partial class Witness;
 

--- a/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
@@ -127,7 +127,7 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 #if NET
 		where TProvider : IShapeable<T> => this.GetEqualityComparer(TProvider.GetTypeShape());
 #else
-		=> this.GetEqualityComparer(MessagePackSerializerTestBase.GetTypeShape<T, TProvider>());
+		=> this.GetEqualityComparer(TypeShapeResolver.ResolveDynamicOrThrow<T, TProvider>());
 #endif
 
 	protected IEqualityComparer<T> GetEqualityComparer<T>()
@@ -144,7 +144,7 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 #if NET
 		where T : notnull, IShapeable<T> => this.AssertEqualityComparerBehavior<T, T>(equivalent, different);
 #else
-		where T : notnull => this.AssertEqualityComparerBehavior<T, Witness>(equivalent, different);
+		where T : notnull => this.AssertEqualityComparerBehavior<T, T>(equivalent, different);
 #endif
 
 	/// <summary>


### PR DESCRIPTION
* Avoid taking any dependencies on polytype's source generator details
* Remove some helpers from test projects that are no longer necessary
