### PR TITLE
Add `ValidationProblemDetails` serialization to sample `Witness` class

### DIFF
--- a/samples/AspNetMvc/Program.cs
+++ b/samples/AspNetMvc/Program.cs
@@ -35,6 +35,7 @@ void ConfigureServices(IServiceCollection services)
 // Generate shapes for types commonly used in communicating errors in ASP.NET Core MVC.
 [GenerateShapeFor<ProblemDetails>]
 [GenerateShapeFor<SerializableError>]
+[GenerateShapeFor<ValidationProblemDetails>]
 [GenerateShapeFor<string[]>]
 partial class Witness;
 #endregion


### PR DESCRIPTION
there's always a new surprise with asp :)

it caused problems when a validation attribute failed

```cs
    [SocialId]
    public string SocialId { get; set; } = null!;
```

where SocialId is

```cs
[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
public class SocialIdAttribute() : ValidationAttribute
```