### PR TITLE
Port span-based Encoding.GetBytes to Write(string) and Write(ReadOnlySpan<char>) (#1004)

### DIFF
--- a/src/Nerdbank.MessagePack/MessagePackWriter.cs
+++ b/src/Nerdbank.MessagePack/MessagePackWriter.cs
@@ -674,13 +674,18 @@ public ref struct MessagePackWriter
 		}
 
 		ref byte buffer = ref this.WriteString_PrepareSpan(value.Length, out int bufferSize, out int useOffset);
-		fixed (char* pValue = value)
+		fixed (byte* pBuffer = &buffer)
 		{
-			fixed (byte* pBuffer = &buffer)
+			int byteCount;
+#if NET
+			byteCount = StringEncoding.UTF8.GetBytes(value, new Span<byte>(pBuffer + useOffset, bufferSize - useOffset));
+#else
+			fixed (char* pValue = value)
 			{
-				int byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize);
-				this.WriteString_PostEncoding(pBuffer, useOffset, byteCount);
+				byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize - useOffset);
 			}
+#endif
+			this.WriteString_PostEncoding(pBuffer, useOffset, byteCount);
 		}
 	}
 
@@ -695,13 +700,18 @@ public ref struct MessagePackWriter
 	public unsafe void Write(scoped ReadOnlySpan<char> value)
 	{
 		ref byte buffer = ref this.WriteString_PrepareSpan(value.Length, out int bufferSize, out int useOffset);
-		fixed (char* pValue = value)
+		fixed (byte* pBuffer = &buffer)
 		{
-			fixed (byte* pBuffer = &buffer)
+			int byteCount;
+#if NET
+			byteCount = StringEncoding.UTF8.GetBytes(value, new Span<byte>(pBuffer + useOffset, bufferSize - useOffset));
+#else
+			fixed (char* pValue = value)
 			{
-				int byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize);
-				this.WriteString_PostEncoding(pBuffer, useOffset, byteCount);
+				byteCount = StringEncoding.UTF8.GetBytes(pValue, value.Length, pBuffer + useOffset, bufferSize - useOffset);
 			}
+#endif
+			this.WriteString_PostEncoding(pBuffer, useOffset, byteCount);
 		}
 	}
 


### PR DESCRIPTION
* Port MessagePack-CSharp PR #2258: use span-based Encoding.GetBytes in Write(string) and Write(ReadOnlySpan<char>)
* Remove unnecessary .AsSpan() in Write(string) - string implicitly converts to ReadOnlySpan<char>
* Fix legacy path buffer size: use bufferSize - useOffset in GetBytes calls
