### PR TITLE
Avoid repeat allocations from calls to `SerializationContext.GetConverter<T>()` on .NET Framework

### DIFF
--- a/src/Nerdbank.MessagePack/ConverterCache.cs
+++ b/src/Nerdbank.MessagePack/ConverterCache.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using PolyType.Utilities;
@@ -100,6 +101,8 @@ internal class ConverterCache(SerializerConfiguration configuration)
 		}
 	}
 
+	private ConcurrentDictionary<(Type Type, Type Provider), ITypeShape> CachedTypeShapes => field ??= new();
+
 	/// <summary>
 	/// Gets a converter for the given type shape.
 	/// An existing converter is reused if one is found in the cache.
@@ -142,6 +145,41 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// <returns>A msgpack converter.</returns>
 	internal ConverterResult GetOrAddConverter(Type type, ITypeShapeProvider provider)
 		=> (ConverterResult)this.CachedConverters.GetOrAddOrThrow(type, provider);
+
+	/// <inheritdoc cref="TypeShapeResolver.ResolveDynamicOrThrow{T}()"/>
+#if NET8_0
+	[RequiresDynamicCode(MessagePackSerializerExtensions.ResolveDynamicMessage)]
+#endif
+	internal ITypeShape<T> ResolveDynamicTypeShapeOrThrow<T>()
+	{
+		Type type = typeof(T);
+		(Type, Type) key = (type, type);
+		if (!this.CachedTypeShapes.TryGetValue(key, out ITypeShape? shape))
+		{
+			// We want to cache the result because TypeShapeResolver.ResolveDynamicOrThrow instantiates a new ITypeShapeProvider with each call,
+			// and we want to be alloc-free after the first call. See https://github.com/eiriktsarpalis/PolyType/pull/432/changes#r3260136940
+			shape = this.CachedTypeShapes.GetOrAdd(key, TypeShapeResolver.ResolveDynamicOrThrow<T>());
+		}
+
+		return (ITypeShape<T>)shape;
+	}
+
+	/// <inheritdoc cref="TypeShapeResolver.ResolveDynamicOrThrow{T, TProvider}()"/>
+#if NET8_0
+	[RequiresDynamicCode(MessagePackSerializerExtensions.ResolveDynamicMessage)]
+#endif
+	internal ITypeShape<T> ResolveDynamicTypeShapeOrThrow<T, TProvider>()
+	{
+		(Type, Type) key = (typeof(T), typeof(TProvider));
+		if (!this.CachedTypeShapes.TryGetValue(key, out ITypeShape? shape))
+		{
+			// We want to cache the result because TypeShapeResolver.ResolveDynamicOrThrow instantiates a new ITypeShapeProvider with each call,
+			// and we want to be alloc-free after the first call. See https://github.com/eiriktsarpalis/PolyType/pull/432/changes#r3260136940
+			shape = this.CachedTypeShapes.GetOrAdd(key, TypeShapeResolver.ResolveDynamicOrThrow<T, TProvider>());
+		}
+
+		return (ITypeShape<T>)shape;
+	}
 
 	/// <summary>
 	/// Gets a user-defined converter for the specified type if one is available from

--- a/src/Nerdbank.MessagePack/ConverterContext.cs
+++ b/src/Nerdbank.MessagePack/ConverterContext.cs
@@ -15,7 +15,6 @@ namespace Nerdbank.MessagePack;
 /// </remarks>
 public struct ConverterContext
 {
-	private readonly ConverterCache cache;
 	private readonly bool preserveReferences;
 
 	/// <summary>
@@ -26,7 +25,7 @@ public struct ConverterContext
 	/// <param name="referencePreservationMode">The reference preservation mode.</param>
 	internal ConverterContext(ConverterCache converterCache, ITypeShapeProvider typeShapeProvider, ReferencePreservationMode referencePreservationMode)
 	{
-		this.cache = converterCache;
+		this.Cache = converterCache;
 		this.TypeShapeProvider = typeShapeProvider;
 		this.preserveReferences = referencePreservationMode != ReferencePreservationMode.Off;
 	}
@@ -35,6 +34,11 @@ public struct ConverterContext
 	/// Gets the <see cref="ITypeShapeProvider"/> that can provide shapes for given types.
 	/// </summary>
 	public ITypeShapeProvider TypeShapeProvider { get; }
+
+	/// <summary>
+	/// Gets the converter cache associated with this serializer.
+	/// </summary>
+	internal ConverterCache Cache { get; }
 
 #if NET
 	/// <summary>
@@ -45,8 +49,8 @@ public struct ConverterContext
 	public MessagePackConverter<T> GetConverter<T>()
 		where T : IShapeable<T>
 	{
-		Verify.Operation(this.cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter result = this.cache.GetOrAddConverter(T.GetTypeShape()).ValueOrThrow;
+		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
+		MessagePackConverter result = this.Cache.GetOrAddConverter(T.GetTypeShape()).ValueOrThrow;
 		return (MessagePackConverter<T>)(this.preserveReferences ? ((IMessagePackConverterInternal)result).WrapWithReferencePreservation() : result);
 	}
 
@@ -59,8 +63,8 @@ public struct ConverterContext
 	public MessagePackConverter<T> GetConverter<T, TProvider>()
 		where TProvider : IShapeable<T>
 	{
-		Verify.Operation(this.cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter result = this.cache.GetOrAddConverter(TProvider.GetTypeShape()).ValueOrThrow;
+		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
+		MessagePackConverter result = this.Cache.GetOrAddConverter(TProvider.GetTypeShape()).ValueOrThrow;
 		return (MessagePackConverter<T>)(this.preserveReferences ? ((IMessagePackConverterInternal)result).WrapWithReferencePreservation() : result);
 	}
 #endif
@@ -82,8 +86,8 @@ public struct ConverterContext
 	[OverloadResolutionPriority(1)] // for null values, prefer this method over the one that takes ITypeShape.
 	public MessagePackConverter<T> GetConverter<T>(ITypeShapeProvider? provider)
 	{
-		Verify.Operation(this.cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter result = this.cache.GetOrAddConverter<T>(provider ?? this.TypeShapeProvider ?? throw new UnreachableException()).ValueOrThrow;
+		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
+		MessagePackConverter result = this.Cache.GetOrAddConverter<T>(provider ?? this.TypeShapeProvider ?? throw new UnreachableException()).ValueOrThrow;
 		return (MessagePackConverter<T>)(this.preserveReferences ? ((IMessagePackConverterInternal)result).WrapWithReferencePreservation() : result);
 	}
 
@@ -99,8 +103,8 @@ public struct ConverterContext
 	public MessagePackConverter GetConverter(ITypeShape typeShape)
 	{
 		Requires.NotNull(typeShape);
-		Verify.Operation(this.cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter result = this.cache.GetOrAddConverter(typeShape).ValueOrThrow;
+		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
+		MessagePackConverter result = this.Cache.GetOrAddConverter(typeShape).ValueOrThrow;
 		return this.preserveReferences ? ((IMessagePackConverterInternal)result).WrapWithReferencePreservation() : result;
 	}
 
@@ -117,8 +121,8 @@ public struct ConverterContext
 	public MessagePackConverter<T> GetConverter<T>(ITypeShape<T> typeShape)
 	{
 		Requires.NotNull(typeShape);
-		Verify.Operation(this.cache is not null, "No serialization operation is in progress.");
-		MessagePackConverter result = this.cache.GetOrAddConverter(typeShape).ValueOrThrow;
+		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
+		MessagePackConverter result = this.Cache.GetOrAddConverter(typeShape).ValueOrThrow;
 		return (MessagePackConverter<T>)(this.preserveReferences ? ((IMessagePackConverterInternal)result).WrapWithReferencePreservation() : result);
 	}
 
@@ -135,8 +139,8 @@ public struct ConverterContext
 	public MessagePackConverter GetConverter(Type type, ITypeShapeProvider? provider = null)
 	{
 		Requires.NotNull(type);
-		Verify.Operation(this.cache is not null, "No serialization operation is in progress.");
-		IMessagePackConverterInternal result = (IMessagePackConverterInternal)this.cache.GetOrAddConverter(type, provider ?? this.TypeShapeProvider ?? throw new UnreachableException()).ValueOrThrow;
+		Verify.Operation(this.Cache is not null, "No serialization operation is in progress.");
+		IMessagePackConverterInternal result = (IMessagePackConverterInternal)this.Cache.GetOrAddConverter(type, provider ?? this.TypeShapeProvider ?? throw new UnreachableException()).ValueOrThrow;
 		return this.preserveReferences ? result.WrapWithReferencePreservation() : (MessagePackConverter)result;
 	}
 }

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.AutomatedFriendlyOverloads.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.AutomatedFriendlyOverloads.cs
@@ -269,7 +269,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static void Serialize<T>(this MessagePackSerializer self, ref MessagePackWriter writer, in T? value, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Serialize(ref writer, value, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).Serialize(ref writer, value, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Serialize{T}(in T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -287,7 +287,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static byte[] Serialize<T>(this MessagePackSerializer self, in T? value, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Serialize(value, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).Serialize(value, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Serialize{T}(IBufferWriter{byte}, in T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -305,7 +305,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static void Serialize<T>(this MessagePackSerializer self, IBufferWriter<byte> writer, in T? value, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Serialize(writer, value, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).Serialize(writer, value, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Serialize{T}(Stream, in T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -323,7 +323,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static void Serialize<T>(this MessagePackSerializer self, Stream stream, in T? value, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Serialize(stream, value, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).Serialize(stream, value, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Deserialize{T}(ref MessagePackReader, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -341,7 +341,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static T? Deserialize<T>(this MessagePackSerializer self, ref MessagePackReader reader, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Deserialize(ref reader, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).Deserialize(ref reader, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Deserialize{T}(ReadOnlyMemory{byte}, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -359,7 +359,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static T? Deserialize<T>(this MessagePackSerializer self, ReadOnlyMemory<byte> bytes, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Deserialize(bytes, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).Deserialize(bytes, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Deserialize{T}(in ReadOnlySequence{byte}, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -377,7 +377,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static T? Deserialize<T>(this MessagePackSerializer self, scoped in ReadOnlySequence<byte> bytes, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Deserialize(bytes, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).Deserialize(bytes, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Deserialize{T}(Stream, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -395,7 +395,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static T? Deserialize<T>(this MessagePackSerializer self, Stream stream, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Deserialize(stream, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).Deserialize(stream, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializeAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -415,7 +415,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static ValueTask<T?> DeserializeAsync<T>(this MessagePackSerializer self, PipeReader reader, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializeAsync(reader, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).DeserializeAsync(reader, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializeEnumerableAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -435,7 +435,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static IAsyncEnumerable<T?> DeserializeEnumerableAsync<T>(this MessagePackSerializer self, PipeReader reader, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializeEnumerableAsync(reader, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).DeserializeEnumerableAsync(reader, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePathEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, MessagePackSerializer.StreamingEnumerationOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -455,7 +455,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static IAsyncEnumerable<TElement?> DeserializePathEnumerableAsync<T, TElement>(this MessagePackSerializer self, PipeReader reader, MessagePackSerializer.StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializePathEnumerableAsync(reader, ResolveTypeShapeOrThrow<T>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePathEnumerableAsync(reader, ResolveTypeShapeOrThrow<T>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializeAsync{T}(Stream, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -475,7 +475,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static ValueTask<T?> DeserializeAsync<T>(this MessagePackSerializer self, Stream stream, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializeAsync(stream, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).DeserializeAsync(stream, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializeEnumerableAsync{T}(Stream, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -495,7 +495,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static IAsyncEnumerable<T?> DeserializeEnumerableAsync<T>(this MessagePackSerializer self, Stream stream, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializeEnumerableAsync(stream, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).DeserializeEnumerableAsync(stream, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePathEnumerableAsync{T, TElement}(Stream, ITypeShape{T}, MessagePackSerializer.StreamingEnumerationOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -515,7 +515,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static IAsyncEnumerable<TElement?> DeserializePathEnumerableAsync<T, TElement>(this MessagePackSerializer self, Stream stream, MessagePackSerializer.StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializePathEnumerableAsync(stream, ResolveTypeShapeOrThrow<T>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePathEnumerableAsync(stream, ResolveTypeShapeOrThrow<T>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePath{T, TElement}(ref MessagePackReader, ITypeShape{T}, in MessagePackSerializer.DeserializePathOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -533,7 +533,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static TElement? DeserializePath<T, TElement>(this MessagePackSerializer self, ref MessagePackReader reader, in MessagePackSerializer.DeserializePathOptions<T, TElement> options, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).DeserializePath(ref reader, ResolveTypeShapeOrThrow<T>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePath(ref reader, ResolveTypeShapeOrThrow<T>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePath{T, TElement}(ReadOnlyMemory{byte}, ITypeShape{T}, in MessagePackSerializer.DeserializePathOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -551,7 +551,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static TElement? DeserializePath<T, TElement>(this MessagePackSerializer self, ReadOnlyMemory<byte> bytes, in MessagePackSerializer.DeserializePathOptions<T, TElement> options, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).DeserializePath(bytes, ResolveTypeShapeOrThrow<T>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePath(bytes, ResolveTypeShapeOrThrow<T>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePath{T, TElement}(in ReadOnlySequence{byte}, ITypeShape{T}, in MessagePackSerializer.DeserializePathOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -569,7 +569,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static TElement? DeserializePath<T, TElement>(this MessagePackSerializer self, scoped in ReadOnlySequence<byte> bytes, in MessagePackSerializer.DeserializePathOptions<T, TElement> options, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).DeserializePath(bytes, ResolveTypeShapeOrThrow<T>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePath(bytes, ResolveTypeShapeOrThrow<T>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePath{T, TElement}(Stream, ITypeShape{T}, in MessagePackSerializer.DeserializePathOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -587,7 +587,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static TElement? DeserializePath<T, TElement>(this MessagePackSerializer self, Stream stream, in MessagePackSerializer.DeserializePathOptions<T, TElement> options, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).DeserializePath(stream, ResolveTypeShapeOrThrow<T>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePath(stream, ResolveTypeShapeOrThrow<T>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.SerializeAsync{T}(PipeWriter, T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -607,7 +607,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static ValueTask SerializeAsync<T>(this MessagePackSerializer self, PipeWriter writer, in T? value, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).SerializeAsync(writer, value, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).SerializeAsync(writer, value, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.SerializeAsync{T}(Stream, T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -627,7 +627,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static ValueTask SerializeAsync<T>(this MessagePackSerializer self, Stream stream, in T? value, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).SerializeAsync(stream, value, ResolveTypeShapeOrThrow<T>(), cancellationToken);
+		=> Requires.NotNull(self).SerializeAsync(stream, value, ResolveTypeShapeOrThrow<T>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Serialize{T}(ref MessagePackWriter, in T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -644,7 +644,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static void Serialize<T, TProvider>(this MessagePackSerializer self, ref MessagePackWriter writer, in T? value, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Serialize(ref writer, value, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).Serialize(ref writer, value, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Serialize{T}(in T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -661,7 +661,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static byte[] Serialize<T, TProvider>(this MessagePackSerializer self, in T? value, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Serialize(value, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).Serialize(value, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Serialize{T}(IBufferWriter{byte}, in T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -678,7 +678,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static void Serialize<T, TProvider>(this MessagePackSerializer self, IBufferWriter<byte> writer, in T? value, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Serialize(writer, value, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).Serialize(writer, value, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Serialize{T}(Stream, in T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -695,7 +695,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static void Serialize<T, TProvider>(this MessagePackSerializer self, Stream stream, in T? value, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Serialize(stream, value, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).Serialize(stream, value, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Deserialize{T}(ref MessagePackReader, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -712,7 +712,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static T? Deserialize<T, TProvider>(this MessagePackSerializer self, ref MessagePackReader reader, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Deserialize(ref reader, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).Deserialize(ref reader, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Deserialize{T}(ReadOnlyMemory{byte}, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -729,7 +729,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static T? Deserialize<T, TProvider>(this MessagePackSerializer self, ReadOnlyMemory<byte> bytes, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Deserialize(bytes, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).Deserialize(bytes, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Deserialize{T}(in ReadOnlySequence{byte}, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -746,7 +746,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static T? Deserialize<T, TProvider>(this MessagePackSerializer self, scoped in ReadOnlySequence<byte> bytes, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Deserialize(bytes, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).Deserialize(bytes, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.Deserialize{T}(Stream, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -763,7 +763,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static T? Deserialize<T, TProvider>(this MessagePackSerializer self, Stream stream, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).Deserialize(stream, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).Deserialize(stream, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializeAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -782,7 +782,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static ValueTask<T?> DeserializeAsync<T, TProvider>(this MessagePackSerializer self, PipeReader reader, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializeAsync(reader, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).DeserializeAsync(reader, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializeEnumerableAsync{T}(PipeReader, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -801,7 +801,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static IAsyncEnumerable<T?> DeserializeEnumerableAsync<T, TProvider>(this MessagePackSerializer self, PipeReader reader, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializeEnumerableAsync(reader, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).DeserializeEnumerableAsync(reader, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePathEnumerableAsync{T, TElement}(PipeReader, ITypeShape{T}, MessagePackSerializer.StreamingEnumerationOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -820,7 +820,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static IAsyncEnumerable<TElement?> DeserializePathEnumerableAsync<T, TElement, TProvider>(this MessagePackSerializer self, PipeReader reader, MessagePackSerializer.StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializePathEnumerableAsync(reader, ResolveTypeShapeOrThrow<T, TProvider>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePathEnumerableAsync(reader, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializeAsync{T}(Stream, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -839,7 +839,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static ValueTask<T?> DeserializeAsync<T, TProvider>(this MessagePackSerializer self, Stream stream, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializeAsync(stream, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).DeserializeAsync(stream, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializeEnumerableAsync{T}(Stream, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -858,7 +858,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static IAsyncEnumerable<T?> DeserializeEnumerableAsync<T, TProvider>(this MessagePackSerializer self, Stream stream, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializeEnumerableAsync(stream, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).DeserializeEnumerableAsync(stream, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePathEnumerableAsync{T, TElement}(Stream, ITypeShape{T}, MessagePackSerializer.StreamingEnumerationOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -877,7 +877,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static IAsyncEnumerable<TElement?> DeserializePathEnumerableAsync<T, TElement, TProvider>(this MessagePackSerializer self, Stream stream, MessagePackSerializer.StreamingEnumerationOptions<T, TElement> options, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).DeserializePathEnumerableAsync(stream, ResolveTypeShapeOrThrow<T, TProvider>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePathEnumerableAsync(stream, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePath{T, TElement}(ref MessagePackReader, ITypeShape{T}, in MessagePackSerializer.DeserializePathOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -894,7 +894,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static TElement? DeserializePath<T, TElement, TProvider>(this MessagePackSerializer self, ref MessagePackReader reader, in MessagePackSerializer.DeserializePathOptions<T, TElement> options, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).DeserializePath(ref reader, ResolveTypeShapeOrThrow<T, TProvider>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePath(ref reader, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePath{T, TElement}(ReadOnlyMemory{byte}, ITypeShape{T}, in MessagePackSerializer.DeserializePathOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -911,7 +911,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static TElement? DeserializePath<T, TElement, TProvider>(this MessagePackSerializer self, ReadOnlyMemory<byte> bytes, in MessagePackSerializer.DeserializePathOptions<T, TElement> options, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).DeserializePath(bytes, ResolveTypeShapeOrThrow<T, TProvider>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePath(bytes, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePath{T, TElement}(in ReadOnlySequence{byte}, ITypeShape{T}, in MessagePackSerializer.DeserializePathOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -928,7 +928,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static TElement? DeserializePath<T, TElement, TProvider>(this MessagePackSerializer self, scoped in ReadOnlySequence<byte> bytes, in MessagePackSerializer.DeserializePathOptions<T, TElement> options, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).DeserializePath(bytes, ResolveTypeShapeOrThrow<T, TProvider>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePath(bytes, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.DeserializePath{T, TElement}(Stream, ITypeShape{T}, in MessagePackSerializer.DeserializePathOptions{T, TElement}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -945,7 +945,7 @@ public static partial class MessagePackSerializerExtensions
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	public static TElement? DeserializePath<T, TElement, TProvider>(this MessagePackSerializer self, Stream stream, in MessagePackSerializer.DeserializePathOptions<T, TElement> options, CancellationToken cancellationToken = default)
-		=> Requires.NotNull(self).DeserializePath(stream, ResolveTypeShapeOrThrow<T, TProvider>(), options, cancellationToken);
+		=> Requires.NotNull(self).DeserializePath(stream, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), options, cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.SerializeAsync{T}(PipeWriter, T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -964,7 +964,7 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static ValueTask SerializeAsync<T, TProvider>(this MessagePackSerializer self, PipeWriter writer, in T? value, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).SerializeAsync(writer, value, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).SerializeAsync(writer, value, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 
 	/// <inheritdoc cref="MessagePackSerializer.SerializeAsync{T}(Stream, T, ITypeShape{T}, CancellationToken)" />
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -983,5 +983,5 @@ public static partial class MessagePackSerializerExtensions
 #endif
 	public static ValueTask SerializeAsync<T, TProvider>(this MessagePackSerializer self, Stream stream, in T? value, CancellationToken cancellationToken = default)
 #pragma warning restore RS0027 // optional parameter on a method with overloads
-		=> Requires.NotNull(self).SerializeAsync(stream, value, ResolveTypeShapeOrThrow<T, TProvider>(), cancellationToken);
+		=> Requires.NotNull(self).SerializeAsync(stream, value, ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache), cancellationToken);
 }

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.AutomatedFriendlyOverloads.tt
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.AutomatedFriendlyOverloads.tt
@@ -44,8 +44,8 @@ void WriteClass(bool targetNET) {
     {
         (string genericTypeParameters, string genericTypeParametersWithElement, string typeConstraint, string getShape) = shapeSource switch
         {
-            ShapeSource.T => ("T","T, TElement", targetNET ? "T : IShapeable<T>" : null, targetNET ? "T.GetTypeShape()" : "ResolveTypeShapeOrThrow<T>()"),
-            ShapeSource.TProvider => ("T, TProvider","T, TElement, TProvider", targetNET ? "TProvider : IShapeable<T>" : null, targetNET ? "TProvider.GetTypeShape()" : "ResolveTypeShapeOrThrow<T, TProvider>()"),
+            ShapeSource.T => ("T","T, TElement", targetNET ? "T : IShapeable<T>" : null, targetNET ? "T.GetTypeShape()" : "ResolveTypeShapeOrThrow<T>(self.ConverterCache)"),
+            ShapeSource.TProvider => ("T, TProvider","T, TElement, TProvider", targetNET ? "TProvider : IShapeable<T>" : null, targetNET ? "TProvider.GetTypeShape()" : "ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache)"),
             _ => throw new NotSupportedException(),
         };
         typeConstraint = typeConstraint is null ? "" : $"where {typeConstraint} ";

--- a/src/Nerdbank.MessagePack/MessagePackSerializerExtensions.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializerExtensions.cs
@@ -54,7 +54,7 @@ public static partial class MessagePackSerializerExtensions
 	[Obsolete("Use the MessagePackSerializer.GetJsonSchema<T>() instance method instead. If using the extension method syntax, check that your type argument actually has a [GenerateShape] attribute or otherwise implements IShapeable<T> to avoid a runtime failure.", error: true)]
 #endif
 	public static JsonObject GetJsonSchema<T>(this MessagePackSerializer self)
-		=> Requires.NotNull(self).GetJsonSchema(TypeShapeResolver.ResolveDynamicOrThrow<T>());
+		=> Requires.NotNull(self).GetJsonSchema(ResolveTypeShapeOrThrow<T>(self.ConverterCache));
 
 	/// <summary>
 	/// <inheritdoc cref="MessagePackSerializer.GetJsonSchema(ITypeShape)" path="/summary"/>
@@ -77,7 +77,7 @@ public static partial class MessagePackSerializerExtensions
 	[Obsolete("Use the MessagePackSerializer.GetJsonSchema<T, TProvider>() instance method instead. If using the extension method syntax, check that your type argument actually has a [GenerateShape] attribute or otherwise implements IShapeable<T> to avoid a runtime failure.", error: true)]
 #endif
 	public static JsonObject GetJsonSchema<T, TProvider>(this MessagePackSerializer self)
-		=> Requires.NotNull(self).GetJsonSchema(TypeShapeResolver.ResolveDynamicOrThrow<T, TProvider>());
+		=> Requires.NotNull(self).GetJsonSchema(ResolveTypeShapeOrThrow<T, TProvider>(self.ConverterCache));
 
 	/// <inheritdoc cref="SerializationContext.GetConverter{T}(ITypeShape{T})"/>
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -95,7 +95,7 @@ public static partial class MessagePackSerializerExtensions
 	[Obsolete("Use the SerializationContext.GetConverter<T>() instance method instead. If using the extension method syntax, check that your type argument actually has a [GenerateShape] attribute or otherwise implements IShapeable<T> to avoid a runtime failure.", error: true)]
 #endif
 	public static MessagePackConverter<T> GetConverter<T>(this SerializationContext context)
-		=> context.GetConverter(TypeShapeResolver.ResolveDynamicOrThrow<T>());
+		=> context.GetConverter(ResolveTypeShapeOrThrow<T>(context.Cache, contextualCall: true));
 
 	/// <inheritdoc cref="SerializationContext.GetConverter{T}(ITypeShape{T})"/>
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -112,7 +112,7 @@ public static partial class MessagePackSerializerExtensions
 	[Obsolete("Use the SerializationContext.GetConverter<T, TProvider>() instance method instead. If using the extension method syntax, check that your type argument actually has a [GenerateShape] attribute or otherwise implements IShapeable<T> to avoid a runtime failure.", error: true)]
 #endif
 	public static MessagePackConverter<T> GetConverter<T, TProvider>(this SerializationContext context)
-		=> context.GetConverter(TypeShapeResolver.ResolveDynamicOrThrow<T, TProvider>());
+		=> context.GetConverter(ResolveTypeShapeOrThrow<T, TProvider>(context.Cache, contextualCall: true));
 
 	/// <inheritdoc cref="ConverterContext.GetConverter{T}(ITypeShape{T})"/>
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="T"/> has no type shape created via the <see cref="GenerateShapeAttribute"/> source generator.</exception>
@@ -130,7 +130,7 @@ public static partial class MessagePackSerializerExtensions
 	[Obsolete("Use the ConverterContext.GetConverter<T>() instance method instead. If using the extension method syntax, check that your type argument actually has a [GenerateShape] attribute or otherwise implements IShapeable<T> to avoid a runtime failure.", error: true)]
 #endif
 	public static MessagePackConverter<T> GetConverter<T>(this ConverterContext context)
-		=> context.GetConverter(TypeShapeResolver.ResolveDynamicOrThrow<T>());
+		=> context.GetConverter(ResolveTypeShapeOrThrow<T>(context.Cache, contextualCall: true));
 
 	/// <inheritdoc cref="SerializationContext.GetConverter{T}(ITypeShape{T})"/>
 	/// <exception cref="NotSupportedException">Thrown if <typeparamref name="TProvider"/> has no <see cref="GenerateShapeForAttribute{T}"/> source generator attribute for <typeparamref name="T"/>.</exception>
@@ -147,7 +147,7 @@ public static partial class MessagePackSerializerExtensions
 	[Obsolete("Use the ConverterContext.GetConverter<T, TProvider>() instance method instead. If using the extension method syntax, check that your type argument actually has a [GenerateShape] attribute or otherwise implements IShapeable<T> to avoid a runtime failure.", error: true)]
 #endif
 	public static MessagePackConverter<T> GetConverter<T, TProvider>(this ConverterContext context)
-		=> context.GetConverter(TypeShapeResolver.ResolveDynamicOrThrow<T, TProvider>());
+		=> context.GetConverter(ResolveTypeShapeOrThrow<T, TProvider>(context.Cache, contextualCall: true));
 
 	/// <summary>
 	/// Resolves a type shape, providing enhanced error messages for array types.
@@ -161,13 +161,13 @@ public static partial class MessagePackSerializerExtensions
 #if NET8_0
 	[RequiresDynamicCode(ResolveDynamicMessage)]
 #endif
-	private static ITypeShape<T> ResolveTypeShapeOrThrow<T>()
+	private static ITypeShape<T> ResolveTypeShapeOrThrow<T>(ConverterCache? cache, bool contextualCall = false)
 	{
 		try
 		{
-			return TypeShapeResolver.ResolveDynamicOrThrow<T>();
+			return cache is null ? TypeShapeResolver.ResolveDynamicOrThrow<T>() : cache.ResolveDynamicTypeShapeOrThrow<T>();
 		}
-		catch (NotSupportedException ex) when (typeof(T).IsArray)
+		catch (NotSupportedException ex) when (!contextualCall && typeof(T).IsArray)
 		{
 			throw new NotSupportedException(
 				$"The type '{typeof(T).FullName}' does not have a generated shape. " +
@@ -194,13 +194,13 @@ public static partial class MessagePackSerializerExtensions
 #if NET8_0
 	[RequiresDynamicCode(ResolveDynamicMessage)]
 #endif
-	private static ITypeShape<T> ResolveTypeShapeOrThrow<T, TProvider>()
+	private static ITypeShape<T> ResolveTypeShapeOrThrow<T, TProvider>(ConverterCache? cache, bool contextualCall = false)
 	{
 		try
 		{
-			return TypeShapeResolver.ResolveDynamicOrThrow<T, TProvider>();
+			return cache is null ? TypeShapeResolver.ResolveDynamicOrThrow<T, TProvider>() : cache.ResolveDynamicTypeShapeOrThrow<T, TProvider>();
 		}
-		catch (NotSupportedException ex) when (typeof(T).IsArray)
+		catch (NotSupportedException ex) when (!contextualCall && typeof(T).IsArray)
 		{
 			throw new NotSupportedException(
 				$"The type '{typeof(T).FullName}' does not have a generated shape on the witness type '{typeof(TProvider).FullName}'. " +


### PR DESCRIPTION
See https://github.com/eiriktsarpalis/PolyType/pull/432 for why we need to do this.