### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.6.4",
+      "version": "7.6.5",
       "commands": [
         "pwsh"
       ],
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.9.0",
+      "version": "18.10.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,11 +63,11 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)'=='true' or '$(MSBuildProjectName)'=='Benchmarks'">
     <PackageVersion Update="System.Collections.Immutable" Version="10.0.5" />
-    <PackageVersion Update="System.IO.Pipelines" Version="10.0.8" />
-    <PackageVersion Update="System.Text.Json" Version="10.0.8" />
+    <PackageVersion Update="System.IO.Pipelines" Version="10.0.10" />
+    <PackageVersion Update="System.Text.Json" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="$(MicrosoftTestingPlatformVersion)" />

--- a/test/Nerdbank.MessagePack.Analyzers.Tests/App.net472.config
+++ b/test/Nerdbank.MessagePack.Analyzers.Tests/App.net472.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -91,11 +91,17 @@ if ($isMTP) {
         $tunitArgs += $coverageArgs
     }
 
-    & $dotnet test "$RepoRoot/Nerdbank.MessagePack.slnx" `
-      -p:Platform=NonTUnit `
+    $solutionFiles = @(Get-ChildItem -LiteralPath $RepoRoot -File | Where-Object { $_.Extension -in '.sln', '.slnx' })
+    if ($solutionFiles.Count -ne 1) {
+        throw "Expected exactly one solution file in $RepoRoot, but found $($solutionFiles.Count)."
+    }
+
+    $solutionPath = $solutionFiles[0].FullName
+    & $dotnet test $solutionPath `
+        -p:Platform=NonTUnit `
         --no-build `
         -c $Configuration `
-      -bl:"$testBinLogXunit" `
+        -bl:"$testBinLogXunit" `
         -- `
         --filter-not-trait 'TestCategory=FailsInCloudTest' `
         @mtpArgs `

--- a/tools/publish-CodeCov.ps1
+++ b/tools/publish-CodeCov.ps1
@@ -23,6 +23,9 @@ Param (
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $codeCovTool = & "$PSScriptRoot/Get-CodeCovTool.ps1"
 $coverageFiles = @(Get-ChildItem -Recurse -LiteralPath $PathToCodeCoverage -Filter "*.cobertura.xml")
+if ($coverageFiles.Count -eq 0) {
+    return
+}
 
 $arguments = @(
     "upload-process",


### PR DESCRIPTION
dotnet-test-cloud adopted dynamic solution discovery while preserving the repo-specific NonTUnit platform and xUnit binlog, publish-CodeCov adopted the no-coverage early return, and package pins were raised to 10.0.10 for CodeCoverage 18.10.0 restore compatibility.
