### PR TITLE
Fix JsonNode deserialization of null values

### DIFF
--- a/src/Nerdbank.MessagePack/Converters/JsonNodeConverter.cs
+++ b/src/Nerdbank.MessagePack/Converters/JsonNodeConverter.cs
@@ -18,7 +18,7 @@ internal class JsonNodeConverter : MessagePackConverter<JsonNode>
 		return reader.NextMessagePackType switch
 		{
 			MessagePackType.Integer => MessagePackCode.IsSignedInteger(reader.NextCode) ? JsonValue.Create(reader.ReadInt64()) : JsonValue.Create(reader.ReadUInt64()),
-			MessagePackType.Nil => JsonValue.Create((string?)null),
+			MessagePackType.Nil => ReadNil(ref reader),
 			MessagePackType.Boolean => JsonValue.Create(reader.ReadBoolean()),
 			MessagePackType.Float => JsonValue.Create(reader.ReadDouble()),
 			MessagePackType.String => JsonValue.Create(reader.ReadString()),
@@ -28,6 +28,12 @@ internal class JsonNodeConverter : MessagePackConverter<JsonNode>
 			MessagePackType.Extension => throw new NotSupportedException("msgpack extensions cannot be represented in JSON."),
 			_ => throw new NotSupportedException("Unsupported msgpack token."),
 		};
+
+		JsonNode? ReadNil(ref MessagePackReader reader)
+		{
+			reader.ReadNil();
+			return JsonValue.Create((string?)null);
+		}
 
 		JsonNode ReadArray(ref MessagePackReader reader, SerializationContext context)
 		{

--- a/test/Nerdbank.MessagePack.Tests/Converters/JsonNodeConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/Converters/JsonNodeConverterTests.cs
@@ -28,6 +28,19 @@ public partial class JsonNodeConverterTests : MessagePackSerializerTestBase
 	}
 
 	[Fact]
+	public void Roundtrip_JsonNode_WithNullFollowedByValue()
+	{
+		JsonNode node = JsonNode.Parse("""
+			[null,true,1]
+			""")!;
+		JsonNode? deserialized = this.Roundtrip<JsonNode, Witness>(node);
+		Assert.NotNull(deserialized);
+		Assert.Null(deserialized[0]);
+		Assert.True(deserialized[1]?.GetValue<bool>());
+		Assert.Equal(1ul, deserialized[2]?.GetValue<ulong>());
+	}
+
+	[Fact]
 	public void Roundtrip_JsonNode_WithFloatingPoint()
 	{
 		JsonNode node = JsonNode.Parse("""


### PR DESCRIPTION
It was not advancing the reader when encountering a `null` value, leading to failure in the next step of deserialization.
