### PR TITLE
Fix old-spec raw headers

### DIFF
--- a/src/Nerdbank.MessagePack/MessagePackWriter.cs
+++ b/src/Nerdbank.MessagePack/MessagePackWriter.cs
@@ -531,7 +531,7 @@ public ref struct MessagePackWriter
 	/// Use <see cref="MessagePackReader.ReadBytes"/> to read the bytes back.
 	/// </para>
 	/// <para>
-	/// When <see cref="OldSpec"/> is <see langword="true"/>, the msgpack code used is <see cref="MessagePackCode.Str8"/>, <see cref="MessagePackCode.Str16"/> or <see cref="MessagePackCode.Str32"/> instead.
+	/// When <see cref="OldSpec"/> is <see langword="true"/>, the msgpack code used is <see cref="MessagePackCode.MinFixStr"/>, <see cref="MessagePackCode.Str16"/> or <see cref="MessagePackCode.Str32"/> instead.
 	/// </para>
 	/// </remarks>
 	public void Write(scoped ReadOnlySpan<byte> src)
@@ -555,7 +555,7 @@ public ref struct MessagePackWriter
 	/// Use <see cref="MessagePackReader.ReadBytes"/> to read the bytes back.
 	/// </para>
 	/// <para>
-	/// When <see cref="OldSpec"/> is <see langword="true"/>, the msgpack code used is <see cref="MessagePackCode.Str8"/>, <see cref="MessagePackCode.Str16"/> or <see cref="MessagePackCode.Str32"/> instead.
+	/// When <see cref="OldSpec"/> is <see langword="true"/>, the msgpack code used is <see cref="MessagePackCode.MinFixStr"/>, <see cref="MessagePackCode.Str16"/> or <see cref="MessagePackCode.Str32"/> instead.
 	/// </para>
 	/// </remarks>
 	public void Write(in ReadOnlySequence<byte> src)
@@ -581,7 +581,7 @@ public ref struct MessagePackWriter
 	/// Alternatively a single call to <see cref="Write(ReadOnlySpan{byte})"/> or <see cref="Write(in ReadOnlySequence{byte})"/> will take care of the header and content in one call.
 	/// </para>
 	/// <para>
-	/// When <see cref="OldSpec"/> is <see langword="true"/>, the msgpack code used is <see cref="MessagePackCode.Str8"/>, <see cref="MessagePackCode.Str16"/> or <see cref="MessagePackCode.Str32"/> instead.
+	/// When <see cref="OldSpec"/> is <see langword="true"/>, the msgpack code used is <see cref="MessagePackCode.MinFixStr"/>, <see cref="MessagePackCode.Str16"/> or <see cref="MessagePackCode.Str32"/> instead.
 	/// </para>
 	/// </remarks>
 	public void WriteBinHeader(int length)
@@ -651,6 +651,15 @@ public ref struct MessagePackWriter
 		// When we write the header, we'll ask for all the space we need for the payload as well
 		// as that may help ensure we only allocate a buffer once.
 		Span<byte> span = this.writer.GetSpan(byteCount + 5);
+		if (this.OldSpec && byteCount is > MessagePackRange.MaxFixStringLength and <= byte.MaxValue)
+		{
+			span[0] = MessagePackCode.Str16;
+			span[1] = 0;
+			span[2] = (byte)byteCount;
+			this.writer.Advance(3);
+			return;
+		}
+
 		Assumes.True(MessagePackPrimitives.TryWriteStringHeader(span, (uint)byteCount, out int written));
 		this.writer.Advance(written);
 	}
@@ -733,8 +742,14 @@ public ref struct MessagePackWriter
 	/// <see cref="MessagePackCode.Ext32"/>.
 	/// </summary>
 	/// <param name="extensionHeader">The extension header.</param>
+	/// <exception cref="NotSupportedException">Thrown when <see cref="OldSpec"/> is true because the old spec does not define extension formats.</exception>
 	public void Write(ExtensionHeader extensionHeader)
 	{
+		if (this.OldSpec)
+		{
+			throw new NotSupportedException($"The MsgPack old spec does not define extension formats. Turn off {nameof(this.OldSpec)} mode.");
+		}
+
 		// When we write the header, we'll ask for all the space we need for the payload as well
 		// as that may help ensure we only allocate a buffer once.
 		Span<byte> span = this.writer.GetSpan((int)(extensionHeader.Length + 6));

--- a/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
@@ -475,10 +475,14 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 		this.AssertRoundtrip(new HasDateTimeOffset(System.DateTimeOffset.Now.ToOffset(TimeSpan.FromHours(4))));
 	}
 
-	[Fact]
-	public void ByteArrayWithOldSpec()
+	[Theory]
+	[InlineData(3, 0xa3)]
+	[InlineData(32, MessagePackCode.Str16)]
+	[InlineData(255, MessagePackCode.Str16)]
+	[InlineData(256, MessagePackCode.Str16)]
+	public void ByteArrayWithOldSpec(int length, byte expectedHeader)
 	{
-		byte[] original = [1, 2, 3];
+		byte[] original = new byte[length];
 		Sequence<byte> seq = new();
 		MessagePackWriter writer = new(seq) { OldSpec = true };
 		this.Serializer.Serialize<byte[], Witness>(ref writer, original, TestContext.Current.CancellationToken);
@@ -487,9 +491,34 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 		// Verify that the test is doing what we think it is.
 		MessagePackReader reader = new(seq);
 		Assert.Equal(MessagePackType.String, reader.NextMessagePackType);
+		Assert.Equal(expectedHeader, seq.AsReadOnlySequence.FirstSpan[0]);
 
 		byte[]? deserialized = this.Serializer.Deserialize<byte[], Witness>(seq, TestContext.Current.CancellationToken);
 		Assert.Equal(original, deserialized);
+	}
+
+	[Theory]
+	[InlineData(32)]
+	[InlineData(255)]
+	public void WriteStringHeaderWithOldSpec(int length)
+	{
+		Sequence<byte> seq = new();
+		MessagePackWriter writer = new(seq) { OldSpec = true };
+		writer.WriteString(new byte[length]);
+		writer.Flush();
+
+		Assert.Equal(MessagePackCode.Str16, seq.AsReadOnlySequence.FirstSpan[0]);
+	}
+
+	[Fact]
+	public void ExtensionWithOldSpecIsNotSupported()
+	{
+		Assert.Throws<NotSupportedException>(() =>
+		{
+			Sequence<byte> seq = new();
+			MessagePackWriter writer = new(seq) { OldSpec = true };
+			writer.Write(new ExtensionHeader(15, 1));
+		});
 	}
 
 	[Fact]

--- a/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
+++ b/test/Nerdbank.MessagePack.Tests/BuiltInConverterTests.cs
@@ -491,7 +491,7 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 		// Verify that the test is doing what we think it is.
 		MessagePackReader reader = new(seq);
 		Assert.Equal(MessagePackType.String, reader.NextMessagePackType);
-		Assert.Equal(expectedHeader, seq.AsReadOnlySequence.FirstSpan[0]);
+		Assert.Equal(expectedHeader, seq.AsReadOnlySequence.First.Span[0]);
 
 		byte[]? deserialized = this.Serializer.Deserialize<byte[], Witness>(seq, TestContext.Current.CancellationToken);
 		Assert.Equal(original, deserialized);
@@ -507,7 +507,7 @@ public partial class BuiltInConverterTests : MessagePackSerializerTestBase
 		writer.WriteString(new byte[length]);
 		writer.Flush();
 
-		Assert.Equal(MessagePackCode.Str16, seq.AsReadOnlySequence.FirstSpan[0]);
+		Assert.Equal(MessagePackCode.Str16, seq.AsReadOnlySequence.First.Span[0]);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary
- Emit legacy-compatible raw16 headers for 32-255 byte binary and UTF-8 string payloads in OldSpec mode.
- Reject extension formats in OldSpec mode because the legacy specification does not define them.
- Add boundary and unsupported-format coverage.

## Credit
Thanks to [@mikegoodspeed](https://github.com/mikegoodspeed) for reporting the original MessagePack-CSharp issue ([MessagePack-CSharp#2286](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/2286)).