### PR TITLE
Harden input parsing and fix other correctness issues

### DIFF
--- a/src/Nerdbank.MessagePack.SignalR/MessagePackHubProtocol.Reader.cs
+++ b/src/Nerdbank.MessagePack.SignalR/MessagePackHubProtocol.Reader.cs
@@ -11,6 +11,8 @@ namespace Nerdbank.MessagePack.SignalR;
 /// <content>Contains the deserialize methods of the class.</content>
 internal partial class MessagePackHubProtocol
 {
+	private static readonly SerializationContext EnvelopeSkipContext = new();
+
 	private static T ApplyHeaders<T>(IDictionary<string, string>? source, T destination)
 		where T : HubInvocationMessage
 	{
@@ -26,7 +28,7 @@ internal partial class MessagePackHubProtocol
 	{
 		for (int i = expected; i < actual; i++)
 		{
-			reader.Skip(default);
+			reader.Skip(EnvelopeSkipContext);
 		}
 	}
 
@@ -203,7 +205,7 @@ internal partial class MessagePackHubProtocol
 		MessagePackReader peekReader = reader.CreatePeekReader();
 		if (ReadMapLength(ref peekReader, "headers") == 0)
 		{
-			reader.Skip(default);
+			reader.Skip(EnvelopeSkipContext);
 			return null;
 		}
 
@@ -215,7 +217,7 @@ internal partial class MessagePackHubProtocol
 		MessagePackReader peekReader = reader.CreatePeekReader();
 		if (ReadArrayLength(ref peekReader, "streamIds") == 0)
 		{
-			reader.Skip(default);
+			reader.Skip(EnvelopeSkipContext);
 			return null;
 		}
 
@@ -253,7 +255,7 @@ internal partial class MessagePackHubProtocol
 			}
 			else
 			{
-				reader.Skip(default);
+				reader.Skip(EnvelopeSkipContext);
 			}
 		}
 
@@ -429,13 +431,13 @@ internal partial class MessagePackHubProtocol
 				Type? itemType = TryGetReturnType(binder, invocationId);
 				if (itemType is null)
 				{
-					reader.Skip(default);
+					reader.Skip(EnvelopeSkipContext);
 				}
 				else
 				{
 					if (itemType == typeof(RawResult))
 					{
-						result = new RawResult(reader.ReadRaw(default(SerializationContext)));
+						result = new RawResult(reader.ReadRaw(EnvelopeSkipContext));
 					}
 					else
 					{

--- a/src/Nerdbank.MessagePack.SignalR/MessagePackHubProtocol.Reader.cs
+++ b/src/Nerdbank.MessagePack.SignalR/MessagePackHubProtocol.Reader.cs
@@ -390,7 +390,7 @@ internal partial class MessagePackHubProtocol
 			return new StreamBindingFailureMessage(invocationId, ExceptionDispatchInfo.Capture(ex));
 		}
 
-		SkipTheRest(ref reader, 5, itemCount);
+		SkipTheRest(ref reader, 3, itemCount);
 		return ApplyHeaders(headers, new StreamItemMessage(invocationId, value));
 	}
 

--- a/src/Nerdbank.MessagePack/Converters/ArrayConverterUtilities.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayConverterUtilities.cs
@@ -40,4 +40,40 @@ internal static class ArrayConverterUtilities
 
 		return actual;
 	}
+
+	/// <summary>
+	/// Reads the flat element array header and verifies that its length matches the product of the declared dimensions.
+	/// </summary>
+	/// <param name="reader">The reader.</param>
+	/// <param name="dimensions">The lengths of each dimension.</param>
+	/// <returns>The expected element count.</returns>
+	/// <exception cref="MessagePackSerializationException">Thrown if the dimensions or flat element array length are invalid.</exception>
+	internal static int ReadFlattenedElementCount(ref MessagePackReader reader, scoped ReadOnlySpan<int> dimensions)
+	{
+		long expected = 1;
+		try
+		{
+			foreach (int dimension in dimensions)
+			{
+				if (dimension < 0)
+				{
+					throw new MessagePackSerializationException("Array dimensions may not be negative.");
+				}
+
+				expected = checked(expected * dimension);
+			}
+		}
+		catch (OverflowException ex)
+		{
+			throw new MessagePackSerializationException("Array dimensions are too large.", ex);
+		}
+
+		int actual = reader.ReadArrayHeader();
+		if (expected != actual)
+		{
+			throw new MessagePackSerializationException($"Expected {expected} elements but found {actual}.");
+		}
+
+		return actual;
+	}
 }

--- a/src/Nerdbank.MessagePack/Converters/ArrayConverterUtilities.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayConverterUtilities.cs
@@ -24,6 +24,41 @@ internal static class ArrayConverterUtilities
 	}
 
 	/// <summary>
+	/// Verifies that the declared dimensions can fit in the available msgpack bytes.
+	/// </summary>
+	/// <param name="reader">The reader. This is <em>not</em> a <see langword="ref" /> so as to not impact the caller's read position.</param>
+	/// <param name="dimensions">The lengths of each dimension.</param>
+	/// <exception cref="MessagePackSerializationException">Thrown if the dimensions are invalid or cannot fit in the remaining bytes.</exception>
+#pragma warning disable NBMsgPack050 // use "ref MessagePackReader" for parameter type
+	internal static void VerifyNestedDimensionsFitInBuffer(MessagePackReader reader, scoped ReadOnlySpan<int> dimensions)
+#pragma warning restore NBMsgPack050 // use "ref MessagePackReader" for parameter type
+	{
+		long expected = 1;
+		try
+		{
+			foreach (int dimension in dimensions)
+			{
+				if (dimension < 0)
+				{
+					throw new MessagePackSerializationException("Array dimensions may not be negative.");
+				}
+
+				expected = checked(expected * dimension);
+			}
+		}
+		catch (OverflowException ex)
+		{
+			throw new MessagePackSerializationException("Array dimensions are too large.", ex);
+		}
+
+		long remainingBytes = reader.Sequence.Slice(reader.Position).Length;
+		if (expected > remainingBytes)
+		{
+			throw new MessagePackSerializationException($"Array dimensions require {expected} elements but only {remainingBytes} bytes remain.");
+		}
+	}
+
+	/// <summary>
 	/// Reads an array header and verifies that its length matches the expected length.
 	/// </summary>
 	/// <param name="reader">The reader.</param>

--- a/src/Nerdbank.MessagePack/Converters/ArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayConverter`1.cs
@@ -153,21 +153,26 @@ internal class ArrayConverter<TElement>(MessagePackConverter<TElement> elementCo
 			}
 
 			reader.ReturnReader(ref streamingReader);
-			TElement[] array = new TElement[count];
+			TElement[] elements = ArrayPool<TElement>.Shared.Rent(PolyTypeExtensions.GetStreamingCollectionInitialCapacity(count));
 			int i = 0;
 			try
 			{
 				for (; i < count; i++)
 				{
-					array[i] = (await elementConverter.ReadAsync(reader, context).ConfigureAwait(false))!;
+					elements = PolyTypeExtensions.EnsurePooledBufferSize(elements, i, i + 1, count);
+					elements[i] = (await elementConverter.ReadAsync(reader, context).ConfigureAwait(false))!;
 				}
+
+				return elements.AsSpan(0, count).ToArray();
 			}
 			catch (Exception ex) when (ShouldWrapSerializationException(ex, context.CancellationToken))
 			{
 				throw new MessagePackSerializationException(CreateFailReadingValueAtIndex(typeof(TElement), i), ex);
 			}
-
-			return array;
+			finally
+			{
+				ArrayPool<TElement>.Shared.Return(elements);
+			}
 		}
 		else
 		{

--- a/src/Nerdbank.MessagePack/Converters/ArrayRank2FlattenedConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayRank2FlattenedConverter`1.cs
@@ -44,10 +44,11 @@ internal class ArrayRank2FlattenedConverter<TElement>(MessagePackConverter<TElem
 			dimensionLengths[i] = reader.ReadInt32();
 		}
 
+		ArrayConverterUtilities.ReadFlattenedElementCount(ref reader, dimensionLengths);
+
 		// Now read in the data itself.
 		var result = new TElement[dimensionLengths[0], dimensionLengths[1]];
 
-		ArrayConverterUtilities.ReadArrayHeader(ref reader, dimensionLengths[0] * dimensionLengths[1]);
 		for (int i = 0; i < dimensionLengths[0]; i++)
 		{
 			for (int j = 0; j < dimensionLengths[1]; j++)

--- a/src/Nerdbank.MessagePack/Converters/ArrayRank2NestedConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayRank2NestedConverter`1.cs
@@ -34,6 +34,7 @@ internal class ArrayRank2NestedConverter<TElement>(MessagePackConverter<TElement
 
 		Span<int> dimensionLengths = stackalloc int[Rank];
 		ArrayConverterUtilities.PeekNestedDimensionsLength(reader, dimensionLengths);
+		ArrayConverterUtilities.VerifyNestedDimensionsFitInBuffer(reader, dimensionLengths);
 		var result = new TElement[dimensionLengths[0], dimensionLengths[1]];
 
 		int length0 = ArrayConverterUtilities.ReadArrayHeader(ref reader, dimensionLengths[0]);

--- a/src/Nerdbank.MessagePack/Converters/ArrayRank3FlattenedConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayRank3FlattenedConverter`1.cs
@@ -44,10 +44,11 @@ internal class ArrayRank3FlattenedConverter<TElement>(MessagePackConverter<TElem
 			dimensionLengths[i] = reader.ReadInt32();
 		}
 
+		ArrayConverterUtilities.ReadFlattenedElementCount(ref reader, dimensionLengths);
+
 		// Now read in the data itself.
 		var result = new TElement[dimensionLengths[0], dimensionLengths[1], dimensionLengths[2]];
 
-		ArrayConverterUtilities.ReadArrayHeader(ref reader, dimensionLengths[0] * dimensionLengths[1] * dimensionLengths[2]);
 		for (int i = 0; i < dimensionLengths[0]; i++)
 		{
 			for (int j = 0; j < dimensionLengths[1]; j++)

--- a/src/Nerdbank.MessagePack/Converters/ArrayRank3NestedConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayRank3NestedConverter`1.cs
@@ -34,6 +34,7 @@ internal class ArrayRank3NestedConverter<TElement>(MessagePackConverter<TElement
 
 		Span<int> dimensionLengths = stackalloc int[Rank];
 		ArrayConverterUtilities.PeekNestedDimensionsLength(reader, dimensionLengths);
+		ArrayConverterUtilities.VerifyNestedDimensionsFitInBuffer(reader, dimensionLengths);
 		var result = new TElement[dimensionLengths[0], dimensionLengths[1], dimensionLengths[2]];
 
 		int length0 = ArrayConverterUtilities.ReadArrayHeader(ref reader, dimensionLengths[0]);

--- a/src/Nerdbank.MessagePack/Converters/ArrayWithFlattenedDimensionsConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayWithFlattenedDimensionsConverter`2.cs
@@ -48,13 +48,9 @@ internal class ArrayWithFlattenedDimensionsConverter<TArray, TElement>(MessagePa
 			dimensions[i] = reader.ReadInt32();
 		}
 
+		ArrayConverterUtilities.ReadFlattenedElementCount(ref reader, dimensions.AsSpan(0, rank));
 		Array array = Array.CreateInstance(typeof(TElement), dimensions);
 		Span<TElement> elements = AsSpan(array);
-		int elementCount = reader.ReadArrayHeader();
-		if (elementCount != elements.Length)
-		{
-			throw new MessagePackSerializationException($"Expected {elements.Length} elements but found {elementCount}.");
-		}
 
 		for (int i = 0; i < elements.Length; i++)
 		{

--- a/src/Nerdbank.MessagePack/Converters/ArrayWithFlattenedDimensionsConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayWithFlattenedDimensionsConverter`2.cs
@@ -41,7 +41,13 @@ internal class ArrayWithFlattenedDimensionsConverter<TArray, TElement>(MessagePa
 			throw new MessagePackSerializationException($"Expected array length of 2 but was {outerCount}.");
 		}
 
-		int rank = reader.ReadArrayHeader();
+		int rank = typeof(TArray).GetArrayRank();
+		int serializedRank = reader.ReadArrayHeader();
+		if (serializedRank != rank)
+		{
+			throw new MessagePackSerializationException($"Expected array rank of {rank} but was {serializedRank}.");
+		}
+
 		int[] dimensions = dimensionsReusable ??= new int[rank];
 		for (int i = 0; i < rank; i++)
 		{

--- a/src/Nerdbank.MessagePack/Converters/ArrayWithNestedDimensionsConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ArrayWithNestedDimensionsConverter`2.cs
@@ -45,6 +45,7 @@ internal class ArrayWithNestedDimensionsConverter<TArray, TElement>(MessagePackC
 
 		int[] dimensions = dimensionsReusable ??= new int[rank];
 		ArrayConverterUtilities.PeekNestedDimensionsLength(reader, dimensions);
+		ArrayConverterUtilities.VerifyNestedDimensionsFitInBuffer(reader, dimensions.AsSpan(0, rank));
 		Array array = Array.CreateInstance(typeof(TElement), dimensions);
 		Span<TElement> elements = AsSpan(array);
 		this.ReadSubArray(ref reader, dimensions, elements, context);

--- a/src/Nerdbank.MessagePack/Converters/DictionaryConverter`3.cs
+++ b/src/Nerdbank.MessagePack/Converters/DictionaryConverter`3.cs
@@ -434,7 +434,7 @@ internal class MutableDictionaryConverter<TDictionary, TKey, TValue>(
 				streamingReader = new(await streamingReader.FetchMoreBytesAsync().ConfigureAwait(false));
 			}
 
-			collection = getCollection(state, count);
+			collection = getCollection(state, PolyTypeExtensions.GetStreamingCollectionInitialCapacity(count));
 			reader.ReturnReader(ref streamingReader);
 			for (int i = 0; i < count; i++)
 			{
@@ -540,11 +540,12 @@ internal class ImmutableDictionaryConverter<TDictionary, TKey, TValue>(
 
 		reader.ReturnReader(ref streamingReader);
 
-		KeyValuePair<TKey, TValue>[] entries = ArrayPool<KeyValuePair<TKey, TValue>>.Shared.Rent(count);
+		KeyValuePair<TKey, TValue>[] entries = ArrayPool<KeyValuePair<TKey, TValue>>.Shared.Rent(PolyTypeExtensions.GetStreamingCollectionInitialCapacity(count));
 		try
 		{
 			for (int i = 0; i < count; i++)
 			{
+				entries = PolyTypeExtensions.EnsurePooledBufferSize(entries, i, i + 1, count);
 				entries[i] = await this.ReadEntryAsync(reader, context).ConfigureAwait(false);
 			}
 

--- a/src/Nerdbank.MessagePack/Converters/EnumerableConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/EnumerableConverter`2.cs
@@ -363,7 +363,7 @@ internal class MutableEnumerableConverter<TEnumerable, TElement>(
 
 			reader.ReturnReader(ref streamingReader);
 
-			collection = getCollection(state, count);
+			collection = getCollection(state, PolyTypeExtensions.GetStreamingCollectionInitialCapacity(count));
 			int i = 0;
 			try
 			{
@@ -478,12 +478,13 @@ internal class SpanEnumerableConverter<TEnumerable, TElement>(
 			}
 
 			reader.ReturnReader(ref streamingReader);
-			TElement[] elements = ArrayPool<TElement>.Shared.Rent(count);
+			TElement[] elements = ArrayPool<TElement>.Shared.Rent(PolyTypeExtensions.GetStreamingCollectionInitialCapacity(count));
 			int? i = 0;
 			try
 			{
 				for (; i < count; i++)
 				{
+					elements = PolyTypeExtensions.EnsurePooledBufferSize(elements, i.Value, i.Value + 1, count);
 					elements[i.Value] = await this.ReadElementAsync(reader, context).ConfigureAwait(false);
 				}
 

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
@@ -67,7 +67,7 @@ internal class ObjectArrayConverter<T>(
 			for (int i = 0; i < count; i++)
 			{
 				int index = reader.ReadInt32();
-				if (properties.Length > index && properties.Span[index] is { MsgPackReaders: var (deserialize, _), Shape.Position: int propertyShapePosition })
+				if (index >= 0 && index < properties.Length && properties.Span[index] is { MsgPackReaders: var (deserialize, _), Shape.Position: int propertyShapePosition })
 				{
 					collisionDetection.MarkAsRead(propertyShapePosition);
 					deserialize(ref value, ref reader, context);
@@ -469,7 +469,7 @@ internal class ObjectArrayConverter<T>(
 				for (int i = 0; i < bufferedEntries; i++)
 				{
 					int propertyIndex = syncReader.ReadInt32();
-					if (propertyIndex < properties.Length && properties.Span[propertyIndex] is { MsgPackReaders: { Deserialize: { } deserialize }, Shape.Position: int shapePosition })
+					if (propertyIndex >= 0 && propertyIndex < properties.Length && properties.Span[propertyIndex] is { MsgPackReaders: { Deserialize: { } deserialize }, Shape.Position: int shapePosition })
 					{
 						collisionDetection.MarkAsRead(shapePosition);
 						deserialize(ref value, ref syncReader, context);
@@ -495,7 +495,7 @@ internal class ObjectArrayConverter<T>(
 					{
 						// The property name has already been buffered.
 						int propertyIndex = syncReader.ReadInt32();
-						if (propertyIndex < properties.Length && properties.Span[propertyIndex] is { PreferAsyncSerialization: true, MsgPackReaders: { } propertyReader, Shape.Position: int shapePosition })
+						if (propertyIndex >= 0 && propertyIndex < properties.Length && properties.Span[propertyIndex] is { PreferAsyncSerialization: true, MsgPackReaders: { } propertyReader, Shape.Position: int shapePosition })
 						{
 							collisionDetection.MarkAsRead(shapePosition);
 

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayWithNonDefaultCtorConverter`2.cs
@@ -47,7 +47,7 @@ internal class ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentS
 			for (int i = 0; i < count; i++)
 			{
 				int index = reader.ReadInt32();
-				if (properties.Length > index && parameters[index] is { } deserialize)
+				if (index >= 0 && index < properties.Length && parameters[index] is { } deserialize)
 				{
 					deserialize.Read(ref argState, ref reader, context);
 				}
@@ -147,7 +147,7 @@ internal class ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentS
 				for (int i = 0; i < bufferedEntries; i++)
 				{
 					int propertyIndex = syncReader.ReadInt32();
-					if (propertyIndex < parameters.Length && parameters[propertyIndex] is { Read: { } deserialize })
+					if (propertyIndex >= 0 && propertyIndex < parameters.Length && parameters[propertyIndex] is { Read: { } deserialize })
 					{
 						deserialize(ref argState, ref syncReader, context);
 					}
@@ -172,7 +172,7 @@ internal class ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentS
 					{
 						// The property name has already been buffered.
 						int propertyIndex = syncReader.ReadInt32();
-						if (propertyIndex < parameters.Length && parameters[propertyIndex] is { PreferAsyncSerialization: true, ReadAsync: { } deserializeAsync })
+						if (propertyIndex >= 0 && propertyIndex < parameters.Length && parameters[propertyIndex] is { PreferAsyncSerialization: true, ReadAsync: { } deserializeAsync })
 						{
 							// The next property value is async, so turn in our sync reader and read it asynchronously.
 							reader.ReturnReader(ref syncReader);

--- a/src/Nerdbank.MessagePack/Converters/PolyTypeExtensions.cs
+++ b/src/Nerdbank.MessagePack/Converters/PolyTypeExtensions.cs
@@ -9,6 +9,42 @@ namespace Nerdbank.MessagePack.Converters;
 internal static class PolyTypeExtensions
 {
 	/// <summary>
+	/// The maximum collection capacity to allocate before reading elements from a streaming source.
+	/// </summary>
+	internal const int MaxStreamingCollectionPreallocation = 4096;
+
+	/// <summary>
+	/// Gets the initial capacity to allocate before reading elements from a streaming source.
+	/// </summary>
+	/// <param name="count">The element count declared by the messagepack header.</param>
+	/// <returns>A capacity that does not exceed <see cref="MaxStreamingCollectionPreallocation" />.</returns>
+	internal static int GetStreamingCollectionInitialCapacity(int count) => Math.Min(count, MaxStreamingCollectionPreallocation);
+
+	/// <summary>
+	/// Ensures a pooled buffer can store the required number of elements.
+	/// </summary>
+	/// <typeparam name="T">The element type.</typeparam>
+	/// <param name="buffer">The buffer to grow, if required.</param>
+	/// <param name="initializedLength">The number of elements in <paramref name="buffer" /> that have been initialized.</param>
+	/// <param name="requiredLength">The minimum length required.</param>
+	/// <param name="maxLength">The maximum useful length.</param>
+	/// <returns>A buffer with at least <paramref name="requiredLength" /> elements.</returns>
+	internal static T[] EnsurePooledBufferSize<T>(T[] buffer, int initializedLength, int requiredLength, int maxLength)
+	{
+		if (buffer.Length >= requiredLength)
+		{
+			return buffer;
+		}
+
+		int doubledLength = buffer.Length <= maxLength / 2 ? buffer.Length * 2 : maxLength;
+		int newLength = Math.Max(requiredLength, doubledLength);
+		T[] newBuffer = ArrayPool<T>.Shared.Rent(newLength);
+		buffer.AsSpan(0, initializedLength).CopyTo(newBuffer);
+		ArrayPool<T>.Shared.Return(buffer);
+		return newBuffer;
+	}
+
+	/// <summary>
 	/// Creates a copy of the specified <see cref="CollectionConstructionOptions{TKey}"/> with a new capacity.
 	/// </summary>
 	/// <typeparam name="TKey">The key used in comparers.</typeparam>

--- a/src/Nerdbank.MessagePack/MessagePackPrimitives.Readers.cs
+++ b/src/Nerdbank.MessagePack/MessagePackPrimitives.Readers.cs
@@ -367,13 +367,19 @@ partial class MessagePackPrimitives
 	/// <returns>The result classification of the read operation.</returns>
 	public static DecodeResult TryRead(ReadOnlySpan<byte> source, ExtensionHeader header, out DateTime value, out int tokenSize)
 	{
-		tokenSize = checked((int)header.Length);
 		if (header.TypeCode != ReservedMessagePackExtensionTypeCode.DateTime)
 		{
 			value = default;
+			tokenSize = 0;
 			return DecodeResult.TokenMismatch;
 		}
 
+		if (header.Length is not (4 or 8 or 12))
+		{
+			throw new MessagePackSerializationException($"Invalid timestamp extension length: {header.Length}");
+		}
+
+		tokenSize = unchecked((int)header.Length);
 		if (source.Length < tokenSize)
 		{
 			value = default;

--- a/src/Nerdbank.MessagePack/MessagePackReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackReader.cs
@@ -275,7 +275,7 @@ public ref partial struct MessagePackReader
 		// Protect against corrupted or mischievous data that may lead to allocating way too much memory.
 		// We allow for each primitive to be the minimal 1 byte in size, and we have a key=value map, so that's 2 bytes.
 		// Formatters that know each element is larger can optionally add a stronger check.
-		ThrowInsufficientBufferUnless(this.streamingReader.SequenceReader.Remaining >= count * 2);
+		ThrowInsufficientBufferUnless(this.streamingReader.SequenceReader.Remaining >= (long)count * 2);
 
 		return count;
 	}

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -536,10 +536,17 @@ public partial record MessagePackSerializer
 	{
 		Requires.NotNull(jsonWriter);
 
-		WriteOneElement(ref reader, jsonWriter, options ?? new(), this.LibraryExtensionTypeCodes, 0);
+		SerializationContext context = this.StartingContext with { ExtensionTypeCodes = this.LibraryExtensionTypeCodes };
+		WriteOneElement(ref reader, jsonWriter, options ?? new(), context, 0);
 
-		static void WriteOneElement(ref MessagePackReader reader, TextWriter jsonWriter, JsonOptions options, LibraryReservedMessagePackExtensionTypeCode extensionTypeCodes, int indentationLevel)
+		static void WriteOneElement(ref MessagePackReader reader, TextWriter jsonWriter, JsonOptions options, SerializationContext context, int indentationLevel)
 		{
+			context.CancellationToken.ThrowIfCancellationRequested();
+			if (indentationLevel > context.MaxDepth)
+			{
+				throw new MessagePackSerializationException("Exceeded maximum depth of object graph.");
+			}
+
 			switch (reader.NextMessagePackType)
 			{
 				case MessagePackType.Nil:
@@ -591,7 +598,7 @@ public partial record MessagePackSerializer
 								NewLine(jsonWriter, options, indentationLevel + 1);
 							}
 
-							WriteOneElement(ref reader, jsonWriter, options, extensionTypeCodes, indentationLevel + 1);
+							WriteOneElement(ref reader, jsonWriter, options, context, indentationLevel + 1);
 						}
 
 						if (options.TrailingCommas && options.Indentation is not null && count > 0)
@@ -618,7 +625,7 @@ public partial record MessagePackSerializer
 								NewLine(jsonWriter, options, indentationLevel + 1);
 							}
 
-							WriteOneElement(ref reader, jsonWriter, options, extensionTypeCodes, indentationLevel + 1);
+							WriteOneElement(ref reader, jsonWriter, options, context, indentationLevel + 1);
 							if (options.Indentation is null)
 							{
 								jsonWriter.Write(':');
@@ -628,7 +635,7 @@ public partial record MessagePackSerializer
 								jsonWriter.Write(": ");
 							}
 
-							WriteOneElement(ref reader, jsonWriter, options, extensionTypeCodes, indentationLevel + 1);
+							WriteOneElement(ref reader, jsonWriter, options, context, indentationLevel + 1);
 						}
 
 						if (options.TrailingCommas && options.Indentation is not null && count > 0)
@@ -647,12 +654,11 @@ public partial record MessagePackSerializer
 					jsonWriter.Write('\"');
 					break;
 				case MessagePackType.Extension:
-					SerializationContext context = new() { ExtensionTypeCodes = extensionTypeCodes };
 					MessagePackReader peek = reader.CreatePeekReader();
 					ExtensionHeader extensionHeader = peek.ReadExtensionHeader();
 					if (!options.IgnoreKnownExtensions)
 					{
-						if (extensionHeader.TypeCode == extensionTypeCodes.Guid)
+						if (extensionHeader.TypeCode == context.ExtensionTypeCodes.Guid)
 						{
 							jsonWriter.Write('\"');
 							jsonWriter.Write(GuidAsBinaryConverter.Instance.Read(ref reader, context).ToString("D"));
@@ -660,26 +666,26 @@ public partial record MessagePackSerializer
 							break;
 						}
 
-						if (extensionHeader.TypeCode == extensionTypeCodes.BigInteger)
+						if (extensionHeader.TypeCode == context.ExtensionTypeCodes.BigInteger)
 						{
 							jsonWriter.Write(BigIntegerConverter.Instance.Read(ref reader, context).ToString());
 							break;
 						}
 
-						if (extensionHeader.TypeCode == extensionTypeCodes.Decimal)
+						if (extensionHeader.TypeCode == context.ExtensionTypeCodes.Decimal)
 						{
 							jsonWriter.Write(MessagePack.Converters.DecimalConverter.Instance.Read(ref reader, context).ToString(CultureInfo.InvariantCulture));
 							break;
 						}
 
 #if NET
-						if (extensionHeader.TypeCode == extensionTypeCodes.Int128)
+						if (extensionHeader.TypeCode == context.ExtensionTypeCodes.Int128)
 						{
 							jsonWriter.Write(MessagePack.Converters.Int128Converter.Instance.Read(ref reader, context).ToString(CultureInfo.InvariantCulture));
 							break;
 						}
 
-						if (extensionHeader.TypeCode == extensionTypeCodes.UInt128)
+						if (extensionHeader.TypeCode == context.ExtensionTypeCodes.UInt128)
 						{
 							jsonWriter.Write(MessagePack.Converters.UInt128Converter.Instance.Read(ref reader, context).ToString(CultureInfo.InvariantCulture));
 							break;

--- a/src/Nerdbank.MessagePack/MessagePackStreamingReader.cs
+++ b/src/Nerdbank.MessagePack/MessagePackStreamingReader.cs
@@ -1146,8 +1146,10 @@ public ref partial struct MessagePackStreamingReader
 				}
 			}
 #endif
-			this.Advance(bytesRead);
+			this.Advance(bytesRead, consumed: 0);
 		}
+
+		this.Advance(0);
 
 		value = new string(charArray, 0, initializedChars);
 		ArrayPool<char>.Shared.Return(charArray);

--- a/src/Nerdbank.MessagePack/SecureHash/CollisionResistantHasherLookup.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/CollisionResistantHasherLookup.cs
@@ -37,7 +37,7 @@ internal static class CollisionResistantHasherLookup
 	private static IEqualityComparer? _HashCollisionResistantPrimitives_StringEqualityComparer;
 	private static IEqualityComparer? _HashCollisionResistantPrimitives_BooleanEqualityComparer;
 	private static IEqualityComparer? _HashCollisionResistantPrimitives_VersionEqualityComparer;
-	private static IEqualityComparer? _HashCollisionResistantPrimitives_AlreadySecureEqualityComparer_Uri_;
+	private static IEqualityComparer? _HashCollisionResistantPrimitives_UriEqualityComparer;
 	private static IEqualityComparer? _HashCollisionResistantPrimitives_SingleEqualityComparer;
 	private static IEqualityComparer? _HashCollisionResistantPrimitives_DoubleEqualityComparer;
 	private static IEqualityComparer? _HashCollisionResistantPrimitives_DecimalEqualityComparer;
@@ -142,7 +142,7 @@ internal static class CollisionResistantHasherLookup
 
 		if (typeof(T) == typeof(Uri))
 		{
-			converter = (SecureEqualityComparer<T>)(_HashCollisionResistantPrimitives_AlreadySecureEqualityComparer_Uri_ ??= new HashCollisionResistantPrimitives.AlreadySecureEqualityComparer<Uri>());
+			converter = (SecureEqualityComparer<T>)(_HashCollisionResistantPrimitives_UriEqualityComparer ??= new HashCollisionResistantPrimitives.UriEqualityComparer());
 			return true;
 		}
 

--- a/src/Nerdbank.MessagePack/SecureHash/CollisionResistantHasherLookup.tt
+++ b/src/Nerdbank.MessagePack/SecureHash/CollisionResistantHasherLookup.tt
@@ -31,7 +31,7 @@ var convertersByType = new List<ConverterInfo>
 	new ConverterInfo("string", "HashCollisionResistantPrimitives.StringEqualityComparer"),
 	new ConverterInfo("bool", "HashCollisionResistantPrimitives.BooleanEqualityComparer"),
 	new ConverterInfo("Version", "HashCollisionResistantPrimitives.VersionEqualityComparer"),
-	new ConverterInfo("Uri", "HashCollisionResistantPrimitives.AlreadySecureEqualityComparer<Uri>"),
+	new ConverterInfo("Uri", "HashCollisionResistantPrimitives.UriEqualityComparer"),
 	new ConverterInfo("float", "HashCollisionResistantPrimitives.SingleEqualityComparer"),
 	new ConverterInfo("double", "HashCollisionResistantPrimitives.DoubleEqualityComparer"),
 	new ConverterInfo("decimal", "HashCollisionResistantPrimitives.DecimalEqualityComparer"),

--- a/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
@@ -9,7 +9,6 @@
 #endif
 
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using Microsoft;
@@ -158,6 +157,10 @@ internal static class HashCollisionResistantPrimitives
 
 	internal class DecimalEqualityComparer : SecureEqualityComparer<decimal>
 	{
+		private const int DecimalSignMask = unchecked((int)0x80000000);
+		private const int DecimalScaleMask = 0x00FF0000;
+		private const int DecimalScaleShift = 16;
+
 		/// <inheritdoc/>
 		public override bool Equals(decimal x, decimal y) => x.Equals(y);
 
@@ -165,16 +168,64 @@ internal static class HashCollisionResistantPrimitives
 		public override long GetSecureHashCode([DisallowNull] decimal obj)
 		{
 #if NET
-			Span<int> bytes = stackalloc int[500];
+			Span<int> bytes = stackalloc int[4];
 			if (!decimal.TryGetBits(obj, bytes, out int length))
 			{
 				throw new NotSupportedException("Decimal too long.");
 			}
 
+			NormalizeBits(bytes);
 			return SecureHash(MemoryMarshal.Cast<int, byte>(bytes[..length]));
 #else
-			return StringEqualityComparer.Instance.GetSecureHashCode(obj.ToString(CultureInfo.InvariantCulture));
+			int[] bytes = decimal.GetBits(obj);
+			NormalizeBits(bytes);
+			return SecureHash(MemoryMarshal.Cast<int, byte>(bytes.AsSpan()));
 #endif
+		}
+
+		private static void NormalizeBits(Span<int> bits)
+		{
+			int flags = bits[3];
+			int scale = (flags & DecimalScaleMask) >> DecimalScaleShift;
+			if ((bits[0] | bits[1] | bits[2]) == 0)
+			{
+				bits[3] = 0;
+				return;
+			}
+
+			while (scale > 0 && TryDivideBitsBy10(bits))
+			{
+				scale--;
+			}
+
+			bits[3] = (flags & DecimalSignMask) | (scale << DecimalScaleShift);
+		}
+
+		private static bool TryDivideBitsBy10(Span<int> bits)
+		{
+			ulong remainder = 0;
+
+			ulong high = (uint)bits[2];
+			ulong quotientHigh = high / 10;
+			remainder = high % 10;
+
+			ulong middle = (remainder << 32) | (uint)bits[1];
+			ulong quotientMiddle = middle / 10;
+			remainder = middle % 10;
+
+			ulong low = (remainder << 32) | (uint)bits[0];
+			ulong quotientLow = low / 10;
+			remainder = low % 10;
+
+			if (remainder != 0)
+			{
+				return false;
+			}
+
+			bits[2] = (int)(uint)quotientHigh;
+			bits[1] = (int)(uint)quotientMiddle;
+			bits[0] = (int)(uint)quotientLow;
+			return true;
 		}
 	}
 

--- a/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
@@ -250,7 +250,20 @@ internal static class HashCollisionResistantPrimitives
 		{
 		}
 
-		public override bool Equals(byte[]? x, byte[]? y) => ReferenceEquals(x, y) || (x is null || y is null) ? false : x.SequenceEqual(y);
+		public override bool Equals(byte[]? x, byte[]? y)
+		{
+			if (ReferenceEquals(x, y))
+			{
+				return true;
+			}
+
+			if (x is null || y is null)
+			{
+				return false;
+			}
+
+			return x.SequenceEqual(y);
+		}
 
 		public override long GetSecureHashCode([DisallowNull] byte[] obj) => SecureHash(obj);
 	}

--- a/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
@@ -126,6 +126,8 @@ internal static class HashCollisionResistantPrimitives
 
 	internal class BigIntegerEqualityComparer : SecureEqualityComparer<BigInteger>
 	{
+		private const int MaxStackAllocBytes = 256;
+
 		/// <inheritdoc/>
 		public override bool Equals(BigInteger x, BigInteger y) => x.Equals(y);
 
@@ -133,9 +135,21 @@ internal static class HashCollisionResistantPrimitives
 		public override long GetSecureHashCode([DisallowNull] BigInteger obj)
 		{
 #if NET
-			Span<byte> bytes = stackalloc byte[obj.GetByteCount()];
-			Assumes.True(obj.TryWriteBytes(bytes, out _));
-			return SecureHash(bytes);
+			int byteCount = obj.GetByteCount();
+			byte[]? rented = byteCount > MaxStackAllocBytes ? ArrayPool<byte>.Shared.Rent(byteCount) : null;
+			Span<byte> bytes = rented is null ? stackalloc byte[byteCount] : rented.AsSpan(0, byteCount);
+			try
+			{
+				Assumes.True(obj.TryWriteBytes(bytes, out _));
+				return SecureHash(bytes);
+			}
+			finally
+			{
+				if (rented is not null)
+				{
+					ArrayPool<byte>.Shared.Return(rented);
+				}
+			}
 #else
 			return SecureHash(obj.ToByteArray());
 #endif

--- a/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
@@ -123,6 +123,15 @@ internal static class HashCollisionResistantPrimitives
 		public override long GetSecureHashCode([DisallowNull] T obj) => EqualityComparer<T>.Default.GetHashCode(obj);
 	}
 
+	internal class UriEqualityComparer : SecureEqualityComparer<Uri>
+	{
+		/// <inheritdoc/>
+		public override bool Equals(Uri? x, Uri? y) => EqualityComparer<Uri>.Default.Equals(x, y);
+
+		/// <inheritdoc/>
+		public override long GetSecureHashCode([DisallowNull] Uri obj) => StringEqualityComparer.Instance.GetSecureHashCode(obj.IsAbsoluteUri ? obj.AbsoluteUri : obj.OriginalString);
+	}
+
 	internal class BigIntegerEqualityComparer : SecureEqualityComparer<BigInteger>
 	{
 		private const int MaxStackAllocBytes = 256;

--- a/src/Nerdbank.MessagePack/SecureHash/SecureDictionaryEqualityComparer`3.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SecureDictionaryEqualityComparer`3.cs
@@ -57,15 +57,18 @@ internal class SecureDictionaryEqualityComparer<TDictionary, TKey, TValue>(
 	{
 		IReadOnlyDictionary<TKey, TValue> dict = getDictionary(obj);
 
-		// Ideally we could switch this to a SIP hash implementation that can process additional data in chunks with a constant amount of memory.
-		long[] hashes = new long[dict.Count * 2];
-		int index = 0;
+		long hash = 0;
+		Span<long> entryHashes = stackalloc long[2];
 		foreach (KeyValuePair<TKey, TValue> pair in dict)
 		{
-			hashes[index++] = pair.Key is null ? 0 : keyEqualityComparer.GetSecureHashCode(pair.Key);
-			hashes[index++] = pair.Value is null ? 0 : valueEqualityComparer.GetSecureHashCode(pair.Value);
+			entryHashes[0] = pair.Key is null ? 0 : keyEqualityComparer.GetSecureHashCode(pair.Key);
+			entryHashes[1] = pair.Value is null ? 0 : valueEqualityComparer.GetSecureHashCode(pair.Value);
+			hash ^= SipHash.Default.Compute(MemoryMarshal.Cast<long, byte>(entryHashes));
 		}
 
-		return SipHash.Default.Compute(MemoryMarshal.Cast<long, byte>(hashes));
+		Span<long> finalHashes = stackalloc long[2];
+		finalHashes[0] = dict.Count;
+		finalHashes[1] = hash;
+		return SipHash.Default.Compute(MemoryMarshal.Cast<long, byte>(finalHashes));
 	}
 }

--- a/test/Nerdbank.MessagePack.SignalR.Tests/SerializationTests.cs
+++ b/test/Nerdbank.MessagePack.SignalR.Tests/SerializationTests.cs
@@ -5,6 +5,7 @@ using Microsoft;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Nerdbank.MessagePack;
 using Nerdbank.MessagePack.SignalR;
+using Nerdbank.Streams;
 using PolyType;
 using Xunit;
 
@@ -220,6 +221,31 @@ public partial class SerializationTests
 	}
 
 	[Fact]
+	[Trait("CWE", "1188")]
+	public void CancelInvocationMessage_WithExtraNestedField_SkipsRemainingPayload()
+	{
+		IHubProtocol protocol = this.CreateProtocol();
+		Sequence<byte> payload = new();
+		MessagePackWriter writer = new(payload);
+		writer.WriteArrayHeader(4);
+		writer.Write(5); // CancelInvocationMessage
+		writer.WriteMapHeader(0);
+		writer.Write("201");
+		writer.WriteArrayHeader(1);
+		writer.WriteArrayHeader(1);
+		writer.Write("extra");
+		writer.Flush();
+
+		ReadOnlySequence<byte> serializedSequence = this.FrameHubMessage(payload);
+		this.LogMsgPack(serializedSequence);
+		Assert.True(protocol.TryParseMessage(ref serializedSequence, new MockInvocationBinder(), out HubMessage? message));
+		Assert.True(serializedSequence.IsEmpty);
+
+		CancelInvocationMessage cancelInvocation = Assert.IsType<CancelInvocationMessage>(message);
+		Assert.Equal("201", cancelInvocation.InvocationId);
+	}
+
+	[Fact]
 	public void AckMessage_Serialization()
 	{
 		IHubProtocol protocol = this.CreateProtocol();
@@ -261,6 +287,14 @@ public partial class SerializationTests
 	{
 		Assumes.True(BinaryMessageFormatter.TryParseMessage(ref payload, out ReadOnlySequence<byte> msgpack));
 		TestContext.Current.TestOutputHelper?.WriteLine(this.Serializer.ConvertToJson(msgpack));
+	}
+
+	private ReadOnlySequence<byte> FrameHubMessage(Sequence<byte> payload)
+	{
+		Sequence<byte> framedMessage = new();
+		BinaryMessageFormatter.WriteLengthPrefix(payload.Length, framedMessage);
+		framedMessage.Append(payload.AsReadOnlySequence.ToArray());
+		return framedMessage.AsReadOnlySequence;
 	}
 
 	private IHubProtocol CreateProtocol()

--- a/test/Nerdbank.MessagePack.SignalR.Tests/SerializationTests.cs
+++ b/test/Nerdbank.MessagePack.SignalR.Tests/SerializationTests.cs
@@ -130,6 +130,39 @@ public partial class SerializationTests
 	}
 
 	[Fact]
+	[Trait("CWE", "682")]
+	public void StreamItemMessage_WithExtraField_SkipsRemainingPayload()
+	{
+		IHubProtocol protocol = this.CreateProtocol();
+		Sequence<byte> payload = new();
+		MessagePackWriter writer = new(payload);
+		writer.WriteArrayHeader(5);
+		writer.Write(2); // StreamItemMessage
+		writer.WriteMapHeader(0);
+		writer.Write("789");
+		writer.Write("stream item data");
+		writer.Write("extra");
+		writer.Flush();
+
+		MockInvocationBinder binder = new()
+		{
+			StreamItemType =
+			{
+				["789"] = typeof(string),
+			},
+		};
+
+		ReadOnlySequence<byte> serializedSequence = this.FrameHubMessage(payload);
+		this.LogMsgPack(serializedSequence);
+		Assert.True(protocol.TryParseMessage(ref serializedSequence, binder, out HubMessage? message));
+		Assert.True(serializedSequence.IsEmpty);
+
+		StreamItemMessage streamItem = Assert.IsType<StreamItemMessage>(message);
+		Assert.Equal("789", streamItem.InvocationId);
+		Assert.Equal("stream item data", streamItem.Item);
+	}
+
+	[Fact]
 	public void CompletionMessage_WithResult_Serialization()
 	{
 		IHubProtocol protocol = this.CreateProtocol();

--- a/test/Nerdbank.MessagePack.Tests/AsyncSerializationTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/AsyncSerializationTests.cs
@@ -149,6 +149,40 @@ public partial class AsyncSerializationTests : MessagePackSerializerTestBase
 		Assert.Equal("a"u8, readResult.Buffer.ToArray());
 	}
 
+	[Fact]
+	[Trait("CWE", "770")]
+	public async Task AsyncEnumerableCapacityHintIsCapped()
+	{
+		CapacityTrackingPocoList.LastCapacity = -1;
+		using Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		writer.WriteArrayHeader(CapacityTrackingPocoList.MaxAcceptedCapacity + 1);
+		writer.Flush();
+
+		MessagePackSerializationException ex = await Assert.ThrowsAsync<MessagePackSerializationException>(
+			async () => await this.Serializer.DeserializeAsync<CapacityTrackingPocoList>(PipeReader.Create(sequence), TestContext.Current.CancellationToken));
+
+		this.Logger.WriteLine(ex.Message);
+		Assert.Equal(CapacityTrackingPocoList.MaxAcceptedCapacity, CapacityTrackingPocoList.LastCapacity);
+	}
+
+	[Fact]
+	[Trait("CWE", "770")]
+	public async Task AsyncDictionaryCapacityHintIsCapped()
+	{
+		CapacityTrackingPocoDictionary.LastCapacity = -1;
+		using Sequence<byte> sequence = new();
+		MessagePackWriter writer = new(sequence);
+		writer.WriteMapHeader(CapacityTrackingPocoDictionary.MaxAcceptedCapacity + 1);
+		writer.Flush();
+
+		MessagePackSerializationException ex = await Assert.ThrowsAsync<MessagePackSerializationException>(
+			async () => await this.Serializer.DeserializeAsync<CapacityTrackingPocoDictionary>(PipeReader.Create(sequence), TestContext.Current.CancellationToken));
+
+		this.Logger.WriteLine(ex.Message);
+		Assert.Equal(CapacityTrackingPocoDictionary.MaxAcceptedCapacity, CapacityTrackingPocoDictionary.LastCapacity);
+	}
+
 	[GenerateShapeFor<string>]
 	[GenerateShapeFor<int>]
 	private partial class Witness;
@@ -207,6 +241,36 @@ public partial class AsyncSerializationTests : MessagePackSerializerTestBase
 		public List<Poco>? Pocos => pocos;
 
 		public bool Equals(ListOfPocos? other) => other is not null && StructuralEquality.Equal(this.Pocos, other.Pocos);
+	}
+
+	[GenerateShape, TypeShape(Kind = TypeShapeKind.Enumerable)]
+	public partial class CapacityTrackingPocoList : List<Poco>
+	{
+		internal const int MaxAcceptedCapacity = 4096;
+
+		public CapacityTrackingPocoList(int capacity)
+			: base(capacity)
+		{
+			LastCapacity = capacity;
+			Assert.True(capacity <= MaxAcceptedCapacity);
+		}
+
+		internal static int LastCapacity { get; set; }
+	}
+
+	[GenerateShape, TypeShape(Kind = TypeShapeKind.Dictionary)]
+	public partial class CapacityTrackingPocoDictionary : Dictionary<string, Poco>
+	{
+		internal const int MaxAcceptedCapacity = 4096;
+
+		public CapacityTrackingPocoDictionary(int capacity)
+			: base(capacity)
+		{
+			LastCapacity = capacity;
+			Assert.True(capacity <= MaxAcceptedCapacity);
+		}
+
+		internal static int LastCapacity { get; set; }
 	}
 
 	[GenerateShape]

--- a/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
@@ -208,6 +208,27 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 	}
 
 	[Fact]
+	[Trait("CWE", "789")]
+	[Trait("CWE", "674")]
+	public void BigIntegerDictionaryKey_LargeBin()
+	{
+		const int KeyByteCount = 2 * 1024 * 1024;
+
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.WriteMapHeader(1);
+		writer.Write(Enumerable.Repeat((byte)1, KeyByteCount).ToArray());
+		writer.Write(3);
+		writer.Flush();
+
+		Dictionary<BigInteger, int> result = this.Serializer.Deserialize<Dictionary<BigInteger, int>, Witness>(seq, TestContext.Current.CancellationToken)!;
+
+		KeyValuePair<BigInteger, int> entry = Assert.Single(result);
+		Assert.Equal(KeyByteCount, entry.Key.ToByteArray().Length);
+		Assert.Equal(3, entry.Value);
+	}
+
+	[Fact]
 	public void Guid()
 	{
 		// Test that Guid serialization works by default (using binary format)
@@ -506,5 +527,6 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 	[GenerateShapeFor<CultureInfo>]
 	[GenerateShapeFor<EventArgs>]
 	[GenerateShapeFor<Encoding>]
+	[GenerateShapeFor<Dictionary<BigInteger, int>>]
 	private partial class Witness;
 }

--- a/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
@@ -383,6 +383,24 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 	}
 
 	[Fact]
+	[Trait("CWE", "789")]
+	public void DateTime_BadHeaderLength()
+	{
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.WriteMapHeader(1);
+		writer.Write(nameof(HasDateTime.Value));
+
+		// Allege that you're sending a very large DateTime extension that would blow the stack if allocated on it.
+		writer.Write(new ExtensionHeader(ReservedMessagePackExtensionTypeCode.DateTime, 0x800000));
+		writer.Flush();
+
+		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(
+			() => this.Serializer.Deserialize<HasDateTime>(seq, TestContext.Current.CancellationToken));
+		this.Logger.WriteLine(ex.Message);
+	}
+
+	[Fact]
 	public void DateTimeOffset()
 	{
 		this.AssertRoundtrip(new HasDateTimeOffset(System.DateTimeOffset.Now));

--- a/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ConvertToJsonTests.cs
@@ -25,6 +25,36 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 	public void Sequence() => Assert.Equal("null", this.Serializer.ConvertToJson(new([0xc0])));
 
 	[Fact]
+	[Trait("CWE", "674")]
+	public void StackGuard_Array()
+	{
+		byte[] payload = this.FormatNestedArrays(this.Serializer.StartingContext.MaxDepth + 1);
+
+		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => this.Serializer.ConvertToJson(payload));
+		this.Logger.WriteLine(ex.ToString());
+	}
+
+	[Fact]
+	[Trait("CWE", "674")]
+	public void StackGuard_Array_Streaming()
+	{
+		byte[] payload = this.FormatNestedArrays(this.Serializer.StartingContext.MaxDepth + 1);
+		using StringWriter jsonWriter = new();
+
+		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(() => this.ConvertPayloadToJson(payload, jsonWriter));
+		this.Logger.WriteLine(ex.ToString());
+	}
+
+	[Fact]
+	public void StackGuard_Array_WithinLimit()
+	{
+		int depth = this.Serializer.StartingContext.MaxDepth;
+		byte[] payload = this.FormatNestedArrays(depth);
+
+		Assert.Equal(new string('[', depth) + "null" + new string(']', depth), this.Serializer.ConvertToJson(payload));
+	}
+
+	[Fact]
 	public void Guid_LittleEndian()
 	{
 		Guid guid = Guid.NewGuid();
@@ -238,6 +268,14 @@ public partial class ConvertToJsonTests : MessagePackSerializerTestBase
 		MessagePackReader reader = new(sequence);
 		this.Serializer.ConvertToJson(ref reader, jsonWriter, options);
 		return jsonWriter.ToString();
+	}
+
+	private byte[] FormatNestedArrays(int depth) => Enumerable.Repeat((byte)0x91, depth).Append((byte)0xc0).ToArray();
+
+	private void ConvertPayloadToJson(byte[] payload, TextWriter jsonWriter)
+	{
+		MessagePackReader reader = new(payload);
+		this.Serializer.ConvertToJson(ref reader, jsonWriter);
 	}
 
 	[GenerateShape]

--- a/test/Nerdbank.MessagePack.Tests/MessagePackReaderTests.ReadString.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackReaderTests.ReadString.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NET
+using System.Runtime.CompilerServices;
+#endif
+
 public partial class MessagePackReaderTests
 {
 	[Fact]
@@ -28,6 +32,39 @@ public partial class MessagePackReaderTests
 		var result = reader.ReadString();
 		Assert.Equal("AB", result);
 	}
+
+	[Fact]
+	[Trait("CWE", "682")]
+	public void ReadString_HandlesMultipleSegments_WithExpectedRemainingStructures()
+	{
+		ReadOnlySequence<byte> seq = this.BuildSequence(
+			new[] { (byte)(MessagePackCode.MinFixArray + 2), (byte)(MessagePackCode.MinFixStr + 3), (byte)'A' },
+			new[] { (byte)'B', (byte)'C', (byte)MessagePackCode.Nil });
+
+		var reader = new MessagePackReader(seq);
+		Assert.Equal(2, reader.ReadArrayHeader());
+		AssertExpectedRemainingStructures(ref reader, 2);
+
+		Assert.Equal("ABC", reader.ReadString());
+		AssertExpectedRemainingStructures(ref reader, 1);
+
+		Assert.True(reader.TryReadNil());
+		AssertExpectedRemainingStructures(ref reader, 0);
+	}
+
+	private static void AssertExpectedRemainingStructures(ref MessagePackReader reader, uint expected)
+	{
+#if NET
+		Assert.Equal(expected, GetExpectedRemainingStructures(ref reader));
+#else
+		Assert.Skip("This test validates internal reader accounting that requires UnsafeAccessor.");
+#endif
+	}
+
+#if NET
+	[UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_ExpectedRemainingStructures")]
+	private static extern uint GetExpectedRemainingStructures(ref MessagePackReader reader);
+#endif
 
 	private ReadOnlySequence<T> BuildSequence<T>(params T[][] segmentContents)
 	{

--- a/test/Nerdbank.MessagePack.Tests/MessagePackReaderTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackReaderTests.cs
@@ -89,6 +89,19 @@ public partial class MessagePackReaderTests
 	}
 
 	[Fact]
+	[Trait("CWE", "190")]
+	public void ReadMapHeader_MitigatesLargeAllocations_WithOverflowingCount()
+	{
+		byte[] msgpack = [MessagePackCode.Map32, 0x40, 0x00, 0x00, 0x00];
+
+		Assert.Throws<EndOfStreamException>(() =>
+		{
+			var reader = new MessagePackReader(msgpack);
+			reader.ReadMapHeader();
+		});
+	}
+
+	[Fact]
 	public void TryReadMapHeader()
 	{
 		var sequence = new Sequence<byte>();

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
@@ -139,6 +139,34 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 	}
 
 	[Fact]
+	[Trait("CWE", "665")]
+	public void MultidimensionalArray2D_Flat_RejectsMismatchedRank()
+	{
+		this.Serializer = this.Serializer with { MultiDimensionalArrayFormat = MultiDimensionalArrayFormat.Flat };
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.WriteMapHeader(1);
+		writer.Write(nameof(HasByteMultiDimensionalArray.Array2D));
+		writer.WriteArrayHeader(2);
+		writer.WriteArrayHeader(3);
+		writer.Write(1);
+		writer.Write(1);
+		writer.Write(1);
+		writer.WriteArrayHeader(1);
+		writer.Write((byte)0);
+		writer.Flush();
+
+		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(
+			() => this.Serializer.Deserialize<HasByteMultiDimensionalArray>(seq, TestContext.Current.CancellationToken));
+		this.Logger.WriteLine(ex.ToString());
+		string exceptionMessage = ex.ToString();
+		Assert.True(
+			exceptionMessage.Contains("Expected array rank of 2 but was 3.", StringComparison.Ordinal) ||
+			exceptionMessage.Contains("Expected array length of 2 but was 3.", StringComparison.Ordinal),
+			exceptionMessage);
+	}
+
+	[Fact]
 	[Trait("CWE", "789")]
 	[Trait("CWE", "1284")]
 	public void MultidimensionalArray2D_Nested_ExcessivelyLargeDimensions()

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
@@ -139,6 +139,14 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 	}
 
 	[Fact]
+	[Trait("CWE", "789")]
+	[Trait("CWE", "1284")]
+	public void MultidimensionalArray2D_Nested_ExcessivelyLargeDimensions()
+	{
+		this.AssertNestedMultidimensionalArrayDimensionsRejectedBeforeAllocation(nameof(HasByteMultiDimensionalArray.Array2D), [10_000, 10_000]);
+	}
+
+	[Fact]
 	public void MultidimensionalArray_Null()
 	{
 		try
@@ -615,6 +623,38 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 
 		MessagePackSerializationException rootException = Assert.IsType<MessagePackSerializationException>(ex.GetBaseException());
 		Assert.Equal($"Expected {expectedElementCount} elements but found 0.", rootException.Message);
+
+		long allocatedBytes = GC.GetTotalMemory(false) - before;
+		Assert.True(allocatedBytes < 64 * 1024 * 1024, $"Deserialization allocated {allocatedBytes:N0} bytes.");
+	}
+
+	private void AssertNestedMultidimensionalArrayDimensionsRejectedBeforeAllocation(string propertyName, int[] dimensions)
+	{
+		this.Serializer = this.Serializer with { MultiDimensionalArrayFormat = MultiDimensionalArrayFormat.Nested };
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.WriteMapHeader(1);
+		writer.Write(propertyName);
+		long expectedElementCount = 1;
+		foreach (int dimension in dimensions)
+		{
+			writer.WriteArrayHeader(dimension);
+			expectedElementCount *= dimension;
+		}
+
+		for (int i = 0; i < dimensions[^1]; i++)
+		{
+			writer.Write((byte)0);
+		}
+
+		writer.Flush();
+
+		long before = GC.GetTotalMemory(true);
+		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(
+			() => this.Serializer.Deserialize<HasByteMultiDimensionalArray>(seq, TestContext.Current.CancellationToken));
+		this.Logger.WriteLine(ex.ToString());
+
+		Assert.Contains($"Array dimensions require {expectedElementCount} elements", ex.ToString());
 
 		long allocatedBytes = GC.GetTotalMemory(false) - before;
 		Assert.True(allocatedBytes < 64 * 1024 * 1024, $"Deserialization allocated {allocatedBytes:N0} bytes.");

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
@@ -123,6 +123,22 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 #pragma warning restore SA1500 // Braces for multi-line statements should not share line
 
 	[Fact]
+	[Trait("CWE", "789")]
+	[Trait("CWE", "1284")]
+	public void MultidimensionalArray2D_Flat_ExcessivelyLargeDimensions()
+	{
+		this.AssertFlatMultidimensionalArrayDimensionsRejectedBeforeAllocation(nameof(HasByteMultiDimensionalArray.Array2D), [10_000, 10_000]);
+	}
+
+	[Fact]
+	[Trait("CWE", "789")]
+	[Trait("CWE", "1284")]
+	public void MultidimensionalArray3D_Flat_ExcessivelyLargeDimensions()
+	{
+		this.AssertFlatMultidimensionalArrayDimensionsRejectedBeforeAllocation(nameof(HasByteMultiDimensionalArray.Array3D), [1_000, 1_000, 100]);
+	}
+
+	[Fact]
 	public void MultidimensionalArray_Null()
 	{
 		try
@@ -573,6 +589,37 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 		return sequence;
 	}
 
+	private void AssertFlatMultidimensionalArrayDimensionsRejectedBeforeAllocation(string propertyName, int[] dimensions)
+	{
+		this.Serializer = this.Serializer with { MultiDimensionalArrayFormat = MultiDimensionalArrayFormat.Flat };
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.WriteMapHeader(1);
+		writer.Write(propertyName);
+		writer.WriteArrayHeader(2);
+		writer.WriteArrayHeader(dimensions.Length);
+		long expectedElementCount = 1;
+		foreach (int dimension in dimensions)
+		{
+			writer.Write(dimension);
+			expectedElementCount *= dimension;
+		}
+
+		writer.WriteArrayHeader(0);
+		writer.Flush();
+
+		long before = GC.GetTotalMemory(true);
+		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(
+			() => this.Serializer.Deserialize<HasByteMultiDimensionalArray>(seq, TestContext.Current.CancellationToken));
+		this.Logger.WriteLine(ex.ToString());
+
+		MessagePackSerializationException rootException = Assert.IsType<MessagePackSerializationException>(ex.GetBaseException());
+		Assert.Equal($"Expected {expectedElementCount} elements but found 0.", rootException.Message);
+
+		long allocatedBytes = GC.GetTotalMemory(false) - before;
+		Assert.True(allocatedBytes < 64 * 1024 * 1024, $"Deserialization allocated {allocatedBytes:N0} bytes.");
+	}
+
 	[GenerateShape]
 	public partial class KeyedCollections
 	{
@@ -891,6 +938,14 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 		public int[,,]? Array3D { get; set; }
 
 		public bool Equals(HasMultiDimensionalArray? other) => other is not null && StructuralEquality.Equal<int>(this.Array2D, other.Array2D) && StructuralEquality.Equal<int>(this.Array3D, other.Array3D);
+	}
+
+	[GenerateShape]
+	public partial class HasByteMultiDimensionalArray
+	{
+		public byte[,]? Array2D { get; set; }
+
+		public byte[,,]? Array3D { get; set; }
 	}
 
 	public record UnannotatedPoco

--- a/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackSerializerTests.cs
@@ -62,6 +62,23 @@ public partial class MessagePackSerializerTests : MessagePackSerializerTestBase
 	public void Dictionary_Null() => this.AssertRoundtrip(new ClassWithDictionary { StringInt = null });
 
 	[Fact]
+	[Trait("CWE", "190")]
+	public void Dictionary_ExcessivelyLarge()
+	{
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq);
+		writer.WriteMapHeader(1);
+		writer.Write(nameof(ClassWithDictionary.StringInt));
+		writer.WriteRaw([MessagePackCode.Map32, 0x40, 0x00, 0x00, 0x00]);
+		writer.Flush();
+
+		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(
+			() => this.Serializer.Deserialize<ClassWithDictionary>(seq, TestContext.Current.CancellationToken));
+		this.Logger.WriteLine(ex.ToString());
+		Assert.IsType<EndOfStreamException>(ex.GetBaseException());
+	}
+
+	[Fact]
 	public void ImmutableDictionary() => this.AssertRoundtrip(new ClassWithImmutableDictionary { StringInt = ImmutableDictionary<string, int>.Empty.Add("a", 1) });
 
 	[Fact]

--- a/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
@@ -117,15 +117,19 @@ public partial class ObjectsAsArraysTests : MessagePackSerializerTestBase
 		Assert.Equal(new Person { FirstName = "A", LastName = "B" }, person);
 	}
 
+	[Trait("CWE", "129")]
 	[Theory, PairwiseData]
 	public async Task Person_UnknownIndexesInMap(bool async)
 	{
 		Sequence<byte> sequence = new();
 		MessagePackWriter writer = new(sequence);
-		writer.WriteMapHeader(3);
+		writer.WriteMapHeader(4);
 
 		writer.Write(0);
 		writer.Write("A");
+
+		writer.Write(-1);  // This should be ignored.
+		writer.Write("Z");
 
 		writer.Write(15);  // This should be ignored.
 		writer.Write("C");
@@ -200,15 +204,19 @@ public partial class ObjectsAsArraysTests : MessagePackSerializerTestBase
 		Assert.Equal(new PersonWithDefaultConstructor { FirstName = "A", LastName = "B" }, person);
 	}
 
+	[Trait("CWE", "129")]
 	[Theory, PairwiseData]
 	public async Task PersonWithDefaultConstructor_UnknownIndexesInMap(bool async)
 	{
 		Sequence<byte> sequence = new();
 		MessagePackWriter writer = new(sequence);
-		writer.WriteMapHeader(3);
+		writer.WriteMapHeader(4);
 
 		writer.Write(0);
 		writer.Write("A");
+
+		writer.Write(-1);  // This should be ignored.
+		writer.Write("Z");
 
 		writer.Write(15);  // This should be ignored.
 		writer.Write("C");

--- a/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
@@ -210,6 +210,26 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 	public class HashCollisionResistant(ITestOutputHelper logger) : StructuralEqualityComparerTests(logger)
 	{
 		[Fact]
+		[Trait("CWE", "697")]
+		public void Dictionary()
+		{
+			Dictionary<string, int> forward = new()
+			{
+				["a"] = 1,
+				["b"] = 2,
+			};
+			Dictionary<string, int> reverse = new()
+			{
+				["b"] = 2,
+				["a"] = 1,
+			};
+
+			IEqualityComparer<Dictionary<string, int>> comparer = this.GetEqualityComparer<Dictionary<string, int>, Witness>();
+			Assert.True(comparer.Equals(forward, reverse));
+			Assert.Equal(comparer.GetHashCode(forward), comparer.GetHashCode(reverse));
+		}
+
+		[Fact]
 		public override void CustomHash()
 		{
 			CustomHasher obj = new();
@@ -222,6 +242,7 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 
 	[GenerateShapeFor<bool>]
 	[GenerateShapeFor<BigInteger>]
+	[GenerateShapeFor<Dictionary<string, int>>]
 	[GenerateShapeFor<CustomHasher>]
 	internal partial class Witness;
 

--- a/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
@@ -25,6 +25,14 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 	public void BigInteger() => this.AssertEqualityComparerBehavior<BigInteger, Witness>([new BigInteger(5), new BigInteger(5)], [new BigInteger(10)]);
 
 	[Fact]
+	[Trait("CWE", "783")]
+	public void ByteArray()
+	{
+		byte[] shared = [1, 2];
+		this.AssertEqualityComparerBehavior<byte[], Witness>([shared, shared, [1, 2]], [[1, 3], [1, 2, 3]]);
+	}
+
+	[Fact]
 	public void CustomType_Tree() => this.AssertEqualityComparerBehavior(
 		[new Tree([new Fruit(3, "Red"), new Fruit(4, "Green")], 4, FruitKind.Apple), new Tree([new Fruit(3, "Red"), new Fruit(4, "Green")], 4, FruitKind.Apple)],
 		[
@@ -255,6 +263,7 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 
 	[GenerateShapeFor<bool>]
 	[GenerateShapeFor<BigInteger>]
+	[GenerateShapeFor<byte[]>]
 	[GenerateShapeFor<decimal>]
 	[GenerateShapeFor<Dictionary<string, int>>]
 	[GenerateShapeFor<CustomHasher>]

--- a/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
@@ -251,6 +251,22 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 		}
 
 		[Fact]
+		[Trait("CWE", "407")]
+		public void Uri()
+		{
+			IEqualityComparer<Uri> comparer = this.GetEqualityComparer<Uri, Witness>();
+			Uri first = new("https://example.com/path?query=value");
+			Uri second = new("https://example.com/path?query=value");
+			Uri relativeFirst = new("relative/path?query=value", UriKind.Relative);
+			Uri relativeSecond = new("relative/path?query=value", UriKind.Relative);
+
+			Assert.True(comparer.Equals(first, second));
+			Assert.Equal(comparer.GetHashCode(first), comparer.GetHashCode(second));
+			Assert.True(comparer.Equals(relativeFirst, relativeSecond));
+			Assert.Equal(comparer.GetHashCode(relativeFirst), comparer.GetHashCode(relativeSecond));
+		}
+
+		[Fact]
 		public override void CustomHash()
 		{
 			CustomHasher obj = new();
@@ -266,6 +282,7 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 	[GenerateShapeFor<byte[]>]
 	[GenerateShapeFor<decimal>]
 	[GenerateShapeFor<Dictionary<string, int>>]
+	[GenerateShapeFor<Uri>]
 	[GenerateShapeFor<CustomHasher>]
 	internal partial class Witness;
 

--- a/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
@@ -230,6 +230,19 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 		}
 
 		[Fact]
+		[Trait("CWE", "697")]
+		public void Decimal()
+		{
+			IEqualityComparer<decimal> comparer = this.GetEqualityComparer<decimal, Witness>();
+			Assert.True(comparer.Equals(1.0m, 1.00m));
+			Assert.Equal(comparer.GetHashCode(1.0m), comparer.GetHashCode(1.00m));
+			Assert.True(comparer.Equals(123.4500m, 123.45m));
+			Assert.Equal(comparer.GetHashCode(123.4500m), comparer.GetHashCode(123.45m));
+			Assert.True(comparer.Equals(0m, new decimal(0, 0, 0, isNegative: true, scale: 1)));
+			Assert.Equal(comparer.GetHashCode(0m), comparer.GetHashCode(new decimal(0, 0, 0, isNegative: true, scale: 1)));
+		}
+
+		[Fact]
 		public override void CustomHash()
 		{
 			CustomHasher obj = new();
@@ -242,6 +255,7 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 
 	[GenerateShapeFor<bool>]
 	[GenerateShapeFor<BigInteger>]
+	[GenerateShapeFor<decimal>]
 	[GenerateShapeFor<Dictionary<string, int>>]
 	[GenerateShapeFor<CustomHasher>]
 	internal partial class Witness;


### PR DESCRIPTION
ba15f73 Skip StreamItem extension fields (CWE-682)
a59c544 Use explicit SignalR skip context (CWE-1188)
468b8c1 Hash Uri values securely (CWE-407)
2c1b2f8 Correct byte array secure equality (CWE-783)
1878a78 Normalize decimal secure hashes (CWE-697)
330e9b2 Stabilize dictionary secure hashes (CWE-697)
7237184 Validate flattened array rank (CWE-665)
c7367ff Skip invalid object array indexes (CWE-129)
b35372b Preserve string reader accounting (CWE-682)
ee0e89e Limit nested array resource use (CWE-789, CWE-1284)
939fb26 Harden JSON conversion depth handling for CWE-674
78521ee Harden secure hashing allocation for CWE-789/CWE-674
36e1bcc Reduce async read resource usage (CWE-770)
a77a65d Harden malformed input validation against DoS (CWE-789, CWE-1284)
da08fa0 Harden malformed input validation against DoS (CWE-190)
924121a Validate DateTime extension header lengths before allocating  (CWE-789)