### PR TITLE
Merge latest Library.Template updates

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.8.0",
+      "version": "18.9.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:10.0.301@sha256:548d93f8a18a1acbe6cc127bc4f47281430d34a9e35c18afa80a8d6741c2adc3
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <!-- Put repo-specific PackageVersion items in this group. -->
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="$(MicrosoftTestingPlatformVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="PolyType" Version="$(PolyTypeVersion)" />
     <PackageVersion Include="PolyType.TestCases" Version="$(PolyTypeVersion)-unstable" />
-    <PackageVersion Include="System.IO.Pipelines" Version="10.0.8" />
+    <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
     <PackageVersion Include="System.Memory.Data" Version="8.0.1" />
     <PackageVersion Include="TUnit" Version="1.58.0" />
     <PackageVersion Include="TUnit.Engine" Version="1.58.0" />
@@ -53,7 +53,7 @@
          dependency than they were expecting or needlessly bring in a 9.0 assembly to an 8.0 runtime. -->
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsAnalyzerProject)'=='true'">
     <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicrosoftTestingPlatformVersion>2.2.3</MicrosoftTestingPlatformVersion>
+    <MicrosoftTestingPlatformVersion>2.3.0</MicrosoftTestingPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Put repo-specific PackageVersion items in this group. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/App.net472.config
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/App.net472.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="DiffPlex" publicKeyToken="1d35e91d1bd7bc0f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/Nerdbank.MessagePack.Analyzers.Tests.csproj
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/Nerdbank.MessagePack.Analyzers.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <AppConfig Condition="'$(TargetFramework)'=='net472'">App.net472.config</AppConfig>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/Verifiers/ReferencesHelper.cs
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/Verifiers/ReferencesHelper.cs
@@ -11,7 +11,7 @@ internal static class ReferencesHelper
 	internal static ReferenceAssemblies References = ReferenceAssemblies.NetFramework.Net472.Default
 		.WithPackages([
 			new PackageIdentity("System.Memory", "4.6.3"),
-			new PackageIdentity("System.Text.Json", "10.0.8"),
+			new PackageIdentity("System.Text.Json", "8.0.6"),
 		]);
 #endif
 

--- a/tools/GitHubActions.ps1
+++ b/tools/GitHubActions.ps1
@@ -9,7 +9,7 @@ function Add-GitHubActionsEnvVariable {
     )
 
     if ([string]::IsNullOrWhiteSpace($Path)) {
-        throw "GitHub Actions environment file path must not be empty."
+        throw "GitHub Actions GITHUB_ENV file path must not be empty."
     }
 
     if ([string]::IsNullOrWhiteSpace($Name)) {
@@ -29,7 +29,7 @@ function Add-GitHubActionsPath {
     )
 
     if ([string]::IsNullOrWhiteSpace($Path)) {
-        throw "GitHub Actions path file path must not be empty."
+        throw "GitHub Actions GITHUB_PATH file path must not be empty."
     }
 
     if ([string]::IsNullOrWhiteSpace($Value)) {

--- a/tools/GitHubActions.ps1
+++ b/tools/GitHubActions.ps1
@@ -8,6 +8,10 @@ function Add-GitHubActionsEnvVariable {
         [string]$Value
     )
 
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "GitHub Actions environment file must not be empty."
+    }
+
     if ([string]::IsNullOrWhiteSpace($Name)) {
         throw "GitHub Actions environment variable names must not be empty."
     }

--- a/tools/GitHubActions.ps1
+++ b/tools/GitHubActions.ps1
@@ -16,3 +16,18 @@ function Add-GitHubActionsEnvVariable {
     $delimiter = [guid]::NewGuid().ToString('N')
     [System.IO.File]::AppendAllText($Path, "$Name<<$delimiter`n$Value`n$delimiter`n", $utf8NoBom)
 }
+
+function Add-GitHubActionsPath {
+    param(
+        [string]$Path = $env:GITHUB_PATH,
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "GitHub Actions path file must not be empty."
+    }
+
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
+}

--- a/tools/GitHubActions.ps1
+++ b/tools/GitHubActions.ps1
@@ -32,6 +32,10 @@ function Add-GitHubActionsPath {
         throw "GitHub Actions path file must not be empty."
     }
 
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        throw "GitHub Actions path entries must not be empty."
+    }
+
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
 }

--- a/tools/GitHubActions.ps1
+++ b/tools/GitHubActions.ps1
@@ -9,11 +9,11 @@ function Add-GitHubActionsEnvVariable {
     )
 
     if ([string]::IsNullOrWhiteSpace($Path)) {
-        throw "GitHub Actions environment file must not be empty."
+        throw "GitHub Actions environment file path must not be empty."
     }
 
     if ([string]::IsNullOrWhiteSpace($Name)) {
-        throw "GitHub Actions environment variable names must not be empty."
+        throw "GitHub Actions environment variable name must not be empty."
     }
 
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
@@ -29,11 +29,11 @@ function Add-GitHubActionsPath {
     )
 
     if ([string]::IsNullOrWhiteSpace($Path)) {
-        throw "GitHub Actions path file must not be empty."
+        throw "GitHub Actions path file path must not be empty."
     }
 
     if ([string]::IsNullOrWhiteSpace($Value)) {
-        throw "GitHub Actions path entries must not be empty."
+        throw "GitHub Actions path entry must not be empty."
     }
 
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)

--- a/tools/Set-EnvVars.ps1
+++ b/tools/Set-EnvVars.ps1
@@ -82,7 +82,7 @@ if ($PrependPath) {
             Write-Host "##vso[task.prependpath]$_"
         }
         if ($env:GITHUB_ACTIONS) {
-            Add-GitHubActionsEnvVariable -Name PATH -Value $newPathValue
+            Add-GitHubActionsPath -Value $_
         }
 
         $CmdEnvScript += "SET PATH=$_$pathDelimiter%PATH%"

--- a/tools/Set-EnvVars.ps1
+++ b/tools/Set-EnvVars.ps1
@@ -19,7 +19,9 @@ Param(
     [string[]]$PrependPath
 )
 
-. "$PSScriptRoot\GitHubActions.ps1"
+if ($env:GITHUB_ACTIONS) {
+    . "$PSScriptRoot\GitHubActions.ps1"
+}
 
 if ($Variables.Count -eq 0) {
     return $true

--- a/tools/variables/_define.ps1
+++ b/tools/variables/_define.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
     This script translates the variables returned by the _all.ps1 script
-    into commands that instruct Azure Pipelines to actually set those variables for other pipeline tasks to consume.
+    into commands that instruct Azure Pipelines or GitHub Actions to actually set those variables for other pipeline tasks to consume.
 
     The build or release definition may have set these variables to override
     what the build would do. So only set them if they have not already been set.

--- a/tools/variables/_define.ps1
+++ b/tools/variables/_define.ps1
@@ -11,7 +11,9 @@
 param (
 )
 
-. "$PSScriptRoot\..\GitHubActions.ps1"
+if ($env:GITHUB_ACTIONS) {
+    . "$PSScriptRoot\..\GitHubActions.ps1"
+}
 
 (& "$PSScriptRoot\_all.ps1").GetEnumerator() |% {
     # Always use ALL CAPS for env var names since Azure Pipelines converts variable names to all caps and on non-Windows OS, env vars are case sensitive.


### PR DESCRIPTION
This brings the repo up to date with the latest Library.Template changes so it picks up the current test infrastructure and GitHub Actions script fixes.

The merge keeps this repo's Roslyn and PolyType version pins, adopts Microsoft Testing Platform 2.3.0 and the related tool updates, and preserves validation by aligning the net472 analyzer test references with the newer `System.Text.Json` version required by the merged package graph.

### Validation
- `dotnet restore`
- `dotnet build tools/dirs.proj -t:build,pack --no-restore -c Release`
- `tools/dotnet-test-cloud.ps1`
- `dotnet format --verify-no-changes --no-restore --exclude ./samples/AnalyzerDocs/NBMsgPack051.cs`
- `test/AotNativeConsole`: `dotnet run --no-build -c Release`
- `samples/AspNetMvc`: `dotnet run --no-build -c Release`

### Notes for reviewers
- `Directory.Packages.props` was the only merge conflict.
- `System.IO.Pipelines` and `System.Text.Json` were updated to satisfy the newer coverage/test dependencies introduced by the template merge.
- `test/Nerdbank.MessagePack.Analyzers.Tests/Verifiers/ReferencesHelper.cs` was updated so the net472 analyzer tests reference the same `System.Text.Json` version as the merged dependency graph.