### PR TITLE
Fix ArgumentNullException in Decoder.Convert and fix secure hash of `ROS<byte>`

### DIFF
--- a/src/Nerdbank.MessagePack/Extension.cs
+++ b/src/Nerdbank.MessagePack/Extension.cs
@@ -39,17 +39,5 @@ public partial record struct Extension(sbyte TypeCode, ReadOnlySequence<byte> Da
 
 	/// <inheritdoc/>
 	long IStructuralSecureEqualityComparer<Extension>.GetSecureHashCode()
-	{
-		// We don't have an incremental SipHash implementation, so we have to copy the data to a rented buffer.
-		byte[] rented = ArrayPool<byte>.Shared.Rent(checked((int)this.Data.Length));
-		try
-		{
-			this.Data.CopyTo(rented);
-			return SipHash.Default.Compute(rented.AsSpan(0, (int)this.Data.Length)) + this.TypeCode;
-		}
-		finally
-		{
-			ArrayPool<byte>.Shared.Return(rented);
-		}
-	}
+		=> SipHash.Default.Compute(this.Data) + this.TypeCode;
 }

--- a/src/Nerdbank.MessagePack/PolyfillExtensions.cs
+++ b/src/Nerdbank.MessagePack/PolyfillExtensions.cs
@@ -90,6 +90,11 @@ namespace Nerdbank.MessagePack
 
 		internal static unsafe int GetChars(this Encoding encoding, ReadOnlySequence<byte> source, Span<char> destination)
 		{
+			if (source.IsEmpty)
+			{
+				return 0;
+			}
+
 			if (source.IsSingleSegment)
 			{
 				return GetChars(encoding, source.First.Span, destination);
@@ -100,6 +105,11 @@ namespace Nerdbank.MessagePack
 			bool completed = true;
 			foreach (ReadOnlyMemory<byte> sourceSegment in source)
 			{
+				if (sourceSegment.IsEmpty)
+				{
+					continue;
+				}
+
 				fixed (byte* pSource = sourceSegment.Span)
 				{
 					fixed (char* pDestination = destination)

--- a/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/HashCollisionResistantPrimitives.cs
@@ -287,42 +287,7 @@ internal static class HashCollisionResistantPrimitives
 
 		public override bool Equals(ReadOnlySequence<byte> x, ReadOnlySequence<byte> y) => x.SequenceEqual(y);
 
-		public override long GetSecureHashCode([DisallowNull] ReadOnlySequence<byte> obj)
-		{
-			int segmentCount = 0;
-			foreach (ReadOnlyMemory<byte> segment in obj)
-			{
-				if (++segmentCount > 64)
-				{
-					break;
-				}
-			}
-
-			if (segmentCount <= 64)
-			{
-				Span<long> hashesSpan = stackalloc long[segmentCount];
-				int i = 0;
-				foreach (ReadOnlyMemory<byte> segment in obj)
-				{
-					hashesSpan[i++] = SecureHash(segment.Span);
-				}
-
-				return SipHash.Default.Compute(MemoryMarshal.Cast<long, byte>(hashesSpan));
-			}
-
-			List<long> hashes = [];
-			foreach (ReadOnlyMemory<byte> segment in obj)
-			{
-				hashes.Add(SecureHash(segment.Span));
-			}
-
-#if NET
-			Span<long> span = CollectionsMarshal.AsSpan(hashes);
-#else
-			Span<long> span = hashes.ToArray();
-#endif
-			return SipHash.Default.Compute(MemoryMarshal.Cast<long, byte>(span));
-		}
+		public override long GetSecureHashCode([DisallowNull] ReadOnlySequence<byte> obj) => SipHash.Default.Compute(obj);
 	}
 
 	internal class CollisionResistantEnumHasher<TEnum, TUnderlying>(SecureEqualityComparer<TUnderlying> equalityComparer) : SecureEqualityComparer<TEnum>

--- a/src/Nerdbank.MessagePack/SecureHash/SipHash.cs
+++ b/src/Nerdbank.MessagePack/SecureHash/SipHash.cs
@@ -7,7 +7,6 @@
 //// SipHash website: https://131002.net/siphash/
 
 using System.Buffers.Binary;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
 namespace Nerdbank.MessagePack.SecureHash;
@@ -71,7 +70,7 @@ internal class SipHash
 	}
 
 	/// <summary>
-	/// Gets a 128-bit SipHash key.
+	/// Gets the 128-bit SipHash key used to construct this instance.
 	/// </summary>
 	/// <param name="key">The 16-byte buffer that receives the key originally provided to the constructor.</param>
 	public void GetKey(Span<byte> key)
@@ -90,199 +89,186 @@ internal class SipHash
 	/// <returns>Returns 64-bit (8 bytes) SipHash tag.</returns>
 	public long Compute(scoped ReadOnlySpan<byte> data)
 	{
+		IncrementalHasher hasher = this.CreateIncrementalHasher();
+		hasher.Append(data);
+		return hasher.FinalizeHash();
+	}
+
+	/// <summary>Computes 64-bit SipHash tag for the specified sequence.</summary>
+	/// <param name="data">The byte sequence for which to compute a SipHash tag.</param>
+	/// <returns>Returns 64-bit (8 bytes) SipHash tag.</returns>
+	public long Compute(scoped in ReadOnlySequence<byte> data)
+	{
+		if (data.IsSingleSegment)
+		{
+			return this.Compute(data.First.Span);
+		}
+
+		IncrementalHasher hasher = this.CreateIncrementalHasher();
+		foreach (ReadOnlyMemory<byte> segment in data)
+		{
+			hasher.Append(segment.Span);
+		}
+
+		return hasher.FinalizeHash();
+	}
+
+	/// <summary>
+	/// Creates a stateful hasher that can accept data in multiple segments.
+	/// </summary>
+	/// <returns>An incremental SipHash hasher.</returns>
+	internal IncrementalHasher CreateIncrementalHasher() => new(this.initialState0, this.initialState1);
+
+	private static void ProcessMessageBlock(ref ulong v0, ref ulong v1, ref ulong v2, ref ulong v3, ulong block)
+	{
 		unchecked
 		{
-			// SipHash internal state
-			ulong v0 = this.initialState0;
-			ulong v1 = this.initialState1;
+			v3 ^= block;
+			SipRound(ref v0, ref v1, ref v2, ref v3);
+			SipRound(ref v0, ref v1, ref v2, ref v3);
+			v0 ^= block;
+		}
+	}
 
-			// It is faster to load the initialStateX fields from memory again than to reference v0 and v1:
-			ulong v2 = 0x1F160A001E161714UL ^ this.initialState0;
-			ulong v3 = 0x100A160317100A1EUL ^ this.initialState1;
+	private static void ProcessFinalBlock(ref ulong v0, ref ulong v1, ref ulong v2, ref ulong v3, ulong block)
+	{
+		unchecked
+		{
+			v3 ^= block;
+			SipRound(ref v0, ref v1, ref v2, ref v3);
+			SipRound(ref v0, ref v1, ref v2, ref v3);
+			v0 ^= block;
+			v2 ^= 0xff;
+		}
+	}
 
-			// We process data in 64-bit blocks
-			ulong block;
+	private static void FinalizeCore(ref ulong v0, ref ulong v1, ref ulong v2, ref ulong v3)
+	{
+		unchecked
+		{
+			SipRound(ref v0, ref v1, ref v2, ref v3);
+			SipRound(ref v0, ref v1, ref v2, ref v3);
+			SipRound(ref v0, ref v1, ref v2, ref v3);
+			SipRound(ref v0, ref v1, ref v2, ref v3);
+		}
+	}
 
-			// The last 64-bit block of data
+	private static void SipRound(ref ulong v0, ref ulong v1, ref ulong v2, ref ulong v3)
+	{
+		unchecked
+		{
+			v0 += v1;
+			v2 += v3;
+			v1 = (v1 << 13) | (v1 >> 51);
+			v3 = (v3 << 16) | (v3 >> 48);
+			v1 ^= v0;
+			v3 ^= v2;
+			v0 = (v0 << 32) | (v0 >> 32);
+			v2 += v1;
+			v0 += v3;
+			v1 = (v1 << 17) | (v1 >> 47);
+			v3 = (v3 << 21) | (v3 >> 43);
+			v1 ^= v2;
+			v3 ^= v0;
+			v2 = (v2 << 32) | (v2 >> 32);
+		}
+	}
+
+	/// <summary>
+	/// Incrementally computes a SipHash value over multiple segments.
+	/// </summary>
+	internal struct IncrementalHasher
+	{
+		private ulong v0;
+		private ulong v1;
+		private ulong v2;
+		private ulong v3;
+		private ulong tailBlock;
+		private int tailLength;
+		private ulong totalLength;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="IncrementalHasher"/> struct.
+		/// </summary>
+		/// <param name="initialState0">The first half of the keyed initial state.</param>
+		/// <param name="initialState1">The second half of the keyed initial state.</param>
+		internal IncrementalHasher(ulong initialState0, ulong initialState1)
+		{
+			this.v0 = initialState0;
+			this.v1 = initialState1;
+			this.v2 = 0x1F160A001E161714UL ^ initialState0;
+			this.v3 = 0x100A160317100A1EUL ^ initialState1;
+			this.tailBlock = 0;
+			this.tailLength = 0;
+			this.totalLength = 0;
+		}
+
+		/// <summary>
+		/// Appends data to the hash computation.
+		/// </summary>
+		/// <param name="data">The data to hash.</param>
+		internal void Append(ReadOnlySpan<byte> data)
+		{
+			this.totalLength += (ulong)data.Length;
+
+			if (this.tailLength > 0)
+			{
+				int bytesNeeded = sizeof(ulong) - this.tailLength;
+				int bytesToCopy = Math.Min(bytesNeeded, data.Length);
+				for (int i = 0; i < bytesToCopy; i++)
+				{
+					this.tailBlock |= (ulong)data[i] << ((this.tailLength + i) * 8);
+				}
+
+				this.tailLength += bytesToCopy;
+				data = data[bytesToCopy..];
+
+				if (this.tailLength < sizeof(ulong))
+				{
+					return;
+				}
+
+				if (this.tailLength == sizeof(ulong))
+				{
+					ProcessMessageBlock(ref this.v0, ref this.v1, ref this.v2, ref this.v3, this.tailBlock);
+					this.tailBlock = 0;
+					this.tailLength = 0;
+				}
+			}
+
 			int finalBlockPosition = data.Length & ~7;
-
-			// Process the input data in blocks of 64 bits
 			for (int blockPosition = 0; blockPosition < finalBlockPosition; blockPosition += sizeof(ulong))
 			{
-				block = MemoryMarshal.Read<ulong>(data.Slice(blockPosition));
-
-				v3 ^= block;
-
-				// Round 1
-				v0 += v1;
-				v2 += v3;
-				v1 = v1 << 13 | v1 >> 51;
-				v3 = v3 << 16 | v3 >> 48;
-				v1 ^= v0;
-				v3 ^= v2;
-				v0 = v0 << 32 | v0 >> 32;
-				v2 += v1;
-				v0 += v3;
-				v1 = v1 << 17 | v1 >> 47;
-				v3 = v3 << 21 | v3 >> 43;
-				v1 ^= v2;
-				v3 ^= v0;
-				v2 = v2 << 32 | v2 >> 32;
-
-				// Round 2
-				v0 += v1;
-				v2 += v3;
-				v1 = v1 << 13 | v1 >> 51;
-				v3 = v3 << 16 | v3 >> 48;
-				v1 ^= v0;
-				v3 ^= v2;
-				v0 = v0 << 32 | v0 >> 32;
-				v2 += v1;
-				v0 += v3;
-				v1 = v1 << 17 | v1 >> 47;
-				v3 = v3 << 21 | v3 >> 43;
-				v1 ^= v2;
-				v3 ^= v0;
-				v2 = v2 << 32 | v2 >> 32;
-
-				v0 ^= block;
+				ProcessMessageBlock(ref this.v0, ref this.v1, ref this.v2, ref this.v3, BinaryPrimitives.ReadUInt64LittleEndian(data.Slice(blockPosition)));
 			}
 
-			// Load the remaining bytes
-			block = (ulong)data.Length << 56;
-			switch (data.Length & 7)
+			ReadOnlySpan<byte> tail = data[finalBlockPosition..];
+			for (int i = 0; i < tail.Length; i++)
 			{
-				case 7:
-					block |= MemoryMarshal.Read<uint>(data.Slice(finalBlockPosition)) | (ulong)MemoryMarshal.Read<ushort>(data.Slice(finalBlockPosition + 4)) << 32 | (ulong)data[finalBlockPosition + 6] << 48;
-					break;
-				case 6:
-					block |= MemoryMarshal.Read<uint>(data.Slice(finalBlockPosition)) | (ulong)MemoryMarshal.Read<ushort>(data.Slice(finalBlockPosition + 4)) << 32;
-					break;
-				case 5:
-					block |= MemoryMarshal.Read<uint>(data.Slice(finalBlockPosition)) | (ulong)data[finalBlockPosition + 4] << 32;
-					break;
-				case 4:
-					block |= MemoryMarshal.Read<uint>(data.Slice(finalBlockPosition));
-					break;
-				case 3:
-					block |= MemoryMarshal.Read<ushort>(data.Slice(finalBlockPosition)) | (ulong)data[finalBlockPosition + 2] << 16;
-					break;
-				case 2:
-					block |= MemoryMarshal.Read<ushort>(data.Slice(finalBlockPosition));
-					break;
-				case 1:
-					block |= data[finalBlockPosition];
-					break;
+				this.tailBlock |= (ulong)tail[i] << (i * 8);
 			}
 
-			// Process the final block
+			this.tailLength = tail.Length;
+		}
+
+		/// <summary>
+		/// Computes the hash for all data appended so far.
+		/// </summary>
+		/// <returns>The 64-bit SipHash tag.</returns>
+		internal long FinalizeHash()
+		{
+			unchecked
 			{
-				v3 ^= block;
+				ulong v0 = this.v0;
+				ulong v1 = this.v1;
+				ulong v2 = this.v2;
+				ulong v3 = this.v3;
+				ulong finalBlock = this.tailBlock | ((this.totalLength & 0xFFUL) << 56);
 
-				// Round 1
-				v0 += v1;
-				v2 += v3;
-				v1 = v1 << 13 | v1 >> 51;
-				v3 = v3 << 16 | v3 >> 48;
-				v1 ^= v0;
-				v3 ^= v2;
-				v0 = v0 << 32 | v0 >> 32;
-				v2 += v1;
-				v0 += v3;
-				v1 = v1 << 17 | v1 >> 47;
-				v3 = v3 << 21 | v3 >> 43;
-				v1 ^= v2;
-				v3 ^= v0;
-				v2 = v2 << 32 | v2 >> 32;
-
-				// Round 2
-				v0 += v1;
-				v2 += v3;
-				v1 = v1 << 13 | v1 >> 51;
-				v3 = v3 << 16 | v3 >> 48;
-				v1 ^= v0;
-				v3 ^= v2;
-				v0 = v0 << 32 | v0 >> 32;
-				v2 += v1;
-				v0 += v3;
-				v1 = v1 << 17 | v1 >> 47;
-				v3 = v3 << 21 | v3 >> 43;
-				v1 ^= v2;
-				v3 ^= v0;
-				v2 = v2 << 32 | v2 >> 32;
-
-				v0 ^= block;
-				v2 ^= 0xff;
+				ProcessFinalBlock(ref v0, ref v1, ref v2, ref v3, finalBlock);
+				FinalizeCore(ref v0, ref v1, ref v2, ref v3);
+				return (long)(v0 ^ v1 ^ v2 ^ v3);
 			}
-
-			// 4 finalization rounds
-			{
-				// Round 1
-				v0 += v1;
-				v2 += v3;
-				v1 = v1 << 13 | v1 >> 51;
-				v3 = v3 << 16 | v3 >> 48;
-				v1 ^= v0;
-				v3 ^= v2;
-				v0 = v0 << 32 | v0 >> 32;
-				v2 += v1;
-				v0 += v3;
-				v1 = v1 << 17 | v1 >> 47;
-				v3 = v3 << 21 | v3 >> 43;
-				v1 ^= v2;
-				v3 ^= v0;
-				v2 = v2 << 32 | v2 >> 32;
-
-				// Round 2
-				v0 += v1;
-				v2 += v3;
-				v1 = v1 << 13 | v1 >> 51;
-				v3 = v3 << 16 | v3 >> 48;
-				v1 ^= v0;
-				v3 ^= v2;
-				v0 = v0 << 32 | v0 >> 32;
-				v2 += v1;
-				v0 += v3;
-				v1 = v1 << 17 | v1 >> 47;
-				v3 = v3 << 21 | v3 >> 43;
-				v1 ^= v2;
-				v3 ^= v0;
-				v2 = v2 << 32 | v2 >> 32;
-
-				// Round 3
-				v0 += v1;
-				v2 += v3;
-				v1 = v1 << 13 | v1 >> 51;
-				v3 = v3 << 16 | v3 >> 48;
-				v1 ^= v0;
-				v3 ^= v2;
-				v0 = v0 << 32 | v0 >> 32;
-				v2 += v1;
-				v0 += v3;
-				v1 = v1 << 17 | v1 >> 47;
-				v3 = v3 << 21 | v3 >> 43;
-				v1 ^= v2;
-				v3 ^= v0;
-				v2 = v2 << 32 | v2 >> 32;
-
-				// Round 4
-				v0 += v1;
-				v2 += v3;
-				v1 = v1 << 13 | v1 >> 51;
-				v3 = v3 << 16 | v3 >> 48;
-				v1 ^= v0;
-				v3 ^= v2;
-				v0 = v0 << 32 | v0 >> 32;
-				v2 += v1;
-				v0 += v3;
-				v1 = v1 << 17 | v1 >> 47;
-				v3 = v3 << 21 | v3 >> 43;
-				v1 ^= v2;
-				v3 ^= v0;
-				v2 = v2 << 32 | v2 >> 32;
-			}
-
-			return (long)(v0 ^ v1 ^ v2 ^ v3);
 		}
 	}
 }

--- a/test/Nerdbank.MessagePack.Tests/ArraysOfPrimitivesTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ArraysOfPrimitivesTests.cs
@@ -40,6 +40,16 @@ public partial class ArraysOfPrimitivesTests : MessagePackSerializerTestBase
 		this.Roundtrip<Memory<bool>, Witness>(values);
 	}
 
+	[Fact]
+	public void BoolArray_FragmentedWithEmptySegment()
+	{
+		ReadOnlyMemory<byte> buffer = this.Serializer.Serialize<bool[], Witness>([true, false, true], TestContext.Current.CancellationToken);
+		ReadOnlySequence<byte> sequence = SequenceBuilder.Create(buffer[..2], ReadOnlyMemory<byte>.Empty, buffer[2..]);
+		bool[]? deserialized = this.Serializer.Deserialize<bool[], Witness>(sequence, TestContext.Current.CancellationToken);
+		Assert.NotNull(deserialized);
+		Assert.Equal([true, false, true], deserialized);
+	}
+
 	[Theory, PairwiseData]
 	public void Int8([CombinatorialMemberData(nameof(GetInterestingLengths), typeof(sbyte))] int length)
 		=> this.Roundtrip<Memory<sbyte>, Witness>(GetRandomValues<sbyte>(length));

--- a/test/Nerdbank.MessagePack.Tests/MessagePackReaderTests.ReadString.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackReaderTests.ReadString.cs
@@ -10,7 +10,7 @@ public partial class MessagePackReaderTests
 	[Fact]
 	public void ReadString_HandlesSingleSegment()
 	{
-		ReadOnlySequence<byte> seq = this.BuildSequence(new[]
+		ReadOnlySequence<byte> seq = SequenceBuilder.Create(new[]
 		{
 			(byte)(MessagePackCode.MinFixStr + 2),
 			(byte)'A', (byte)'B',
@@ -24,8 +24,21 @@ public partial class MessagePackReaderTests
 	[Fact]
 	public void ReadString_HandlesMultipleSegments()
 	{
-		ReadOnlySequence<byte> seq = this.BuildSequence(
+		ReadOnlySequence<byte> seq = SequenceBuilder.Create(
 			new[] { (byte)(MessagePackCode.MinFixStr + 2), (byte)'A' },
+			new[] { (byte)'B' });
+
+		var reader = new MessagePackReader(seq);
+		var result = reader.ReadString();
+		Assert.Equal("AB", result);
+	}
+
+	[Fact]
+	public void ReadString_HandlesMultipleSegments_WithEmptySegment()
+	{
+		ReadOnlySequence<byte> seq = SequenceBuilder.Create(
+			new[] { (byte)(MessagePackCode.MinFixStr + 2), (byte)'A' },
+			[],
 			new[] { (byte)'B' });
 
 		var reader = new MessagePackReader(seq);
@@ -37,7 +50,7 @@ public partial class MessagePackReaderTests
 	[Trait("CWE", "682")]
 	public void ReadString_HandlesMultipleSegments_WithExpectedRemainingStructures()
 	{
-		ReadOnlySequence<byte> seq = this.BuildSequence(
+		ReadOnlySequence<byte> seq = SequenceBuilder.Create(
 			new[] { (byte)(MessagePackCode.MinFixArray + 2), (byte)(MessagePackCode.MinFixStr + 3), (byte)'A' },
 			new[] { (byte)'B', (byte)'C', (byte)MessagePackCode.Nil });
 
@@ -66,38 +79,4 @@ public partial class MessagePackReaderTests
 	private static extern uint GetExpectedRemainingStructures(ref MessagePackReader reader);
 #endif
 
-	private ReadOnlySequence<T> BuildSequence<T>(params T[][] segmentContents)
-	{
-		if (segmentContents.Length == 1)
-		{
-			return new ReadOnlySequence<T>(segmentContents[0].AsMemory());
-		}
-
-		var bufferSegment = new BufferSegment<T>(segmentContents[0].AsMemory());
-		BufferSegment<T>? last = default;
-		for (var i = 1; i < segmentContents.Length; i++)
-		{
-			last = bufferSegment.Append(segmentContents[i]);
-		}
-
-		return new ReadOnlySequence<T>(bufferSegment, 0, last!, last!.Memory.Length);
-	}
-
-	internal class BufferSegment<T> : ReadOnlySequenceSegment<T>
-	{
-		public BufferSegment(ReadOnlyMemory<T> memory)
-		{
-			this.Memory = memory;
-		}
-
-		public BufferSegment<T> Append(ReadOnlyMemory<T> memory)
-		{
-			var segment = new BufferSegment<T>(memory)
-			{
-				RunningIndex = this.RunningIndex + this.Memory.Length,
-			};
-			this.Next = segment;
-			return segment;
-		}
-	}
 }

--- a/test/Nerdbank.MessagePack.Tests/MessagePackReaderTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/MessagePackReaderTests.cs
@@ -186,9 +186,9 @@ public partial class MessagePackReaderTests
 		byte[] expected = [0x1, 0x2, 0x3];
 		writer.WriteString(expected);
 		writer.Flush();
-		ReadOnlySequence<byte> fragmentedSequence = BuildSequence(
-		   contiguousSequence.AsReadOnlySequence.First.Slice(0, 2),
-		   contiguousSequence.AsReadOnlySequence.First.Slice(2));
+		ReadOnlySequence<byte> fragmentedSequence = SequenceBuilder.Create(
+			contiguousSequence.AsReadOnlySequence.First.Slice(0, 2),
+			contiguousSequence.AsReadOnlySequence.First.Slice(2));
 
 		var reader = new MessagePackReader(fragmentedSequence);
 		Assert.False(reader.TryReadStringSpan(out ReadOnlySpan<byte> span));
@@ -253,9 +253,9 @@ public partial class MessagePackReaderTests
 		byte[] expected = [0x1, 0x2, 0x3];
 		writer.WriteString(expected);
 		writer.Flush();
-		ReadOnlySequence<byte> fragmentedSequence = BuildSequence(
-		   contiguousSequence.AsReadOnlySequence.First.Slice(0, 2),
-		   contiguousSequence.AsReadOnlySequence.First.Slice(2));
+		ReadOnlySequence<byte> fragmentedSequence = SequenceBuilder.Create(
+			contiguousSequence.AsReadOnlySequence.First.Slice(0, 2),
+			contiguousSequence.AsReadOnlySequence.First.Slice(2));
 
 		var reader = new MessagePackReader(fragmentedSequence);
 		ReadOnlySpan<byte> span = reader.ReadStringSpan();
@@ -451,22 +451,6 @@ public partial class MessagePackReaderTests
 		cb(ref writer);
 		writer.Flush();
 		return sequence.AsReadOnlySequence;
-	}
-
-	private static ReadOnlySequence<T> BuildSequence<T>(params ReadOnlyMemory<T>[] memoryChunks)
-	{
-		var sequence = new Sequence<T>(new ExactArrayPool<T>())
-		{
-			MinimumSpanLength = -1,
-		};
-		foreach (ReadOnlyMemory<T> chunk in memoryChunks)
-		{
-			Span<T> span = sequence.GetSpan(chunk.Length);
-			chunk.Span.CopyTo(span);
-			sequence.Advance(chunk.Length);
-		}
-
-		return sequence;
 	}
 
 	private void AssertCodeRange(RangeChecker predicate, Func<byte, bool> isOneByteRepresentation, Func<byte, bool> isIntroductoryByte)

--- a/test/Nerdbank.MessagePack.Tests/SequenceBuilder.cs
+++ b/test/Nerdbank.MessagePack.Tests/SequenceBuilder.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/// <summary>
+/// Helper class for constructing artificial <see cref="ReadOnlySequence{T}"/> instances for testing purposes.
+/// </summary>
+internal static class SequenceBuilder
+{
+	/// <summary>
+	/// Creates a <see cref="ReadOnlySequence{T}"/> from the provided segments.
+	/// </summary>
+	/// <typeparam name="T">The type of element in the sequence.</typeparam>
+	/// <param name="segmentContents">The segments for the sequence.</param>
+	/// <returns>A <see cref="ReadOnlySequence{T}"/> representing the concatenated segments.</returns>
+	/// <remarks>
+	/// This does not use <see cref="Nerdbank.Streams.Sequence{T}"/> to construct sequences because that
+	/// type will not append <em>empty</em> segments, which for some tests is exactly what we need.
+	/// </remarks>
+	internal static ReadOnlySequence<T> Create<T>(params ReadOnlyMemory<T>[] segmentContents)
+	{
+		if (segmentContents.Length == 1)
+		{
+			return new ReadOnlySequence<T>(segmentContents[0]);
+		}
+
+		BufferSegment<T> bufferSegment = new(segmentContents[0]);
+		BufferSegment<T>? last = bufferSegment;
+		for (int i = 1; i < segmentContents.Length; i++)
+		{
+			last = last.Append(segmentContents[i]);
+		}
+
+		return new ReadOnlySequence<T>(bufferSegment, 0, last!, last!.Memory.Length);
+	}
+
+	/// <inheritdoc cref="Create{T}(ReadOnlyMemory{T}[])"/>
+	internal static ReadOnlySequence<T> Create<T>(params T[][] segmentContents)
+	{
+		ReadOnlyMemory<T>[] memorySegments = new ReadOnlyMemory<T>[segmentContents.Length];
+		for (int i = 0; i < segmentContents.Length; i++)
+		{
+			memorySegments[i] = segmentContents[i].AsMemory();
+		}
+
+		return Create(memorySegments);
+	}
+
+	private sealed class BufferSegment<T> : ReadOnlySequenceSegment<T>
+	{
+		internal BufferSegment(ReadOnlyMemory<T> memory)
+		{
+			this.Memory = memory;
+		}
+
+		internal BufferSegment<T> Append(ReadOnlyMemory<T> memory)
+		{
+			var segment = new BufferSegment<T>(memory)
+			{
+				RunningIndex = this.RunningIndex + this.Memory.Length,
+			};
+			this.Next = segment;
+			return segment;
+		}
+	}
+}

--- a/test/Nerdbank.MessagePack.Tests/StringInterningTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StringInterningTests.cs
@@ -56,6 +56,15 @@ public partial class StringInterningTests : MessagePackSerializerTestBase
 		Assert.Equal("abc", deserialized);
 	}
 
+	[Fact]
+	public void FragmentedWithEmptySegment()
+	{
+		ReadOnlyMemory<byte> buffer = this.Serializer.Serialize<string, Witness>("abc", TestContext.Current.CancellationToken);
+		ReadOnlySequence<byte> sequence = SequenceBuilder.Create(buffer[..2], ReadOnlyMemory<byte>.Empty, buffer[2..^1], buffer[^1..]);
+		string? deserialized = this.Serializer.Deserialize<string, Witness>(sequence, TestContext.Current.CancellationToken);
+		Assert.Equal("abc", deserialized);
+	}
+
 	[GenerateShapeFor<string>]
 	[GenerateShapeFor<string[]>]
 	private partial class Witness;

--- a/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/StructuralEqualityComparerTests.cs
@@ -61,7 +61,12 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 
 	[Fact]
 	public void ReadOnlySequenceOfByte() => this.AssertEqualityComparerBehavior(
-		[new HaveReadOnlySequenceOfByte(new([1, 2])), new HaveReadOnlySequenceOfByte(new([1, 2]))],
+		[
+			new HaveReadOnlySequenceOfByte(new([1, 2])),
+			new HaveReadOnlySequenceOfByte(new([1, 2])),
+			new HaveReadOnlySequenceOfByte(SequenceBuilder.Create(new byte[] { 1 }, new byte[] { 2 })),
+			new HaveReadOnlySequenceOfByte(SequenceBuilder.Create(new byte[] { 1 }, ReadOnlyMemory<byte>.Empty, new byte[] { 2 })),
+		],
 		[new HaveReadOnlySequenceOfByte(new([1, 3])), new HaveReadOnlySequenceOfByte(new([1, 2, 3]))]);
 
 	[Fact]
@@ -264,6 +269,20 @@ public abstract partial class StructuralEqualityComparerTests(ITestOutputHelper 
 			Assert.Equal(comparer.GetHashCode(first), comparer.GetHashCode(second));
 			Assert.True(comparer.Equals(relativeFirst, relativeSecond));
 			Assert.Equal(comparer.GetHashCode(relativeFirst), comparer.GetHashCode(relativeSecond));
+		}
+
+		[Fact]
+		public void Extension_IgnoresSegmentBoundaries()
+		{
+			IEqualityComparer<Extension> comparer = this.GetEqualityComparer<Extension>();
+			Extension contiguous = new(5, new byte[] { 1, 2 });
+			Extension segmented = new(5, SequenceBuilder.Create(new byte[] { 1 }, new byte[] { 2 }));
+			Extension segmentedWithEmpty = new(5, SequenceBuilder.Create(new byte[] { 1 }, ReadOnlyMemory<byte>.Empty, new byte[] { 2 }));
+
+			Assert.True(comparer.Equals(contiguous, segmented));
+			Assert.Equal(comparer.GetHashCode(contiguous), comparer.GetHashCode(segmented));
+			Assert.True(comparer.Equals(contiguous, segmentedWithEmpty));
+			Assert.Equal(comparer.GetHashCode(contiguous), comparer.GetHashCode(segmentedWithEmpty));
 		}
 
 		[Fact]


### PR DESCRIPTION
## Fix ArgumentNullException thrown from Decoder.Convert

When a `ReadOnlySequence<byte>` that includes an empty `ReadOnlyMemory<byte>` segment is deserialized, the string interning converter may end up throwing `ArgumentNullException`.
This fixes that bug.

## Fix secure hashing of `ReadOnlySequence<byte>`

Previously, it was producing multiple hashes for 'equal' sequences based on where the segment boundaries fell.
This change updates `SipHash` so that it properly supports streaming hashing such that the boundaries of each segment do not impact the resulting value.