### PR TITLE
Optimize object-as-array serialization

### DIFF
--- a/src/Nerdbank.MessagePack/ConverterCache.cs
+++ b/src/Nerdbank.MessagePack/ConverterCache.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using PolyType.Utilities;
 
 namespace Nerdbank.MessagePack;
@@ -30,7 +31,7 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// An optimization that avoids the dictionary lookup to start serialization
 	/// when the caller repeatedly serializes the same type.
 	/// </summary>
-	private object? lastConverter;
+	private LastConverterCacheEntry? lastConverter;
 
 	private MultiProviderTypeCache? cachedConverters;
 
@@ -112,7 +113,38 @@ internal class ConverterCache(SerializerConfiguration configuration)
 	/// <param name="shape">The shape of the type to convert.</param>
 	/// <returns>A msgpack converter.</returns>
 	internal ConverterResult GetOrAddConverter<T>(ITypeShape<T> shape)
-		=> (ConverterResult)(this.lastConverter is MessagePackConverter<T> lastConverter ? lastConverter : (this.lastConverter = this.CachedConverters.GetOrAdd(shape)!));
+	{
+		LastConverterCacheEntry? lastConverter = this.lastConverter;
+		if (lastConverter is not null && ReferenceEquals(lastConverter.Shape, shape))
+		{
+			return lastConverter.Converter;
+		}
+
+		ConverterResult converter = (ConverterResult)this.CachedConverters.GetOrAdd(shape)!;
+		this.lastConverter = new(shape, converter);
+		return converter;
+	}
+
+	/// <summary>
+	/// Gets a successfully constructed converter for the given type shape.
+	/// </summary>
+	/// <typeparam name="T">The data type to convert.</typeparam>
+	/// <param name="shape">The shape of the type to convert.</param>
+	/// <returns>A msgpack converter.</returns>
+	/// <exception cref="MessagePackSerializationException">Thrown if converter construction failed.</exception>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal MessagePackConverter<T> GetOrAddConverterValue<T>(ITypeShape<T> shape)
+	{
+		LastConverterCacheEntry? lastConverter = this.lastConverter;
+		if (lastConverter is not null && ReferenceEquals(lastConverter.Shape, shape))
+		{
+			return lastConverter.ConverterValue is { } converter
+				? (MessagePackConverter<T>)converter
+				: ThrowConverterError<T>(lastConverter.Converter);
+		}
+
+		return this.GetOrAddConverterValueSlow(shape);
+	}
 
 	/// <summary>
 	/// Gets a converter for the given type shape.
@@ -277,5 +309,29 @@ internal class ConverterCache(SerializerConfiguration configuration)
 		}
 
 		return this.PropertyNamingPolicy.ConvertName(name);
+	}
+
+	[DoesNotReturn]
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static MessagePackConverter<T> ThrowConverterError<T>(ConverterResult converter)
+		=> throw converter.Error!.ThrowException();
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private MessagePackConverter<T> GetOrAddConverterValueSlow<T>(ITypeShape<T> shape)
+	{
+		ConverterResult converter = (ConverterResult)this.CachedConverters.GetOrAdd(shape)!;
+		this.lastConverter = new(shape, converter);
+		return (MessagePackConverter<T>)converter.ValueOrThrow;
+	}
+
+	private sealed class LastConverterCacheEntry(ITypeShape shape, ConverterResult converter)
+	{
+		private readonly MessagePackConverter? converterValue = converter.Value;
+
+		internal ITypeShape Shape => shape;
+
+		internal ConverterResult Converter => converter;
+
+		internal MessagePackConverter? ConverterValue => this.converterValue;
 	}
 }

--- a/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
+++ b/src/Nerdbank.MessagePack/Converters/CommonRecords.cs
@@ -14,7 +14,7 @@ namespace Nerdbank.MessagePack.Converters;
 /// <param name="container">The instance of the data type to be serialized.</param>
 /// <param name="writer">The means by which msgpack should be written.</param>
 /// <param name="context"><inheritdoc cref="MessagePackConverter{T}.Write" path="/param[@name='context']"/></param>
-internal delegate void SerializeProperty<TDeclaringType>(in TDeclaringType container, ref MessagePackWriter writer, SerializationContext context);
+internal delegate void SerializeProperty<TDeclaringType>(in TDeclaringType container, ref MessagePackWriter writer, in SerializationContext context);
 
 /// <summary>
 /// A delegate that can asynchronously serialize a property to a <see cref="MessagePackAsyncWriter"/>.
@@ -33,7 +33,7 @@ internal delegate ValueTask SerializePropertyAsync<TDeclaringType>(TDeclaringTyp
 /// <param name="container">The instance of the data type to be serialized.</param>
 /// <param name="reader">The means by which msgpack should be read.</param>
 /// <param name="context"><inheritdoc cref="MessagePackConverter{T}.Read" path="/param[@name='context']"/></param>
-internal delegate void DeserializeProperty<TDeclaringType>(ref TDeclaringType container, ref MessagePackReader reader, SerializationContext context);
+internal delegate void DeserializeProperty<TDeclaringType>(ref TDeclaringType container, ref MessagePackReader reader, in SerializationContext context);
 
 /// <summary>
 /// A delegate that can asynchronously deserialize the value from a <see cref="MessagePackAsyncReader"/> and assign it to a property.

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayConverter`1.cs
@@ -6,6 +6,8 @@ using System.Runtime.CompilerServices;
 using System.Text.Json.Nodes;
 using Microsoft;
 
+#pragma warning disable SA1202, SA1204 // Keep public entry points adjacent to their optimized implementations.
+
 namespace Nerdbank.MessagePack.Converters;
 
 /// <summary>
@@ -25,6 +27,9 @@ internal class ObjectArrayConverter<T>(
 	IReadOnlyList<IPropertyShape> propertyShapes,
 	SerializeDefaultValuesPolicy defaultValuesPolicy) : ObjectConverterBase<T>
 {
+	private readonly DeserializeProperty<T>[]? denseReaders = unusedDataProperty is null ? GetDenseReaders(properties.Span) : null;
+	private readonly SerializeProperty<T>[]? denseWriters = unusedDataProperty is null && defaultValuesPolicy == SerializeDefaultValuesPolicy.Always ? GetDenseWriters(properties.Span) : null;
+
 	/// <inheritdoc/>
 	public override bool PreferAsyncSerialization => true;
 
@@ -34,7 +39,12 @@ internal class ObjectArrayConverter<T>(
 	protected DirectPropertyAccess<T, UnusedDataPacket>? UnusedDataProperty => unusedDataProperty;
 
 	/// <inheritdoc/>
-	public override T? Read(ref MessagePackReader reader, SerializationContext context)
+#pragma warning disable NBMsgPack031 // The core implementation consumes exactly one structure.
+	public override T? Read(ref MessagePackReader reader, SerializationContext context) => this.ReadCore(ref reader, ref context);
+#pragma warning restore NBMsgPack031
+
+	/// <inheritdoc/>
+	internal override T? ReadCore(ref MessagePackReader reader, ref SerializationContext context)
 	{
 		if (reader.TryReadNil())
 		{
@@ -60,47 +70,27 @@ internal class ObjectArrayConverter<T>(
 
 		if (reader.NextMessagePackType == MessagePackType.Map)
 		{
-			PropertyCollisionDetection collisionDetection = new(propertyShapes);
-
-			// The indexes we have are the keys in the map rather than indexes into the array.
-			int count = reader.ReadMapHeader();
-			for (int i = 0; i < count; i++)
-			{
-				int index = reader.ReadInt32();
-				if (index >= 0 && index < properties.Length && properties.Span[index] is { MsgPackReaders: var (deserialize, _), Shape.Position: int propertyShapePosition })
-				{
-					collisionDetection.MarkAsRead(propertyShapePosition);
-					deserialize(ref value, ref reader, context);
-				}
-				else if (unusedDataProperty?.Setter is not null)
-				{
-					unused ??= new();
-					unused.Add(index, reader.ReadRaw(context));
-				}
-				else
-				{
-					reader.Skip(context);
-				}
-			}
+			this.ReadMap(ref value, ref reader, ref unused, in context);
 		}
 		else
 		{
 			int count = reader.ReadArrayHeader();
-			for (int i = 0; i < count; i++)
+			if (this.denseReaders is { } readers)
 			{
-				if (properties.Length > i && properties.Span[i]?.MsgPackReaders is var (deserialize, _))
+				int readableCount = Math.Min(count, readers.Length);
+				for (int i = 0; i < readableCount; i++)
 				{
-					deserialize(ref value, ref reader, context);
+					readers[i](ref value, ref reader, in context);
 				}
-				else if (unusedDataProperty?.Setter is not null)
-				{
-					unused ??= new();
-					unused.Add(i, reader.ReadRaw(context));
-				}
-				else
+
+				for (int i = readableCount; i < count; i++)
 				{
 					reader.Skip(context);
 				}
+			}
+			else
+			{
+				this.ReadSparseArray(ref value, ref reader, count, ref unused, in context);
 			}
 		}
 
@@ -114,10 +104,62 @@ internal class ObjectArrayConverter<T>(
 		return value;
 	}
 
+	// Keep uncommon representations out of the dense array implementation that the JIT inlines into the serializer.
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void ReadMap(ref T value, ref MessagePackReader reader, ref UnusedDataPacket.Array? unused, in SerializationContext context)
+	{
+		PropertyCollisionDetection collisionDetection = new(propertyShapes);
+
+		// The indexes we have are the keys in the map rather than indexes into the array.
+		int count = reader.ReadMapHeader();
+		for (int i = 0; i < count; i++)
+		{
+			int index = reader.ReadInt32();
+			if (index >= 0 && index < properties.Length && properties.Span[index] is { MsgPackReaders: var (deserialize, _), Shape.Position: int propertyShapePosition })
+			{
+				collisionDetection.MarkAsRead(propertyShapePosition);
+				deserialize(ref value, ref reader, in context);
+			}
+			else if (unusedDataProperty?.Setter is not null)
+			{
+				unused ??= new();
+				unused.Add(index, reader.ReadRaw(context));
+			}
+			else
+			{
+				reader.Skip(context);
+			}
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void ReadSparseArray(ref T value, ref MessagePackReader reader, int count, ref UnusedDataPacket.Array? unused, in SerializationContext context)
+	{
+		for (int i = 0; i < count; i++)
+		{
+			if (properties.Length > i && properties.Span[i]?.MsgPackReaders is var (deserialize, _))
+			{
+				deserialize(ref value, ref reader, in context);
+			}
+			else if (unusedDataProperty?.Setter is not null)
+			{
+				unused ??= new();
+				unused.Add(i, reader.ReadRaw(context));
+			}
+			else
+			{
+				reader.Skip(context);
+			}
+		}
+	}
+
 	/// <inheritdoc/>
 #pragma warning disable NBMsgPack031 // Exactly one structure - this method is super complicated and beyond the analyzer
-	public override void Write(ref MessagePackWriter writer, in T? value, SerializationContext context)
+	public override void Write(ref MessagePackWriter writer, in T? value, SerializationContext context) => this.WriteCore(ref writer, value, ref context);
 #pragma warning restore NBMsgPack031
+
+	/// <inheritdoc/>
+	internal override void WriteCore(ref MessagePackWriter writer, in T? value, ref SerializationContext context)
 	{
 		if (value is null)
 		{
@@ -129,6 +171,27 @@ internal class ObjectArrayConverter<T>(
 		callbacks?.OnBeforeSerialize();
 
 		context.DepthStep();
+
+		if (this.denseWriters is { } writers)
+		{
+			writer.WriteArrayHeader(writers.Length);
+			for (int i = 0; i < writers.Length; i++)
+			{
+				writers[i](value, ref writer, in context);
+			}
+
+			callbacks?.OnAfterSerialize();
+			return;
+		}
+
+		this.WriteNonDense(ref writer, value, in context);
+		callbacks?.OnAfterSerialize();
+	}
+
+	// Keep default-value and unused-data handling out of the dense writer's stack frame.
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void WriteNonDense(ref MessagePackWriter writer, in T value, in SerializationContext context)
+	{
 		UnusedDataPacket.Array? unused = unusedDataProperty?.Getter?.Invoke(ref Unsafe.AsRef(in value)) as UnusedDataPacket.Array;
 
 		if (defaultValuesPolicy != SerializeDefaultValuesPolicy.Always && properties.Length > 0)
@@ -187,9 +250,7 @@ internal class ObjectArrayConverter<T>(
 			WriteArray(ref writer, value, unused, properties.Span, context);
 		}
 
-		callbacks?.OnAfterSerialize();
-
-		static void WriteArray(ref MessagePackWriter writer, in T value, UnusedDataPacket.Array? unused, ReadOnlySpan<PropertyAccessors<T>?> properties, SerializationContext context)
+		static void WriteArray(ref MessagePackWriter writer, in T value, UnusedDataPacket.Array? unused, ReadOnlySpan<PropertyAccessors<T>?> properties, in SerializationContext context)
 		{
 			int maxCount = Math.Max(properties.Length, (unused?.MaxIndex + 1) ?? 0);
 			writer.WriteArrayHeader(maxCount);
@@ -209,6 +270,44 @@ internal class ObjectArrayConverter<T>(
 				}
 			}
 		}
+	}
+
+	private static DeserializeProperty<T>[]? GetDenseReaders(ReadOnlySpan<PropertyAccessors<T>?> properties)
+	{
+		for (int i = 0; i < properties.Length; i++)
+		{
+			if (properties[i]?.MsgPackReaders is null)
+			{
+				return null;
+			}
+		}
+
+		DeserializeProperty<T>[] readers = new DeserializeProperty<T>[properties.Length];
+		for (int i = 0; i < properties.Length; i++)
+		{
+			readers[i] = properties[i]!.MsgPackReaders!.Value.Deserialize;
+		}
+
+		return readers;
+	}
+
+	private static SerializeProperty<T>[]? GetDenseWriters(ReadOnlySpan<PropertyAccessors<T>?> properties)
+	{
+		for (int i = 0; i < properties.Length; i++)
+		{
+			if (properties[i]?.MsgPackWriters is null)
+			{
+				return null;
+			}
+		}
+
+		SerializeProperty<T>[] writers = new SerializeProperty<T>[properties.Length];
+		for (int i = 0; i < properties.Length; i++)
+		{
+			writers[i] = properties[i]!.MsgPackWriters!.Value.Serialize;
+		}
+
+		return writers;
 	}
 
 	/// <inheritdoc/>

--- a/src/Nerdbank.MessagePack/Converters/ObjectArrayWithNonDefaultCtorConverter`2.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectArrayWithNonDefaultCtorConverter`2.cs
@@ -3,6 +3,8 @@
 
 namespace Nerdbank.MessagePack.Converters;
 
+#pragma warning disable SA1202 // Keep the public entry point adjacent to its optimized implementation.
+
 /// <summary>
 /// A <see cref="MessagePackConverter{T}"/> that writes objects as maps of property names to values.
 /// Data types with constructors and/or <see langword="init" /> properties may be deserialized.
@@ -29,7 +31,12 @@ internal class ObjectArrayWithNonDefaultCtorConverter<TDeclaringType, TArgumentS
 	where TArgumentState : IArgumentState
 {
 	/// <inheritdoc/>
-	public override TDeclaringType? Read(ref MessagePackReader reader, SerializationContext context)
+#pragma warning disable NBMsgPack031 // The core implementation consumes exactly one structure.
+	public override TDeclaringType? Read(ref MessagePackReader reader, SerializationContext context) => this.ReadCore(ref reader, ref context);
+#pragma warning restore NBMsgPack031
+
+	/// <inheritdoc/>
+	internal override TDeclaringType? ReadCore(ref MessagePackReader reader, ref SerializationContext context)
 	{
 		if (reader.TryReadNil())
 		{

--- a/src/Nerdbank.MessagePack/Converters/ObjectMapConverter`1.cs
+++ b/src/Nerdbank.MessagePack/Converters/ObjectMapConverter`1.cs
@@ -68,7 +68,7 @@ internal class ObjectMapConverter<T>(
 
 		callbacks?.OnAfterSerialize();
 
-		static void WriteProperties(ref MessagePackWriter writer, in T value, ReadOnlySpan<SerializableProperty<T>> properties, DirectPropertyAccess<T, UnusedDataPacket>? unusedDataProperty, SerializationContext context)
+		static void WriteProperties(ref MessagePackWriter writer, in T value, ReadOnlySpan<SerializableProperty<T>> properties, DirectPropertyAccess<T, UnusedDataPacket>? unusedDataProperty, in SerializationContext context)
 		{
 			UnusedDataPacket.Map? unused = unusedDataProperty?.Getter?.Invoke(ref Unsafe.AsRef(in value)) as UnusedDataPacket.Map;
 			writer.WriteMapHeader(properties.Length + (unused?.Count ?? 0));

--- a/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
+++ b/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
@@ -180,9 +180,18 @@ public abstract class MessagePackConverter<T> : MessagePackConverter, IMessagePa
 	MessagePackConverter IMessagePackConverterInternal.UnwrapReferencePreservation() => this.UnwrapReferencePreservation();
 
 	/// <inheritdoc cref="Write"/>
+	/// <devremarks>
+	/// See devremarks in <see cref="ReadCore" />.
+	/// </devremarks>
 	internal virtual void WriteCore(ref MessagePackWriter writer, in T? value, ref SerializationContext context) => this.Write(ref writer, value, context);
 
 	/// <inheritdoc cref="Read"/>
+	/// <devremarks>
+	/// This method is like the <see cref="Write" /> method except that it takes the <paramref name="context" /> parameter by <see langword="ref" />.
+	/// Care must be taken when overriding this method then so that the <paramref name="context" /> is not modified in a way that breaks the caller.
+	/// Typically this should only be overridden by implementations that are simple pass-throughs to other methods, so that <see cref="SerializationContext"/>
+	/// is copied before it is mutated by a callee.
+	/// </devremarks>
 	internal virtual T? ReadCore(ref MessagePackReader reader, ref SerializationContext context) => this.Read(ref reader, context);
 
 	/// <inheritdoc cref="IMessagePackConverterInternal.WrapWithReferencePreservation" />

--- a/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
+++ b/src/Nerdbank.MessagePack/MessagePackConverter`1.cs
@@ -179,6 +179,12 @@ public abstract class MessagePackConverter<T> : MessagePackConverter, IMessagePa
 	/// <inheritdoc/>
 	MessagePackConverter IMessagePackConverterInternal.UnwrapReferencePreservation() => this.UnwrapReferencePreservation();
 
+	/// <inheritdoc cref="Write"/>
+	internal virtual void WriteCore(ref MessagePackWriter writer, in T? value, ref SerializationContext context) => this.Write(ref writer, value, context);
+
+	/// <inheritdoc cref="Read"/>
+	internal virtual T? ReadCore(ref MessagePackReader reader, ref SerializationContext context) => this.Read(ref reader, context);
+
 	/// <inheritdoc cref="IMessagePackConverterInternal.WrapWithReferencePreservation" />
 	internal virtual MessagePackConverter<T> WrapWithReferencePreservation() => typeof(T).IsValueType ? this : new ReferencePreservingConverter<T>(this);
 

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -221,8 +221,16 @@ public partial record MessagePackSerializer
 
 		try
 		{
-			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
-			this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.WriteObject(ref writer, value, context.Value);
+			SerializationContext context = this.StartingContext;
+			context.Initialize(this, this.ConverterCache, shape.Provider, cancellationToken);
+			try
+			{
+				this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.WriteObject(ref writer, value, context);
+			}
+			finally
+			{
+				context.End();
+			}
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -238,14 +246,24 @@ public partial record MessagePackSerializer
 	/// <param name="value">The value to serialize.</param>
 	/// <param name="shape">The shape of <typeparamref name="T"/>.</param>
 	/// <param name="cancellationToken">A cancellation token.</param>
+	// Large converter implementations otherwise inline into this operation-setup path and increase its stack frame.
+	[MethodImpl(MethodImplOptions.NoInlining)]
 	public void Serialize<T>(ref MessagePackWriter writer, in T? value, ITypeShape<T> shape, CancellationToken cancellationToken = default)
 	{
 		Requires.NotNull(shape);
 
 		try
 		{
-			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
-			((MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow).Write(ref writer, value, context.Value);
+			SerializationContext context = this.StartingContext;
+			context.Initialize(this, this.ConverterCache, shape.Provider, cancellationToken);
+			try
+			{
+				this.ConverterCache.GetOrAddConverterValue(shape).WriteCore(ref writer, value, ref context);
+			}
+			finally
+			{
+				context.End();
+			}
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -269,8 +287,16 @@ public partial record MessagePackSerializer
 
 		try
 		{
-			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
-			return this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.ReadObject(ref reader, context.Value);
+			SerializationContext context = this.StartingContext;
+			context.Initialize(this, this.ConverterCache, shape.Provider, cancellationToken);
+			try
+			{
+				return this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow.ReadObject(ref reader, context);
+			}
+			finally
+			{
+				context.End();
+			}
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -348,13 +374,23 @@ public partial record MessagePackSerializer
 	/// <param name="shape">The shape of <typeparamref name="T"/>.</param>
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>The deserialized value.</returns>
+	// Large converter implementations otherwise inline into this operation-setup path and increase its stack frame.
+	[MethodImpl(MethodImplOptions.NoInlining)]
 	public T? Deserialize<T>(ref MessagePackReader reader, ITypeShape<T> shape, CancellationToken cancellationToken = default)
 	{
 		Requires.NotNull(shape);
-		using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
+		SerializationContext context = this.StartingContext;
+		context.Initialize(this, this.ConverterCache, shape.Provider, cancellationToken);
 		try
 		{
-			return ((MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow).Read(ref reader, context.Value);
+			try
+			{
+				return this.ConverterCache.GetOrAddConverterValue(shape).ReadCore(ref reader, ref context);
+			}
+			finally
+			{
+				context.End();
+			}
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
 		{
@@ -380,7 +416,7 @@ public partial record MessagePackSerializer
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
 			MessagePackAsyncWriter asyncWriter = new(writer);
-			await ((MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow).WriteAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
+			await this.ConverterCache.GetOrAddConverterValue(shape).WriteAsync(asyncWriter, value, context.Value).ConfigureAwait(false);
 			asyncWriter.Flush();
 		}
 		catch (Exception ex) when (ShouldWrapSerializationException(ex, cancellationToken))
@@ -424,7 +460,7 @@ public partial record MessagePackSerializer
 		try
 		{
 			using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
-			var converter = (MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow;
+			MessagePackConverter<T> converter = this.ConverterCache.GetOrAddConverterValue(shape);
 
 			// Buffer up to some threshold before starting deserialization.
 			// Only engage with the async code path (which is slower) if we reach our threshold
@@ -786,7 +822,7 @@ public partial record MessagePackSerializer
 
 		using DisposableSerializationContext context = this.CreateSerializationContext(shape.Provider, cancellationToken);
 
-		var converter = (MessagePackConverter<T>)this.ConverterCache.GetOrAddConverter(shape).ValueOrThrow;
+		MessagePackConverter<T> converter = this.ConverterCache.GetOrAddConverterValue(shape);
 		MessagePackAsyncReader asyncReader = new(reader) { CancellationToken = cancellationToken };
 		bool readMore = false;
 		while (!await asyncReader.GetIsEndOfStreamAsync(readMore).ConfigureAwait(false))

--- a/src/Nerdbank.MessagePack/MessagePackSerializer.cs
+++ b/src/Nerdbank.MessagePack/MessagePackSerializer.cs
@@ -246,8 +246,6 @@ public partial record MessagePackSerializer
 	/// <param name="value">The value to serialize.</param>
 	/// <param name="shape">The shape of <typeparamref name="T"/>.</param>
 	/// <param name="cancellationToken">A cancellation token.</param>
-	// Large converter implementations otherwise inline into this operation-setup path and increase its stack frame.
-	[MethodImpl(MethodImplOptions.NoInlining)]
 	public void Serialize<T>(ref MessagePackWriter writer, in T? value, ITypeShape<T> shape, CancellationToken cancellationToken = default)
 	{
 		Requires.NotNull(shape);
@@ -374,8 +372,6 @@ public partial record MessagePackSerializer
 	/// <param name="shape">The shape of <typeparamref name="T"/>.</param>
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>The deserialized value.</returns>
-	// Large converter implementations otherwise inline into this operation-setup path and increase its stack frame.
-	[MethodImpl(MethodImplOptions.NoInlining)]
 	public T? Deserialize<T>(ref MessagePackReader reader, ITypeShape<T> shape, CancellationToken cancellationToken = default)
 	{
 		Requires.NotNull(shape);

--- a/src/Nerdbank.MessagePack/SerializationContext.cs
+++ b/src/Nerdbank.MessagePack/SerializationContext.cs
@@ -25,7 +25,12 @@ namespace Nerdbank.MessagePack;
 public record struct SerializationContext
 {
 	private ImmutableDictionary<object, object?> specialState = ImmutableDictionary<object, object?>.Empty;
+	private ConverterCache? cache;
+	private CancellationToken cancellationToken;
 	private LibraryReservedMessagePackExtensionTypeCode? extensionTypeCodes;
+	private ReferenceEqualityTracker? referenceEqualityTracker;
+	private StringInterning? stringInterningCache;
+	private ITypeShapeProvider? typeShapeProvider;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="SerializationContext"/> struct.
@@ -62,14 +67,22 @@ public record struct SerializationContext
 	/// <remarks>
 	/// In <see cref="MessagePackConverter{T}.WriteAsync(MessagePackAsyncWriter, T, SerializationContext)" />
 	/// or <see cref="MessagePackConverter{T}.ReadAsync(MessagePackAsyncReader, SerializationContext)"/> methods,
-	/// this will tend to be equivalent to the <c>cancellationToken</c> parameter passed to those methods.
+	/// this will tend to be equivalent to the cancellation token argument passed to those methods.
 	/// </remarks>
-	public CancellationToken CancellationToken { get; init; }
+	public CancellationToken CancellationToken
+	{
+		get => this.cancellationToken;
+		init => this.cancellationToken = value;
+	}
 
 	/// <summary>
 	/// Gets the type shape provider that applies to the serialization operation.
 	/// </summary>
-	public ITypeShapeProvider? TypeShapeProvider { get; internal init; }
+	public ITypeShapeProvider? TypeShapeProvider
+	{
+		get => this.typeShapeProvider;
+		internal init => this.typeShapeProvider = value;
+	}
 
 	/// <summary>
 	/// Gets the extension type codes to use for library-reserved extension types.
@@ -83,12 +96,20 @@ public record struct SerializationContext
 	/// <summary>
 	/// Gets the <see cref="MessagePackSerializer"/> that owns this context.
 	/// </summary>
-	internal ConverterCache? Cache { get; private init; }
+	internal ConverterCache? Cache
+	{
+		get => this.cache;
+		private init => this.cache = value;
+	}
 
 	/// <summary>
 	/// Gets the string interning cache to use for this serialization.
 	/// </summary>
-	internal StringInterning? StringInterningCache { get; private init; }
+	internal StringInterning? StringInterningCache
+	{
+		get => this.stringInterningCache;
+		private init => this.stringInterningCache = value;
+	}
 
 	/// <summary>
 	/// Gets or sets the index of the object being deserialized in the reference equality tracker.
@@ -98,7 +119,11 @@ public record struct SerializationContext
 	/// <summary>
 	/// Gets the reference equality tracker for this serialization operation.
 	/// </summary>
-	internal ReferenceEqualityTracker? ReferenceEqualityTracker { get; private init; }
+	internal ReferenceEqualityTracker? ReferenceEqualityTracker
+	{
+		get => this.referenceEqualityTracker;
+		private init => this.referenceEqualityTracker = value;
+	}
 
 	/// <summary>
 	/// Gets or sets the number of elements that must still be skipped to complete a skip operation.
@@ -292,19 +317,25 @@ public record struct SerializationContext
 	/// <returns>The new context for the operation.</returns>
 	internal SerializationContext Start(MessagePackSerializer owner, ConverterCache cache, ITypeShapeProvider provider, CancellationToken cancellationToken)
 	{
-		cancellationToken.ThrowIfCancellationRequested();
-		SerializationContext result = this with
-		{
-			Cache = cache,
-			ExtensionTypeCodes = owner.LibraryExtensionTypeCodes,
-			ReferenceEqualityTracker = cache.PreserveReferences != ReferencePreservationMode.Off ? ReusableObjectPool<ReferenceEqualityTracker>.Take(owner) : null,
-			StringInterningCache = cache.InternStrings ? ReusableObjectPool<StringInterning>.Take(owner) : null,
-			TypeShapeProvider = provider,
-			CancellationToken = cancellationToken,
-		};
-
-		result.ReferenceEqualityTracker?.SetSerializationContext(result);
+		SerializationContext result = this;
+		result.Initialize(owner, cache, provider, cancellationToken);
 		return result;
+	}
+
+	/// <summary>
+	/// Initializes this context for a new serialization operation.
+	/// </summary>
+	/// <inheritdoc cref="Start(MessagePackSerializer, ConverterCache, ITypeShapeProvider, CancellationToken)"/>
+	internal void Initialize(MessagePackSerializer owner, ConverterCache cache, ITypeShapeProvider provider, CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		this.cache = cache;
+		this.extensionTypeCodes = owner.LibraryExtensionTypeCodes;
+		this.referenceEqualityTracker = cache.PreserveReferences != ReferencePreservationMode.Off ? ReusableObjectPool<ReferenceEqualityTracker>.Take(owner) : null;
+		this.stringInterningCache = cache.InternStrings ? ReusableObjectPool<StringInterning>.Take(owner) : null;
+		this.typeShapeProvider = provider;
+		this.cancellationToken = cancellationToken;
+		this.referenceEqualityTracker?.SetSerializationContext(this);
 	}
 
 	/// <summary>

--- a/src/Nerdbank.MessagePack/SerializationContext.cs
+++ b/src/Nerdbank.MessagePack/SerializationContext.cs
@@ -326,6 +326,9 @@ public record struct SerializationContext
 	/// Initializes this context for a new serialization operation.
 	/// </summary>
 	/// <inheritdoc cref="Start(MessagePackSerializer, ConverterCache, ITypeShapeProvider, CancellationToken)"/>
+	/// <remarks>
+	/// This method is like <see cref="Start" /> except that it doesn't require copying the return value (a large struct).
+	/// </remarks>
 	internal void Initialize(MessagePackSerializer owner, ConverterCache cache, ITypeShapeProvider provider, CancellationToken cancellationToken)
 	{
 		cancellationToken.ThrowIfCancellationRequested();

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -349,6 +349,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 		IParameterShape? constructorParameterShape = (IParameterShape?)state;
 
 		ConverterResult converter = this.GetConverterForMemberOrParameter(propertyShape.PropertyType, propertyShape.AttributeProvider);
+		MessagePackConverter<TPropertyType>? typedConverter = converter.Value as MessagePackConverter<TPropertyType>;
 
 		(SerializeProperty<TDeclaringType>, SerializePropertyAsync<TDeclaringType>)? msgpackWriters = null;
 		Func<TDeclaringType, bool>? shouldSerialize = null;
@@ -382,25 +383,47 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 					}
 				}
 
-				SerializeProperty<TDeclaringType> serialize = (in TDeclaringType container, ref MessagePackWriter writer, SerializationContext context) =>
+				SerializeProperty<TDeclaringType> serialize;
+				if (typedConverter is not null && DirectPrimitiveConverter<TPropertyType>.IsSupported(typedConverter))
 				{
-					// Workaround https://github.com/eiriktsarpalis/PolyType/issues/46.
-					// We get significantly improved usability in the API if we use the `in` modifier on the Serialize method
-					// instead of `ref`. And since serialization should fundamentally be a read-only operation, this *should* be safe.
-					try
+					// Inlining primitive codecs here expands each containing object converter enough to make its hot loop slower.
+					serialize =
+						[MethodImpl(MethodImplOptions.NoInlining)]
+					(in TDeclaringType container, ref MessagePackWriter writer, in SerializationContext context) =>
 					{
-						((MessagePackConverter<TPropertyType>)converter.ValueOrThrow).Write(ref writer, getter(ref Unsafe.AsRef(in container)), context);
-					}
-					catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
+						try
+						{
+							DirectPrimitiveConverter<TPropertyType>.Write(ref writer, getter(ref Unsafe.AsRef(in container)));
+						}
+						catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
+						{
+							throw new MessagePackSerializationException(CreateWriteFailMessage(propertyShape), ex);
+						}
+					};
+				}
+				else
+				{
+					serialize = (in TDeclaringType container, ref MessagePackWriter writer, in SerializationContext context) =>
 					{
-						throw new MessagePackSerializationException(CreateWriteFailMessage(propertyShape), ex);
-					}
-				};
+						// Workaround https://github.com/eiriktsarpalis/PolyType/issues/46.
+						// We get significantly improved usability in the API if we use the `in` modifier on the Serialize method
+						// instead of `ref`. And since serialization should fundamentally be a read-only operation, this *should* be safe.
+						try
+						{
+							typedConverter!.Write(ref writer, getter(ref Unsafe.AsRef(in container)), context);
+						}
+						catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
+						{
+							throw new MessagePackSerializationException(CreateWriteFailMessage(propertyShape), ex);
+						}
+					};
+				}
+
 				SerializePropertyAsync<TDeclaringType> serializeAsync = async (TDeclaringType container, MessagePackAsyncWriter writer, SerializationContext context) =>
 				{
 					try
 					{
-						await ((MessagePackConverter<TPropertyType>)converter.ValueOrThrow).WriteAsync(writer, getter(ref container), context).ConfigureAwait(false);
+						await typedConverter!.WriteAsync(writer, getter(ref container), context).ConfigureAwait(false);
 					}
 					catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
 					{
@@ -419,22 +442,44 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			void SetterHelper()
 			{
 				Setter<TDeclaringType, TPropertyType> setter = propertyShape.GetSetter();
-				DeserializeProperty<TDeclaringType> deserialize = (ref TDeclaringType container, ref MessagePackReader reader, SerializationContext context) =>
+				DeserializeProperty<TDeclaringType> deserialize;
+				if (typedConverter is not null && DirectPrimitiveConverter<TPropertyType>.IsSupported(typedConverter))
 				{
-					try
+					// Inlining primitive codecs here expands each containing object converter enough to make its hot loop slower.
+					deserialize =
+						[MethodImpl(MethodImplOptions.NoInlining)]
+					(ref TDeclaringType container, ref MessagePackReader reader, in SerializationContext context) =>
 					{
-						setter(ref container, ((MessagePackConverter<TPropertyType>)converter.ValueOrThrow).Read(ref reader, context)!);
-					}
-					catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
+						try
+						{
+							setter(ref container, DirectPrimitiveConverter<TPropertyType>.Read(ref reader)!);
+						}
+						catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
+						{
+							throw new MessagePackSerializationException(CreateReadFailMessage(propertyShape), ex);
+						}
+					};
+				}
+				else
+				{
+					deserialize = (ref TDeclaringType container, ref MessagePackReader reader, in SerializationContext context) =>
 					{
-						throw new MessagePackSerializationException(CreateReadFailMessage(propertyShape), ex);
-					}
-				};
+						try
+						{
+							setter(ref container, typedConverter!.Read(ref reader, context)!);
+						}
+						catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
+						{
+							throw new MessagePackSerializationException(CreateReadFailMessage(propertyShape), ex);
+						}
+					};
+				}
+
 				DeserializePropertyAsync<TDeclaringType> deserializeAsync = async (TDeclaringType container, MessagePackAsyncReader reader, SerializationContext context) =>
 				{
 					try
 					{
-						setter(ref container, (await ((MessagePackConverter<TPropertyType>)converter.ValueOrThrow).ReadAsync(reader, context).ConfigureAwait(false))!);
+						setter(ref container, (await typedConverter!.ReadAsync(reader, context).ConfigureAwait(false))!);
 						return container;
 					}
 					catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
@@ -456,7 +501,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				// and we'll just deserialize into it.
 				suppressIfNoConstructorParameter = false;
 				Getter<TDeclaringType, TPropertyType> getter = propertyShape.GetGetter();
-				DeserializeProperty<TDeclaringType> deserialize = (ref TDeclaringType container, ref MessagePackReader reader, SerializationContext context) =>
+				DeserializeProperty<TDeclaringType> deserialize = (ref TDeclaringType container, ref MessagePackReader reader, in SerializationContext context) =>
 				{
 					if (reader.TryReadNil())
 					{
@@ -606,7 +651,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			ThrowingHelper();
 			void ThrowingHelper()
 			{
-				read = (ref TArgumentState state, ref MessagePackReader reader, SerializationContext context) =>
+				read = (ref TArgumentState state, ref MessagePackReader reader, in SerializationContext context) =>
 				{
 					try
 					{
@@ -638,7 +683,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			NonThrowingHelper();
 			void NonThrowingHelper()
 			{
-				read = (ref TArgumentState state, ref MessagePackReader reader, SerializationContext context) =>
+				read = (ref TArgumentState state, ref MessagePackReader reader, in SerializationContext context) =>
 				{
 					try
 					{
@@ -1332,6 +1377,47 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 		catch (Exception ex) when (SecureVisitor.TryGetEmptyTypeFailure(ex.GetBaseException(), out Type? emptyType))
 		{
 			return new VisitorError(new NotSupportedException($"Serializing dictionaries or hash sets with keys that are or contain empty types is not supported. {emptyType.FullName} is an empty type. Consider using a strong-typed key with properties, or using a custom (or null) MessagePackSerializer.ComparerProvider.", ex));
+		}
+	}
+
+	private static class DirectPrimitiveConverter<T>
+	{
+		internal static bool IsSupported(MessagePackConverter<T> converter)
+			=> (typeof(T) == typeof(int) && converter.GetType() == typeof(Int32Converter))
+				|| (typeof(T) == typeof(string) && converter.GetType() == typeof(Converters.StringConverter));
+
+		internal static T? Read(ref MessagePackReader reader)
+		{
+			if (typeof(T) == typeof(int))
+			{
+				int value = reader.ReadInt32();
+				return Unsafe.As<int, T>(ref value);
+			}
+
+			if (typeof(T) == typeof(string))
+			{
+				string? value = reader.ReadString();
+				return Unsafe.As<string?, T?>(ref value);
+			}
+
+			throw new UnreachableException();
+		}
+
+		internal static void Write(ref MessagePackWriter writer, in T? value)
+		{
+			if (typeof(T) == typeof(int))
+			{
+				writer.Write(Unsafe.As<T?, int>(ref Unsafe.AsRef(in value)));
+				return;
+			}
+
+			if (typeof(T) == typeof(string))
+			{
+				writer.Write(Unsafe.As<T?, string?>(ref Unsafe.AsRef(in value)));
+				return;
+			}
+
+			throw new UnreachableException();
 		}
 	}
 

--- a/src/Nerdbank.MessagePack/StandardVisitor.cs
+++ b/src/Nerdbank.MessagePack/StandardVisitor.cs
@@ -349,7 +349,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 		IParameterShape? constructorParameterShape = (IParameterShape?)state;
 
 		ConverterResult converter = this.GetConverterForMemberOrParameter(propertyShape.PropertyType, propertyShape.AttributeProvider);
-		MessagePackConverter<TPropertyType>? typedConverter = converter.Value as MessagePackConverter<TPropertyType>;
+		MessagePackConverter<TPropertyType>? typedConverter = (MessagePackConverter<TPropertyType>?)converter.Value;
 
 		(SerializeProperty<TDeclaringType>, SerializePropertyAsync<TDeclaringType>)? msgpackWriters = null;
 		Func<TDeclaringType, bool>? shouldSerialize = null;
@@ -384,22 +384,26 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 				}
 
 				SerializeProperty<TDeclaringType> serialize;
-				if (typedConverter is not null && DirectPrimitiveConverter<TPropertyType>.IsSupported(typedConverter))
+				if (typedConverter is null)
+				{
+					serialize = (in TDeclaringType container, ref MessagePackWriter writer, in SerializationContext context) => converter.Error!.ThrowException();
+				}
+				else if (DirectPrimitiveConverter<TPropertyType>.IsSupported(typedConverter))
 				{
 					// Inlining primitive codecs here expands each containing object converter enough to make its hot loop slower.
 					serialize =
 						[MethodImpl(MethodImplOptions.NoInlining)]
 					(in TDeclaringType container, ref MessagePackWriter writer, in SerializationContext context) =>
-					{
-						try
 						{
-							DirectPrimitiveConverter<TPropertyType>.Write(ref writer, getter(ref Unsafe.AsRef(in container)));
-						}
-						catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
-						{
-							throw new MessagePackSerializationException(CreateWriteFailMessage(propertyShape), ex);
-						}
-					};
+							try
+							{
+								DirectPrimitiveConverter<TPropertyType>.Write(ref writer, getter(ref Unsafe.AsRef(in container)));
+							}
+							catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
+							{
+								throw new MessagePackSerializationException(CreateWriteFailMessage(propertyShape), ex);
+							}
+						};
 				}
 				else
 				{
@@ -410,7 +414,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 						// instead of `ref`. And since serialization should fundamentally be a read-only operation, this *should* be safe.
 						try
 						{
-							typedConverter!.Write(ref writer, getter(ref Unsafe.AsRef(in container)), context);
+							typedConverter.Write(ref writer, getter(ref Unsafe.AsRef(in container)), context);
 						}
 						catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
 						{
@@ -419,17 +423,19 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 					};
 				}
 
-				SerializePropertyAsync<TDeclaringType> serializeAsync = async (TDeclaringType container, MessagePackAsyncWriter writer, SerializationContext context) =>
-				{
-					try
+				SerializePropertyAsync<TDeclaringType> serializeAsync =
+					typedConverter is null ? async (TDeclaringType container, MessagePackAsyncWriter writer, SerializationContext context) => throw converter.Error!.ThrowException() :
+					async (TDeclaringType container, MessagePackAsyncWriter writer, SerializationContext context) =>
 					{
-						await typedConverter!.WriteAsync(writer, getter(ref container), context).ConfigureAwait(false);
-					}
-					catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
-					{
-						throw new MessagePackSerializationException(CreateWriteFailMessage(propertyShape), ex);
-					}
-				};
+						try
+						{
+							await typedConverter.WriteAsync(writer, getter(ref container), context).ConfigureAwait(false);
+						}
+						catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
+						{
+							throw new MessagePackSerializationException(CreateWriteFailMessage(propertyShape), ex);
+						}
+					};
 				msgpackWriters = (serialize, serializeAsync);
 			}
 		}
@@ -443,22 +449,26 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 			{
 				Setter<TDeclaringType, TPropertyType> setter = propertyShape.GetSetter();
 				DeserializeProperty<TDeclaringType> deserialize;
-				if (typedConverter is not null && DirectPrimitiveConverter<TPropertyType>.IsSupported(typedConverter))
+				if (typedConverter is null)
+				{
+					deserialize = (ref TDeclaringType container, ref MessagePackReader reader, in SerializationContext context) => converter.Error!.ThrowException();
+				}
+				else if (DirectPrimitiveConverter<TPropertyType>.IsSupported(typedConverter))
 				{
 					// Inlining primitive codecs here expands each containing object converter enough to make its hot loop slower.
 					deserialize =
 						[MethodImpl(MethodImplOptions.NoInlining)]
 					(ref TDeclaringType container, ref MessagePackReader reader, in SerializationContext context) =>
-					{
-						try
 						{
-							setter(ref container, DirectPrimitiveConverter<TPropertyType>.Read(ref reader)!);
-						}
-						catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
-						{
-							throw new MessagePackSerializationException(CreateReadFailMessage(propertyShape), ex);
-						}
-					};
+							try
+							{
+								setter(ref container, DirectPrimitiveConverter<TPropertyType>.Read(ref reader)!);
+							}
+							catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
+							{
+								throw new MessagePackSerializationException(CreateReadFailMessage(propertyShape), ex);
+							}
+						};
 				}
 				else
 				{
@@ -466,7 +476,7 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 					{
 						try
 						{
-							setter(ref container, typedConverter!.Read(ref reader, context)!);
+							setter(ref container, typedConverter.Read(ref reader, context)!);
 						}
 						catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
 						{
@@ -475,18 +485,20 @@ internal class StandardVisitor : TypeShapeVisitor, ITypeShapeFunc
 					};
 				}
 
-				DeserializePropertyAsync<TDeclaringType> deserializeAsync = async (TDeclaringType container, MessagePackAsyncReader reader, SerializationContext context) =>
-				{
-					try
+				DeserializePropertyAsync<TDeclaringType> deserializeAsync =
+					typedConverter is null ? async (TDeclaringType container, MessagePackAsyncReader reader, SerializationContext context) => throw converter.Error!.ThrowException() :
+					async (TDeclaringType container, MessagePackAsyncReader reader, SerializationContext context) =>
 					{
-						setter(ref container, (await typedConverter!.ReadAsync(reader, context).ConfigureAwait(false))!);
-						return container;
-					}
-					catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
-					{
-						throw new MessagePackSerializationException(CreateReadFailMessage(propertyShape), ex);
-					}
-				};
+						try
+						{
+							setter(ref container, (await typedConverter.ReadAsync(reader, context).ConfigureAwait(false))!);
+							return container;
+						}
+						catch (Exception ex) when (MessagePackConverter.ShouldWrapSerializationException(ex, context.CancellationToken))
+						{
+							throw new MessagePackSerializationException(CreateReadFailMessage(propertyShape), ex);
+						}
+					};
 				msgpackReaders = (deserialize, deserializeAsync);
 				suppressIfNoConstructorParameter = false;
 			}

--- a/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/ObjectsAsArraysTests.cs
@@ -21,6 +21,81 @@ public partial class ObjectsAsArraysTests : MessagePackSerializerTestBase
 	public void PersonWithDefaultConstructor_Roundtrip() => this.AssertRoundtrip(new PersonWithDefaultConstructor { FirstName = "Andrew", LastName = "Arnott" });
 
 	[Fact]
+	public void DensePrimitiveProperties_Roundtrip()
+	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always };
+		DensePrimitiveProperties value = new() { Number = 42, Text = "Hello, World!" };
+
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip(value);
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(2, reader.ReadArrayHeader());
+		Assert.Equal(value.Number, reader.ReadInt32());
+		Assert.Equal(value.Text, reader.ReadString());
+		Assert.True(reader.End);
+	}
+
+	[Fact]
+	public void DensePrimitiveProperties_UseCustomConverter()
+	{
+		OffsetInt32Converter converter = new();
+		this.Serializer = this.Serializer with
+		{
+			Converters = [converter],
+			SerializeDefaultValues = SerializeDefaultValuesPolicy.Always,
+		};
+
+		DensePrimitiveProperties value = new() { Number = 42, Text = "Hello, World!" };
+		ReadOnlySequence<byte> msgpack = this.AssertRoundtrip(value);
+		Assert.Equal(1, converter.ReadCount);
+		Assert.Equal(1, converter.WriteCount);
+
+		MessagePackReader reader = new(msgpack);
+		Assert.Equal(2, reader.ReadArrayHeader());
+		Assert.Equal(value.Number + 1, reader.ReadInt32());
+		Assert.Equal(value.Text, reader.ReadString());
+		Assert.True(reader.End);
+	}
+
+	[Fact]
+	public void DensePrimitiveProperties_SerializationCallbacks()
+	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always };
+		DensePrimitivePropertiesWithCallbacks value = new() { Number = 42, Text = "Hello, World!" };
+
+		this.Serializer.Serialize(value, TestContext.Current.CancellationToken);
+
+		Assert.Equal(1, value.OnBeforeSerializeCount);
+		Assert.Equal(1, value.OnAfterSerializeCount);
+	}
+
+	[Fact]
+	public void DensePrimitiveProperties_DerivedSerializationCallbacks()
+	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always };
+		DensePrimitiveProperties value = new DerivedDensePrimitiveProperties { Number = 42, Text = "Hello, World!" };
+
+		this.Serializer.Serialize(value, TestContext.Current.CancellationToken);
+
+		DerivedDensePrimitiveProperties derivedValue = Assert.IsType<DerivedDensePrimitiveProperties>(value);
+		Assert.Equal(1, derivedValue.OnBeforeSerializeCount);
+		Assert.Equal(1, derivedValue.OnAfterSerializeCount);
+	}
+
+	[Fact]
+	public void DensePrimitiveProperties_GetterExceptionIdentifiesProperty()
+	{
+		this.Serializer = this.Serializer with { SerializeDefaultValues = SerializeDefaultValuesPolicy.Always };
+		ThrowingDensePrimitiveProperties value = new() { Text = "Hello, World!" };
+
+		MessagePackSerializationException ex = Assert.Throws<MessagePackSerializationException>(
+			() => this.Serializer.Serialize(value, TestContext.Current.CancellationToken));
+
+		MessagePackSerializationException propertyException = Assert.IsType<MessagePackSerializationException>(ex.InnerException);
+		Assert.Contains("'Number' property", propertyException.Message, StringComparison.Ordinal);
+		Assert.IsType<InvalidOperationException>(propertyException.InnerException);
+	}
+
+	[Fact]
 	public void Null() => this.AssertRoundtrip<Person>(null);
 
 	[Fact]
@@ -398,6 +473,75 @@ public partial class ObjectsAsArraysTests : MessagePackSerializerTestBase
 	private partial class Witness;
 
 	[GenerateShape]
+	public partial record DensePrimitiveProperties
+	{
+		[Key(0)]
+		public int Number { get; set; }
+
+		[Key(1)]
+		public string? Text { get; set; }
+	}
+
+	[GenerateShape]
+	public partial record DensePrimitivePropertiesWithCallbacks : IMessagePackSerializationCallbacks
+	{
+		[Key(0)]
+		public int Number { get; set; }
+
+		[Key(1)]
+		public string? Text { get; set; }
+
+		internal int OnBeforeSerializeCount { get; private set; }
+
+		internal int OnAfterSerializeCount { get; private set; }
+
+		void IMessagePackSerializationCallbacks.OnBeforeSerialize() => this.OnBeforeSerializeCount++;
+
+		void IMessagePackSerializationCallbacks.OnAfterSerialize() => this.OnAfterSerializeCount++;
+
+		void IMessagePackSerializationCallbacks.OnBeforeDeserialize()
+		{
+		}
+
+		void IMessagePackSerializationCallbacks.OnAfterDeserialize()
+		{
+		}
+	}
+
+	public partial record DerivedDensePrimitiveProperties : DensePrimitiveProperties, IMessagePackSerializationCallbacks
+	{
+		internal int OnBeforeSerializeCount { get; private set; }
+
+		internal int OnAfterSerializeCount { get; private set; }
+
+		void IMessagePackSerializationCallbacks.OnBeforeSerialize() => this.OnBeforeSerializeCount++;
+
+		void IMessagePackSerializationCallbacks.OnAfterSerialize() => this.OnAfterSerializeCount++;
+
+		void IMessagePackSerializationCallbacks.OnBeforeDeserialize()
+		{
+		}
+
+		void IMessagePackSerializationCallbacks.OnAfterDeserialize()
+		{
+		}
+	}
+
+	[GenerateShape]
+	public partial record ThrowingDensePrimitiveProperties
+	{
+		[Key(0)]
+		public int Number
+		{
+			get => throw new InvalidOperationException();
+			set { }
+		}
+
+		[Key(1)]
+		public string? Text { get; set; }
+	}
+
+	[GenerateShape]
 	public partial record Person
 	{
 		[Key(0)]
@@ -492,5 +636,23 @@ public partial class ObjectsAsArraysTests : MessagePackSerializerTestBase
 
 		[Key(0)]
 		public bool Value { get; set; }
+	}
+
+	private sealed class OffsetInt32Converter : MessagePackConverter<int>
+	{
+		internal int ReadCount;
+		internal int WriteCount;
+
+		public override int Read(ref MessagePackReader reader, SerializationContext context)
+		{
+			this.ReadCount++;
+			return reader.ReadInt32() - 1;
+		}
+
+		public override void Write(ref MessagePackWriter writer, in int value, SerializationContext context)
+		{
+			this.WriteCount++;
+			writer.Write(value + 1);
+		}
 	}
 }


### PR DESCRIPTION
This reduces the overhead of synchronous object-as-array conversion by:

- fixing the last-converter cache so it is keyed by the exact `ITypeShape` and can actually hit;
- initializing and disposing the synchronous `SerializationContext` in place instead of copying it through the hot path;
- using dense reader/writer tables for contiguous array schemas while retaining the existing sparse/map paths;
- directly reading and writing properties that use the built-in `int` and `string` converters, without bypassing custom converters, string interning, or reference-preserving wrappers.

The callback, constructor, sparse-array, custom-converter, and exception behavior remains covered by tests.

## Benchmark

The checked-in [`SimplePoco` benchmark](https://github.com/AArnott/Nerdbank.MessagePack/blob/21a1c47290adf78efc38904f2aee81c3eec0080d/test/Benchmarks/SimplePoco.cs#L86-L114) serializes the same two-property `[Key]`-annotated POCO with Nerdbank.MessagePack and MessagePack-CSharp 3.1.7. The benchmark source is unchanged between the before and after revisions.

These are medians from the controlled runs below. I used medians because the Hyper-V host occasionally produced distinct performance modes; BenchmarkDotNet reports the same virtualization warning.

| Operation | Nerdbank before (`0e5310bb`) | Nerdbank after (`21a1c472`) | MessagePack-CSharp 3.1.7 |
|---|---:|---:|---:|
| Serialize | 125.80 ns | 54.17 ns | 57.17 ns |
| Deserialize | 158.47 ns | 89.45 ns | 96.89 ns |

This is a 56.9% serialization reduction and a 43.6% deserialization reduction relative to the merge base. The after result is 5.2% faster than MessagePack-CSharp for serialization and 7.7% faster for deserialization in these runs. Both serializers remain allocation-free when serializing; both allocate 80 B when deserializing.

## Reproduction

Run the following at `0e5310bb1c05cac1e7167b997ba6ea9a07887d30`, then repeat at `21a1c47290adf78efc38904f2aee81c3eec0080d`:

```powershell
$env:NBGV_GitEngine = 'Disabled'
./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
dotnet build test/Benchmarks/Benchmarks.csproj --framework net10.0 -c Release
dotnet run --project test/Benchmarks/Benchmarks.csproj --framework net10.0 --no-build -c Release -- `
  --filter '*SimplePoco.SerializeAsArray*' '*SimplePoco.DeserializeAsArray' '*SimplePoco.DeserializeAsArray_MsgPackCSharp' `
  --affinity 4 --launchCount 2 --warmupCount 10 --iterationCount 20 --iterationTime 500
```

Environment: BenchmarkDotNet 0.15.8, .NET 10.0.10, Windows 11 Hyper-V, Intel Xeon Platinum 8370C.

## Validation

- Release build and package: zero warnings and errors.
- `Nerdbank.MessagePack.Tests`: 18,737 total, 16,456 passed, 2,281 skipped, zero failed across .NET Framework 4.7.2 and .NET 8, 9, and 10.
- `dotnet format --verify-no-changes --no-restore` passed.
- NativeAOT console sample completed with `Success`.
- ASP.NET MVC sample returned HTTP 200.